### PR TITLE
Fix compile errors

### DIFF
--- a/docs/vcluster-yaml/control-plane/distro/README.mdx
+++ b/docs/vcluster-yaml/control-plane/distro/README.mdx
@@ -18,13 +18,12 @@ import EKSCompat from './_partials/compat-eks.mdx'
 
 By default, vCluster uses [Lightweight Kubernetes (K3s)](https://k3s.io/) as the virtual Kubernetes cluster. However, vCluster is not tied to a specific distribution and should work with all certified Kubernetes distributions.
 
-By default, Loft Labs recommends using the [K3s distro](./k8s.mdx), because it has a small footprint and is widely adopted. However, if your use case requires a different Kubernetes distribution, vCluster  supports the following:
+By default, Loft Labs recommends using the [K3s distro](./k3s.mdx), because it has a small footprint and is widely adopted. However, if your use case requires a different Kubernetes distribution, vCluster supports the following:
 
 * [K8s](./k8s.mdx)
 * [k0s](./k3s.mdx)
-* [AWS EKS](./eks.mdx)
 
-Additionally, you can add your custom Kubernetes distribution using [advanced configuration](./advanced.mdx).
+You can add your custom Kubernetes distribution using [advanced configuration](/vcluster-yaml/control-plane/advanced/README.mdx).
 
 ## Compatibility matrix
 
@@ -48,7 +47,4 @@ Additionally, you can add your custom Kubernetes distribution using [advanced co
 
 <Distro/>
 
-
-distroContainer.mdx - no idea where this goes
-<DistroContainer/>
 

--- a/docs/vcluster-yaml/networking/advanced.mdx
+++ b/docs/vcluster-yaml/networking/advanced.mdx
@@ -5,7 +5,7 @@ sidebar_position: 3
 description: Configuration for advanced networking like cluster domain, fallback cluster, and Kubernetes proxy.
 ---
 
-import NetworkingAdvanced from '@site/docs/_partials/config/NetworkingAdvanced.mdx'
+import NetworkingAdvanced from '@site/docs/_partials/config/networkingAdvanced.mdx'
 
 ## Config Reference
 <NetworkingAdvanced/>

--- a/docs/vcluster-yaml/sync/to-host/persistent-volume-claims.mdx
+++ b/docs/vcluster-yaml/sync/to-host/persistent-volume-claims.mdx
@@ -14,10 +14,9 @@ import EnableSwitch from '@site/docs/_partials/config/enableSwitch.mdx'
   <figcaption>vcluster - Persistent Volume Provisioning</figcaption>
 </figure>
 
-Since the vCluster's syncer synchronizes pods to the underlying host cluster to schedule them, vCluster users can use the storage classes of the underlying host cluster to create persistent volume claims and to mount persistent volumes. By default, the host's storage classes can be used without the need to create it in the vCluster, but this can be configured by [enabling sync of "storageclasses" or "hoststorageclasses"](./core_resources.mdx).
+Since the vCluster's syncer synchronizes pods to the underlying host cluster to schedule them, vCluster users can use the storage classes of the underlying host cluster to create persistent volume claims and to mount persistent volumes. By default, the host's storage classes can be used without the need to create it in the vCluster, but this can be configured by enabling sync of "storageclasses" or "hoststorageclasses".
 
-
-vCluster provides helm values to adjust this behavior during vCluster installation or upgrade. Find out more below.
+vCluster provides Helm values to adjust this behavior during vCluster installation or upgrade. 
 
 ### Sync Persistent Volumes
 


### PR DESCRIPTION

For links to internal pages, `npm run start` throws different compile errors than `npm run build` and vice versa. Also the two don't always catch broken links when pages move or are deleted.