### PR TITLE
Upgrade Docusaurus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "name": "vcluster-docs",
       "version": "0.0.0",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/preset-classic": "3.1.1",
-        "@docusaurus/theme-mermaid": "^3.1.1",
+        "@docusaurus/core": "^3.2.0",
+        "@docusaurus/preset-classic": "^3.2.0",
+        "@docusaurus/theme-mermaid": "^3.2.0",
         "@mdx-js/react": "^3.0.0",
         "@saucelabs/theme-github-codeblock": "^0.2.3",
         "clsx": "^2.0.0",
@@ -25,8 +25,8 @@
         "sass": "^1.71.1"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.1.1",
-        "@docusaurus/types": "3.1.1"
+        "@docusaurus/module-type-aliases": "^3.2.0",
+        "@docusaurus/types": "^3.2.0"
       },
       "engines": {
         "node": ">=18.0"
@@ -36,7 +36,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
       "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
-      "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
         "@algolia/autocomplete-shared": "1.9.3"
@@ -46,7 +45,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
       "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
-      "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-shared": "1.9.3"
       },
@@ -58,7 +56,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
       "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
-      "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-shared": "1.9.3"
       },
@@ -71,145 +68,147 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
       "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
-      "license": "MIT",
       "peerDependencies": {
         "@algolia/client-search": ">= 4.9.1 < 6",
         "algoliasearch": ">= 4.9.1 < 6"
       }
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.22.1.tgz",
-      "integrity": "sha512-Sw6IAmOCvvP6QNgY9j+Hv09mvkvEIDKjYW8ow0UDDAxSXy664RBNQk3i/0nt7gvceOJ6jGmOTimaZoY1THmU7g==",
-      "license": "MIT",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.23.2.tgz",
+      "integrity": "sha512-PvRQdCmtiU22dw9ZcTJkrVKgNBVAxKgD0/cfiqyxhA5+PHzA2WDt6jOmZ9QASkeM2BpyzClJb/Wr1yt2/t78Kw==",
       "dependencies": {
-        "@algolia/cache-common": "4.22.1"
+        "@algolia/cache-common": "4.23.2"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.22.1.tgz",
-      "integrity": "sha512-TJMBKqZNKYB9TptRRjSUtevJeQVXRmg6rk9qgFKWvOy8jhCPdyNZV1nB3SKGufzvTVbomAukFR8guu/8NRKBTA==",
-      "license": "MIT"
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.23.2.tgz",
+      "integrity": "sha512-OUK/6mqr6CQWxzl/QY0/mwhlGvS6fMtvEPyn/7AHUx96NjqDA4X4+Ju7aXFQKh+m3jW9VPB0B9xvEQgyAnRPNw=="
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.22.1.tgz",
-      "integrity": "sha512-ve+6Ac2LhwpufuWavM/aHjLoNz/Z/sYSgNIXsinGofWOysPilQZPUetqLj8vbvi+DHZZaYSEP9H5SRVXnpsNNw==",
-      "license": "MIT",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.23.2.tgz",
+      "integrity": "sha512-rfbi/SnhEa3MmlqQvgYz/9NNJ156NkU6xFxjbxBtLWnHbpj+qnlMoKd+amoiacHRITpajg6zYbLM9dnaD3Bczw==",
       "dependencies": {
-        "@algolia/cache-common": "4.22.1"
+        "@algolia/cache-common": "4.23.2"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.22.1.tgz",
-      "integrity": "sha512-k8m+oegM2zlns/TwZyi4YgCtyToackkOpE+xCaKCYfBfDtdGOaVZCM5YvGPtK+HGaJMIN/DoTL8asbM3NzHonw==",
-      "license": "MIT",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.23.2.tgz",
+      "integrity": "sha512-VbrOCLIN/5I7iIdskSoSw3uOUPF516k4SjDD4Qz3BFwa3of7D9A0lzBMAvQEJJEPHWdVraBJlGgdJq/ttmquJQ==",
       "dependencies": {
-        "@algolia/client-common": "4.22.1",
-        "@algolia/client-search": "4.22.1",
-        "@algolia/transporter": "4.22.1"
+        "@algolia/client-common": "4.23.2",
+        "@algolia/client-search": "4.23.2",
+        "@algolia/transporter": "4.23.2"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.22.1.tgz",
-      "integrity": "sha512-1ssi9pyxyQNN4a7Ji9R50nSdISIumMFDwKNuwZipB6TkauJ8J7ha/uO60sPJFqQyqvvI+px7RSNRQT3Zrvzieg==",
-      "license": "MIT",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.23.2.tgz",
+      "integrity": "sha512-lLj7irsAztGhMoEx/SwKd1cwLY6Daf1Q5f2AOsZacpppSvuFvuBrmkzT7pap1OD/OePjLKxicJS8wNA0+zKtuw==",
       "dependencies": {
-        "@algolia/client-common": "4.22.1",
-        "@algolia/client-search": "4.22.1",
-        "@algolia/requester-common": "4.22.1",
-        "@algolia/transporter": "4.22.1"
+        "@algolia/client-common": "4.23.2",
+        "@algolia/client-search": "4.23.2",
+        "@algolia/requester-common": "4.23.2",
+        "@algolia/transporter": "4.23.2"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.22.1.tgz",
-      "integrity": "sha512-IvaL5v9mZtm4k4QHbBGDmU3wa/mKokmqNBqPj0K7lcR8ZDKzUorhcGp/u8PkPC/e0zoHSTvRh7TRkGX3Lm7iOQ==",
-      "license": "MIT",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.23.2.tgz",
+      "integrity": "sha512-Q2K1FRJBern8kIfZ0EqPvUr3V29ICxCm/q42zInV+VJRjldAD9oTsMGwqUQ26GFMdFYmqkEfCbY4VGAiQhh22g==",
       "dependencies": {
-        "@algolia/requester-common": "4.22.1",
-        "@algolia/transporter": "4.22.1"
+        "@algolia/requester-common": "4.23.2",
+        "@algolia/transporter": "4.23.2"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.22.1.tgz",
-      "integrity": "sha512-sl+/klQJ93+4yaqZ7ezOttMQ/nczly/3GmgZXJ1xmoewP5jmdP/X/nV5U7EHHH3hCUEHeN7X1nsIhGPVt9E1cQ==",
-      "license": "MIT",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.23.2.tgz",
+      "integrity": "sha512-vwPsgnCGhUcHhhQG5IM27z8q7dWrN9itjdvgA6uKf2e9r7vB+WXt4OocK0CeoYQt3OGEAExryzsB8DWqdMK5wg==",
       "dependencies": {
-        "@algolia/client-common": "4.22.1",
-        "@algolia/requester-common": "4.22.1",
-        "@algolia/transporter": "4.22.1"
+        "@algolia/client-common": "4.23.2",
+        "@algolia/requester-common": "4.23.2",
+        "@algolia/transporter": "4.23.2"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.22.1.tgz",
-      "integrity": "sha512-yb05NA4tNaOgx3+rOxAmFztgMTtGBi97X7PC3jyNeGiwkAjOZc2QrdZBYyIdcDLoI09N0gjtpClcackoTN0gPA==",
-      "license": "MIT",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.23.2.tgz",
+      "integrity": "sha512-CxSB29OVGSE7l/iyoHvamMonzq7Ev8lnk/OkzleODZ1iBcCs3JC/XgTIKzN/4RSTrJ9QybsnlrN/bYCGufo7qw==",
       "dependencies": {
-        "@algolia/client-common": "4.22.1",
-        "@algolia/requester-common": "4.22.1",
-        "@algolia/transporter": "4.22.1"
+        "@algolia/client-common": "4.23.2",
+        "@algolia/requester-common": "4.23.2",
+        "@algolia/transporter": "4.23.2"
       }
     },
     "node_modules/@algolia/events": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/@algolia/events/-/events-4.0.1.tgz",
-      "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ==",
-      "license": "MIT"
+      "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.22.1.tgz",
-      "integrity": "sha512-OnTFymd2odHSO39r4DSWRFETkBufnY2iGUZNrMXpIhF5cmFE8pGoINNPzwg02QLBlGSaLqdKy0bM8S0GyqPLBg==",
-      "license": "MIT"
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.23.2.tgz",
+      "integrity": "sha512-jGM49Q7626cXZ7qRAWXn0jDlzvoA1FvN4rKTi1g0hxKsTTSReyYk0i1ADWjChDPl3Q+nSDhJuosM2bBUAay7xw=="
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.22.1.tgz",
-      "integrity": "sha512-O99rcqpVPKN1RlpgD6H3khUWylU24OXlzkavUAMy6QZd1776QAcauE3oP8CmD43nbaTjBexZj2nGsBH9Tc0FVA==",
-      "license": "MIT",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.23.2.tgz",
+      "integrity": "sha512-oo+lnxxEmlhTBTFZ3fGz1O8PJ+G+8FiAoMY2Qo3Q4w23xocQev6KqDTA1JQAGPDxAewNA2VBwWOsVXeXFjrI/Q==",
       "dependencies": {
-        "@algolia/logger-common": "4.22.1"
+        "@algolia/logger-common": "4.23.2"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.23.2.tgz",
+      "integrity": "sha512-Q75CjnzRCDzgIlgWfPnkLtrfF4t82JCirhalXkSSwe/c1GH5pWh4xUyDOR3KTMo+YxxX3zTlrL/FjHmUJEWEcg==",
+      "dependencies": {
+        "@algolia/cache-browser-local-storage": "4.23.2",
+        "@algolia/cache-common": "4.23.2",
+        "@algolia/cache-in-memory": "4.23.2",
+        "@algolia/client-common": "4.23.2",
+        "@algolia/client-search": "4.23.2",
+        "@algolia/logger-common": "4.23.2",
+        "@algolia/logger-console": "4.23.2",
+        "@algolia/requester-browser-xhr": "4.23.2",
+        "@algolia/requester-common": "4.23.2",
+        "@algolia/requester-node-http": "4.23.2",
+        "@algolia/transporter": "4.23.2"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.22.1.tgz",
-      "integrity": "sha512-dtQGYIg6MteqT1Uay3J/0NDqD+UciHy3QgRbk7bNddOJu+p3hzjTRYESqEnoX/DpEkaNYdRHUKNylsqMpgwaEw==",
-      "license": "MIT",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.23.2.tgz",
+      "integrity": "sha512-TO9wLlp8+rvW9LnIfyHsu8mNAMYrqNdQ0oLF6eTWFxXfxG3k8F/Bh7nFYGk2rFAYty4Fw4XUtrv/YjeNDtM5og==",
       "dependencies": {
-        "@algolia/requester-common": "4.22.1"
+        "@algolia/requester-common": "4.23.2"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.22.1.tgz",
-      "integrity": "sha512-dgvhSAtg2MJnR+BxrIFqlLtkLlVVhas9HgYKMk2Uxiy5m6/8HZBL40JVAMb2LovoPFs9I/EWIoFVjOrFwzn5Qg==",
-      "license": "MIT"
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.23.2.tgz",
+      "integrity": "sha512-3EfpBS0Hri0lGDB5H/BocLt7Vkop0bTTLVUBB844HH6tVycwShmsV6bDR7yXbQvFP1uNpgePRD3cdBCjeHmk6Q=="
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.22.1.tgz",
-      "integrity": "sha512-JfmZ3MVFQkAU+zug8H3s8rZ6h0ahHZL/SpMaSasTCGYR5EEJsCc8SI5UZ6raPN2tjxa5bxS13BRpGSBUens7EA==",
-      "license": "MIT",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.23.2.tgz",
+      "integrity": "sha512-SVzgkZM/malo+2SB0NWDXpnT7nO5IZwuDTaaH6SjLeOHcya1o56LSWXk+3F3rNLz2GVH+I/rpYKiqmHhSOjerw==",
       "dependencies": {
-        "@algolia/requester-common": "4.22.1"
+        "@algolia/requester-common": "4.23.2"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.22.1.tgz",
-      "integrity": "sha512-kzWgc2c9IdxMa3YqA6TN0NW5VrKYYW/BELIn7vnLyn+U/RFdZ4lxxt9/8yq3DKV5snvoDzzO4ClyejZRdV3lMQ==",
-      "license": "MIT",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.23.2.tgz",
+      "integrity": "sha512-GY3aGKBy+8AK4vZh8sfkatDciDVKad5rTY2S10Aefyjh7e7UGBP4zigf42qVXwU8VOPwi7l/L7OACGMOFcjB0Q==",
       "dependencies": {
-        "@algolia/cache-common": "4.22.1",
-        "@algolia/logger-common": "4.22.1",
-        "@algolia/requester-common": "4.22.1"
+        "@algolia/cache-common": "4.23.2",
+        "@algolia/logger-common": "4.23.2",
+        "@algolia/requester-common": "4.23.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2301,20 +2300,18 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.5.2.tgz",
-      "integrity": "sha512-SPiDHaWKQZpwR2siD0KQUwlStvIAnEyK6tAE2h2Wuoq8ue9skzhlyVQ1ddzOxX6khULnAALDiR/isSF3bnuciA==",
-      "license": "MIT"
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.6.0.tgz",
+      "integrity": "sha512-+sbxb71sWre+PwDK7X2T8+bhS6clcVMLwBPznX45Qu6opJcgRjAp7gYSDzVFp187J+feSj5dNBN1mJoi6ckkUQ=="
     },
     "node_modules/@docsearch/react": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.5.2.tgz",
-      "integrity": "sha512-9Ahcrs5z2jq/DcAvYtvlqEBHImbm4YJI8M9y0x6Tqg598P40HTEkX7hsMcIuThI+hTFxRGZ9hll0Wygm2yEjng==",
-      "license": "MIT",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.6.0.tgz",
+      "integrity": "sha512-HUFut4ztcVNmqy9gp/wxNbC7pTOHhgVVkHVGCACTuLhUKUhKAF9KYHJtMiLUJxEqiFLQiuri1fWF8zqwM/cu1w==",
       "dependencies": {
         "@algolia/autocomplete-core": "1.9.3",
         "@algolia/autocomplete-preset-algolia": "1.9.3",
-        "@docsearch/css": "3.5.2",
+        "@docsearch/css": "3.6.0",
         "algoliasearch": "^4.19.1"
       },
       "peerDependencies": {
@@ -2339,10 +2336,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.1.1.tgz",
-      "integrity": "sha512-2nQfKFcf+MLEM7JXsXwQxPOmQAR6ytKMZVSx7tVi9HEm9WtfwBH1fp6bn8Gj4zLUhjWKCLoysQ9/Wm+EZCQ4yQ==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-WTO6vW4404nhTmK9NL+95nd13I1JveFwZ8iOBYxb4xt+N2S3KzY+mm+1YtWw2vV37FbYfH+w+KrlrRaWuy5Hzw==",
       "dependencies": {
         "@babel/core": "^7.23.3",
         "@babel/generator": "^7.23.3",
@@ -2354,14 +2350,13 @@
         "@babel/runtime": "^7.22.6",
         "@babel/runtime-corejs3": "^7.22.6",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.1.1",
-        "@docusaurus/logger": "3.1.1",
-        "@docusaurus/mdx-loader": "3.1.1",
+        "@docusaurus/cssnano-preset": "3.2.0",
+        "@docusaurus/logger": "3.2.0",
+        "@docusaurus/mdx-loader": "3.2.0",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "3.1.1",
-        "@docusaurus/utils-common": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-common": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "@svgr/webpack": "^6.5.1",
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.1.3",
@@ -2382,6 +2377,7 @@
         "detect-port": "^1.5.1",
         "escape-html": "^1.0.3",
         "eta": "^2.2.0",
+        "eval": "^0.1.8",
         "file-loader": "^6.2.0",
         "fs-extra": "^11.1.1",
         "html-minifier-terser": "^7.2.0",
@@ -2390,6 +2386,7 @@
         "leven": "^3.1.0",
         "lodash": "^4.17.21",
         "mini-css-extract-plugin": "^2.7.6",
+        "p-map": "^4.0.0",
         "postcss": "^8.4.26",
         "postcss-loader": "^7.3.3",
         "prompts": "^2.4.2",
@@ -2426,10 +2423,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.1.1.tgz",
-      "integrity": "sha512-LnoIDjJWbirdbVZDMq+4hwmrTl2yHDnBf9MLG9qyExeAE3ac35s4yUhJI8yyTCdixzNfKit4cbXblzzqMu4+8g==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.2.0.tgz",
+      "integrity": "sha512-H88RXGUia7r/VF3XfyoA4kbwgpUZcKsObF6VvwBOP91EdArTf6lnHbJ/x8Ca79KS/zf98qaWyBGzW+5ez58Iyw==",
       "dependencies": {
         "cssnano-preset-advanced": "^5.3.10",
         "postcss": "^8.4.26",
@@ -2441,10 +2437,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.1.1.tgz",
-      "integrity": "sha512-BjkNDpQzewcTnST8trx4idSoAla6zZ3w22NqM/UMcFtvYJgmoE4layuTzlfql3VFPNuivvj7BOExa/+21y4X2Q==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.2.0.tgz",
+      "integrity": "sha512-Z1R1NcOGXZ8CkIJSvjvyxnuDDSlx/+1xlh20iVTw1DZRjonFmI3T3tTgk40YpXyWUYQpIgAoqqPMpuseMMdgRQ==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.6.0"
@@ -2454,16 +2449,13 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.1.1.tgz",
-      "integrity": "sha512-xN2IccH9+sv7TmxwsDJNS97BHdmlqWwho+kIVY4tcCXkp+k4QuzvWBeunIMzeayY4Fu13A6sAjHGv5qm72KyGA==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.2.0.tgz",
+      "integrity": "sha512-JtkI5o6R/rJSr1Y23cHKz085aBJCvJw3AYHihJ7r+mBX+O8EuQIynG0e6/XpbSCpr7Ino0U50UtxaXcEbFwg9Q==",
       "dependencies": {
-        "@babel/parser": "^7.22.7",
-        "@babel/traverse": "^7.22.8",
-        "@docusaurus/logger": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/logger": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -2495,13 +2487,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.1.1.tgz",
-      "integrity": "sha512-xBJyx0TMfAfVZ9ZeIOb1awdXgR4YJMocIEzTps91rq+hJDFJgJaylDtmoRhUxkwuYmNK1GJpW95b7DLztSBJ3A==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.2.0.tgz",
+      "integrity": "sha512-jRSp9YkvBwwNz6Xgy0RJPsnie+Ebb//gy7GdbkJ2pW2gvvlYKGib2+jSF0pfIzvyZLulfCynS1KQdvDKdSl8zQ==",
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "3.1.1",
+        "@docusaurus/types": "3.2.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2515,18 +2506,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.1.1.tgz",
-      "integrity": "sha512-ew/3VtVoG3emoAKmoZl7oKe1zdFOsI0NbcHS26kIxt2Z8vcXKCUgK9jJJrz0TbOipyETPhqwq4nbitrY3baibg==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.2.0.tgz",
+      "integrity": "sha512-MABqwjSicyHmYEfQueMthPCz18JkVxhK3EGhXTSRWwReAZ0UTuw9pG6+Wo+uXAugDaIcJH28rVZSwTDINPm2bw==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/logger": "3.1.1",
-        "@docusaurus/mdx-loader": "3.1.1",
-        "@docusaurus/types": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
-        "@docusaurus/utils-common": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/logger": "3.2.0",
+        "@docusaurus/mdx-loader": "3.2.0",
+        "@docusaurus/types": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-common": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -2547,18 +2537,18 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.1.1.tgz",
-      "integrity": "sha512-lhFq4E874zw0UOH7ujzxnCayOyAt0f9YPVYSb9ohxrdCM8B4szxitUw9rIX4V9JLLHVoqIJb6k+lJJ1jrcGJ0A==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.2.0.tgz",
+      "integrity": "sha512-uuqhahmsBnirxOz+SXksnWt7+wc+iN4ntxNRH48BUgo7QRNLATWjHCgI8t6zrMJxK4o+QL9DhLaPDlFHs91B3Q==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/logger": "3.1.1",
-        "@docusaurus/mdx-loader": "3.1.1",
-        "@docusaurus/module-type-aliases": "3.1.1",
-        "@docusaurus/types": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/logger": "3.2.0",
+        "@docusaurus/mdx-loader": "3.2.0",
+        "@docusaurus/module-type-aliases": "3.2.0",
+        "@docusaurus/types": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-common": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -2577,16 +2567,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.1.1.tgz",
-      "integrity": "sha512-NQHncNRAJbyLtgTim9GlEnNYsFhuCxaCNkMwikuxLTiGIPH7r/jpb7O3f3jUMYMebZZZrDq5S7om9a6rvB/YCA==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.2.0.tgz",
+      "integrity": "sha512-4ofAN7JDsdb4tODO9OIrizWY5DmEJXr0eu+UDIkLqGP+gXXTahJZv8h2mlxO+lPXGXRCVBOfA14OG1hOYJVPwA==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/mdx-loader": "3.1.1",
-        "@docusaurus/types": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/mdx-loader": "3.2.0",
+        "@docusaurus/types": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -2600,14 +2589,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.1.1.tgz",
-      "integrity": "sha512-xWeMkueM9wE/8LVvl4+Qf1WqwXmreMjI5Kgr7GYCDoJ8zu4kD+KaMhrh7py7MNM38IFvU1RfrGKacCEe2DRRfQ==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.2.0.tgz",
+      "integrity": "sha512-p6WxtO5XZGz66y6QNQtCJwBefq4S6/w75XaXVvH1/2P9uaijvF7R+Cm2EWQZ5WsvA5wl//DFWblyDHRyVC207Q==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/types": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/types": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
@@ -2621,14 +2609,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.1.1.tgz",
-      "integrity": "sha512-+q2UpWTqVi8GdlLoSlD5bS/YpxW+QMoBwrPrUH/NpvpuOi0Of7MTotsQf9JWd3hymZxl2uu1o3PIrbpxfeDFDQ==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.2.0.tgz",
+      "integrity": "sha512-//TepJTEyAZSvBwHKEbXHu9xT/VkK3wUil2ZakKvQZYfUC01uWn6A1E3toa8R7WhCy1xPUeIukqmJy1Clg8njQ==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/types": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/types": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2640,14 +2627,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.1.1.tgz",
-      "integrity": "sha512-0mMPiBBlQ5LFHTtjxuvt/6yzh8v7OxLi3CbeEsxXZpUzcKO/GC7UA1VOWUoBeQzQL508J12HTAlR3IBU9OofSw==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.2.0.tgz",
+      "integrity": "sha512-3s6zxlaMMb87MW2Rxy6EnSRDs0WDEQPuHilZZH402C8kOrUnIwlhlfjWZ4ZyLDziGl/Eec/DvD0PVqj0qHRomA==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/types": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/types": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -2660,14 +2646,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.1.1.tgz",
-      "integrity": "sha512-d07bsrMLdDIryDtY17DgqYUbjkswZQr8cLWl4tzXrt5OR/T/zxC1SYKajzB3fd87zTu5W5klV5GmUwcNSMXQXA==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.2.0.tgz",
+      "integrity": "sha512-rAKtsJ11vPHA7dTAqWCgyIy7AyFRF/lpI77Zd/4HKgqcIvIayVBvL3QtelhUazfYTLTH6ls6kQ9wjMcIFxRiGg==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/types": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/types": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2679,17 +2664,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.1.1.tgz",
-      "integrity": "sha512-iJ4hCaMmDaUqRv131XJdt/C/jJQx8UreDWTRqZKtNydvZVh/o4yXGRRFOplea1D9b/zpwL1Y+ZDwX7xMhIOTmg==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.2.0.tgz",
+      "integrity": "sha512-gnWDFt6MStjLkdtt63Lzc+14EPSd8B6mzJGJp9GQMvWDUoMAUijUqpVIHYQq+DPMcI4PJZ5I2nsl5XFf1vOldA==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/logger": "3.1.1",
-        "@docusaurus/types": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
-        "@docusaurus/utils-common": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/logger": "3.2.0",
+        "@docusaurus/types": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-common": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -2703,24 +2687,23 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.1.1.tgz",
-      "integrity": "sha512-jG4ys/hWYf69iaN/xOmF+3kjs4Nnz1Ay3CjFLDtYa8KdxbmUhArA9HmP26ru5N0wbVWhY+6kmpYhTJpez5wTyg==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.2.0.tgz",
+      "integrity": "sha512-t7tXyk8kUgT7hUqEOgSJnPs+Foem9ucuan/a9QVYaVFCDjp92Sb2FpCY8bVasAokYCjodYe2LfpAoSCj5YDYWg==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/plugin-content-blog": "3.1.1",
-        "@docusaurus/plugin-content-docs": "3.1.1",
-        "@docusaurus/plugin-content-pages": "3.1.1",
-        "@docusaurus/plugin-debug": "3.1.1",
-        "@docusaurus/plugin-google-analytics": "3.1.1",
-        "@docusaurus/plugin-google-gtag": "3.1.1",
-        "@docusaurus/plugin-google-tag-manager": "3.1.1",
-        "@docusaurus/plugin-sitemap": "3.1.1",
-        "@docusaurus/theme-classic": "3.1.1",
-        "@docusaurus/theme-common": "3.1.1",
-        "@docusaurus/theme-search-algolia": "3.1.1",
-        "@docusaurus/types": "3.1.1"
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/plugin-content-blog": "3.2.0",
+        "@docusaurus/plugin-content-docs": "3.2.0",
+        "@docusaurus/plugin-content-pages": "3.2.0",
+        "@docusaurus/plugin-debug": "3.2.0",
+        "@docusaurus/plugin-google-analytics": "3.2.0",
+        "@docusaurus/plugin-google-gtag": "3.2.0",
+        "@docusaurus/plugin-google-tag-manager": "3.2.0",
+        "@docusaurus/plugin-sitemap": "3.2.0",
+        "@docusaurus/theme-classic": "3.2.0",
+        "@docusaurus/theme-common": "3.2.0",
+        "@docusaurus/theme-search-algolia": "3.2.0",
+        "@docusaurus/types": "3.2.0"
       },
       "engines": {
         "node": ">=18.0"
@@ -2744,23 +2727,22 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.1.1.tgz",
-      "integrity": "sha512-GiPE/jbWM8Qv1A14lk6s9fhc0LhPEQ00eIczRO4QL2nAQJZXkjPG6zaVx+1cZxPFWbAsqSjKe2lqkwF3fGkQ7Q==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.2.0.tgz",
+      "integrity": "sha512-4oSO5BQOJ5ja7WYdL6jK1n4J96tp+VJHamdwao6Ea252sA3W3vvR0otTflG4p4XVjNZH6hlPQoi5lKW0HeRgfQ==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/mdx-loader": "3.1.1",
-        "@docusaurus/module-type-aliases": "3.1.1",
-        "@docusaurus/plugin-content-blog": "3.1.1",
-        "@docusaurus/plugin-content-docs": "3.1.1",
-        "@docusaurus/plugin-content-pages": "3.1.1",
-        "@docusaurus/theme-common": "3.1.1",
-        "@docusaurus/theme-translations": "3.1.1",
-        "@docusaurus/types": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
-        "@docusaurus/utils-common": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/mdx-loader": "3.2.0",
+        "@docusaurus/module-type-aliases": "3.2.0",
+        "@docusaurus/plugin-content-blog": "3.2.0",
+        "@docusaurus/plugin-content-docs": "3.2.0",
+        "@docusaurus/plugin-content-pages": "3.2.0",
+        "@docusaurus/theme-common": "3.2.0",
+        "@docusaurus/theme-translations": "3.2.0",
+        "@docusaurus/types": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-common": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
@@ -2784,18 +2766,17 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.1.1.tgz",
-      "integrity": "sha512-38urZfeMhN70YaXkwIGXmcUcv2CEYK/2l4b05GkJPrbEbgpsIZM3Xc+Js2ehBGGZmfZq8GjjQ5RNQYG+MYzCYg==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.2.0.tgz",
+      "integrity": "sha512-sFbw9XviNJJ+760kAcZCQMQ3jkNIznGqa6MQ70E5BnbP+ja36kGgPOfjcsvAcNey1H1Rkhh3p2Mhf4HVLdKVVw==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.1.1",
-        "@docusaurus/module-type-aliases": "3.1.1",
-        "@docusaurus/plugin-content-blog": "3.1.1",
-        "@docusaurus/plugin-content-docs": "3.1.1",
-        "@docusaurus/plugin-content-pages": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
-        "@docusaurus/utils-common": "3.1.1",
+        "@docusaurus/mdx-loader": "3.2.0",
+        "@docusaurus/module-type-aliases": "3.2.0",
+        "@docusaurus/plugin-content-blog": "3.2.0",
+        "@docusaurus/plugin-content-docs": "3.2.0",
+        "@docusaurus/plugin-content-pages": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-common": "3.2.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2814,16 +2795,15 @@
       }
     },
     "node_modules/@docusaurus/theme-mermaid": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.1.1.tgz",
-      "integrity": "sha512-O6u9/7QX/ZapV4HJJSzNs0Jir1KA/LRLORWYeDvbGswqZNusj6q4iLELrKIClysJ3PB3zWUzyKtI/wjIKiV1vA==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-mermaid/-/theme-mermaid-3.2.0.tgz",
+      "integrity": "sha512-PvN6K6m3JaM9cr9oSPyba6OlwAiSfBzqQtNqdgPFDjakKuT4kj6JODfExi+HKtWuxayOVRQlRl7zTnWxM4sTVw==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/module-type-aliases": "3.1.1",
-        "@docusaurus/theme-common": "3.1.1",
-        "@docusaurus/types": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/module-type-aliases": "3.2.0",
+        "@docusaurus/theme-common": "3.2.0",
+        "@docusaurus/types": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "mermaid": "^10.4.0",
         "tslib": "^2.6.0"
       },
@@ -2836,19 +2816,18 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.1.1.tgz",
-      "integrity": "sha512-tBH9VY5EpRctVdaAhT+b1BY8y5dyHVZGFXyCHgTrvcXQy5CV4q7serEX7U3SveNT9zksmchPyct6i1sFDC4Z5g==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.2.0.tgz",
+      "integrity": "sha512-PgvF4qHoqJp8+GfqClUbTF/zYNOsz4De251IuzXon7+7FAXwvb2qmYtA2nEwyMbB7faKOz33Pxzv+y+153KS/g==",
       "dependencies": {
         "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/logger": "3.1.1",
-        "@docusaurus/plugin-content-docs": "3.1.1",
-        "@docusaurus/theme-common": "3.1.1",
-        "@docusaurus/theme-translations": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/logger": "3.2.0",
+        "@docusaurus/plugin-content-docs": "3.2.0",
+        "@docusaurus/theme-common": "3.2.0",
+        "@docusaurus/theme-translations": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "algoliasearch": "^4.18.0",
         "algoliasearch-helper": "^3.13.3",
         "clsx": "^2.0.0",
@@ -2867,10 +2846,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.1.1.tgz",
-      "integrity": "sha512-xvWQFwjxHphpJq5fgk37FXCDdAa2o+r7FX8IpMg+bGZBNXyWBu3MjZ+G4+eUVNpDhVinTc+j6ucL0Ain5KCGrg==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.2.0.tgz",
+      "integrity": "sha512-VXzZJBuyVEmwUYyud+7IgJQEBRM6R2u/s10Rp3DOP19CBQxeKgHYTKkKhFtDeKMHDassb665kjgOi0YlJfUT6w==",
       "dependencies": {
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -2880,10 +2858,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.1.1.tgz",
-      "integrity": "sha512-grBqOLnubUecgKFXN9q3uit2HFbCxTWX4Fam3ZFbMN0sWX9wOcDoA7lwdX/8AmeL20Oc4kQvWVgNrsT8bKRvzg==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.2.0.tgz",
+      "integrity": "sha512-uG3FfTkkkbZIPPNYx6xRfZHKeGyRd/inIT1cqvYt1FobFLd+7WhRXrSBqwJ9JajJjEAjNioRMVFgGofGf/Wdww==",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "@types/history": "^4.7.11",
@@ -2901,12 +2878,12 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.1.1.tgz",
-      "integrity": "sha512-ZJfJa5cJQtRYtqijsPEnAZoduW6sjAQ7ZCWSZavLcV10Fw0Z3gSaPKA/B4micvj2afRZ4gZxT7KfYqe5H8Cetg==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.2.0.tgz",
+      "integrity": "sha512-3rgrE7iL60yV2JQivlcoxUNNTK2APmn+OHLUmTvX2pueIM8DEOCEFHpJO4MiWjFO7V/Wq3iA/W1M03JnjdugVw==",
       "dependencies": {
-        "@docusaurus/logger": "3.1.1",
+        "@docusaurus/logger": "3.2.0",
+        "@docusaurus/utils-common": "3.2.0",
         "@svgr/webpack": "^6.5.1",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -2918,6 +2895,7 @@
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "micromatch": "^4.0.5",
+        "prompts": "^2.4.2",
         "resolve-pathname": "^3.0.0",
         "shelljs": "^0.8.5",
         "tslib": "^2.6.0",
@@ -2937,10 +2915,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.1.1.tgz",
-      "integrity": "sha512-eGne3olsIoNfPug5ixjepZAIxeYFzHHnor55Wb2P57jNbtVaFvij/T+MS8U0dtZRFi50QU+UPmRrXdVUM8uyMg==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.2.0.tgz",
+      "integrity": "sha512-WEQT5L2lT/tBQgDRgeZQAIi9YJBrwEILb1BuObQn1St3T/4K1gx5fWwOT8qdLOov296XLd1FQg9Ywu27aE9svw==",
       "dependencies": {
         "tslib": "^2.6.0"
       },
@@ -2957,13 +2934,13 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.1.1.tgz",
-      "integrity": "sha512-KlY4P9YVDnwL+nExvlIpu79abfEv6ZCHuOX4ZQ+gtip+Wxj0daccdReIWWtqxM/Fb5Cz1nQvUCc7VEtT8IBUAA==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.2.0.tgz",
+      "integrity": "sha512-rCzMTqwNrBrEOyU8EaD1fYWdig4TDhfj+YLqB8DY68VUAqSIgbY+yshpqFKB0bznFYNBJbn0bGpvVuImQOa/vA==",
       "dependencies": {
-        "@docusaurus/logger": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/logger": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-common": "3.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
         "tslib": "^2.6.0"
@@ -3366,20 +3343,6 @@
         "micromark-factory-space": "^1.0.0",
         "micromark-util-character": "^1.1.0",
         "micromark-util-symbol": "^1.0.1"
-      }
-    },
-    "node_modules/@slorber/static-site-generator-webpack-plugin": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@slorber/static-site-generator-webpack-plugin/-/static-site-generator-webpack-plugin-4.0.7.tgz",
-      "integrity": "sha512-Ug7x6z5lwrz0WqdnNFOMYrDQNTPAprvHLSh6+/fmml3qUiz6l5eq+2MzLKWtn/q5K5NpSiFsZTP/fck/3vjSxA==",
-      "license": "MIT",
-      "dependencies": {
-        "eval": "^0.1.8",
-        "p-map": "^4.0.0",
-        "webpack-sources": "^3.2.2"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
@@ -3799,8 +3762,7 @@
     "node_modules/@types/gtag.js": {
       "version": "0.0.12",
       "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.12.tgz",
-      "integrity": "sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg==",
-      "license": "MIT"
+      "integrity": "sha512-YQV9bUsemkzG81Ea295/nF/5GijnD2Af7QhEofh7xu+kvCN6RdodgNwwGWXB5GMI3NoyvQo0odNctoH/qLMIpg=="
     },
     "node_modules/@types/hast": {
       "version": "3.0.4",
@@ -4002,7 +3964,6 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/sax/-/sax-1.2.7.tgz",
       "integrity": "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -4393,32 +4354,31 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.22.1.tgz",
-      "integrity": "sha512-jwydKFQJKIx9kIZ8Jm44SdpigFwRGPESaxZBaHSV0XWN2yBJAOT4mT7ppvlrpA4UGzz92pqFnVKr/kaZXrcreg==",
-      "license": "MIT",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.23.2.tgz",
+      "integrity": "sha512-8aCl055IsokLuPU8BzLjwzXjb7ty9TPcUFFOk0pYOwsE5DMVhE3kwCMFtsCFKcnoPZK7oObm+H5mbnSO/9ioxQ==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.22.1",
-        "@algolia/cache-common": "4.22.1",
-        "@algolia/cache-in-memory": "4.22.1",
-        "@algolia/client-account": "4.22.1",
-        "@algolia/client-analytics": "4.22.1",
-        "@algolia/client-common": "4.22.1",
-        "@algolia/client-personalization": "4.22.1",
-        "@algolia/client-search": "4.22.1",
-        "@algolia/logger-common": "4.22.1",
-        "@algolia/logger-console": "4.22.1",
-        "@algolia/requester-browser-xhr": "4.22.1",
-        "@algolia/requester-common": "4.22.1",
-        "@algolia/requester-node-http": "4.22.1",
-        "@algolia/transporter": "4.22.1"
+        "@algolia/cache-browser-local-storage": "4.23.2",
+        "@algolia/cache-common": "4.23.2",
+        "@algolia/cache-in-memory": "4.23.2",
+        "@algolia/client-account": "4.23.2",
+        "@algolia/client-analytics": "4.23.2",
+        "@algolia/client-common": "4.23.2",
+        "@algolia/client-personalization": "4.23.2",
+        "@algolia/client-search": "4.23.2",
+        "@algolia/logger-common": "4.23.2",
+        "@algolia/logger-console": "4.23.2",
+        "@algolia/recommend": "4.23.2",
+        "@algolia/requester-browser-xhr": "4.23.2",
+        "@algolia/requester-common": "4.23.2",
+        "@algolia/requester-node-http": "4.23.2",
+        "@algolia/transporter": "4.23.2"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.16.3",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.16.3.tgz",
-      "integrity": "sha512-1OuJT6sONAa9PxcOmWo5WCAT3jQSpCR9/m5Azujja7nhUQwAUDvaaAYrcmUySsrvHh74usZHbE3jFfGnWtZj8w==",
-      "license": "MIT",
+      "version": "3.17.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.17.0.tgz",
+      "integrity": "sha512-R5422OiQjvjlK3VdpNQ/Qk7KsTIGeM5ACm8civGifOVWdRRV/3SgXuKmeNxe94Dz6fwj/IgpVmXbHutU4mHubg==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -4507,8 +4467,7 @@
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "license": "MIT"
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -4568,9 +4527,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.18",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.18.tgz",
-      "integrity": "sha512-1DKbDfsr6KUElM6wg+0zRNkB/Q7WcKYAaK+pzXn+Xqmszm/5Xa9coeNdtP88Vi+dPzZnMjhge8GIV49ZQkDa+g==",
+      "version": "10.4.19",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
+      "integrity": "sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==",
       "funding": [
         {
           "type": "opencollective",
@@ -4585,10 +4544,9 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "browserslist": "^4.23.0",
-        "caniuse-lite": "^1.0.30001591",
+        "caniuse-lite": "^1.0.30001599",
         "fraction.js": "^4.3.7",
         "normalize-range": "^0.1.2",
         "picocolors": "^1.0.0",
@@ -4990,9 +4948,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001593",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001593.tgz",
-      "integrity": "sha512-UWM1zlo3cZfkpBysd7AS+z+v007q9G1+fLTUU42rQnY6t2axoogPW/xol6T7juU5EUoOhML4WgBIdG+9yYqAjQ==",
+      "version": "1.0.30001605",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001605.tgz",
+      "integrity": "sha512-nXwGlFWo34uliI9z3n6Qc0wZaf7zaZWA1CPZ169La5mV3I/gem7bst0vr5XQH5TJXZIMfDeZyOrZnSlVzKxxHQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -5006,8 +4964,7 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -5563,7 +5520,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/copy-text-to-clipboard/-/copy-text-to-clipboard-3.2.0.tgz",
       "integrity": "sha512-RnJFp1XR/LOBDckxTib5Qjr/PMfkatD0MUCQgdpqS8MdKiNUzBjAQBEN6oUy+jW7LI93BBG3DtMB2KOOKpGs2Q==",
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -5971,7 +5927,6 @@
       "version": "5.3.10",
       "resolved": "https://registry.npmjs.org/cssnano-preset-advanced/-/cssnano-preset-advanced-5.3.10.tgz",
       "integrity": "sha512-fnYJyCS9jgMU+cmHO1rPSPf9axbQyD7iUhLO5Df6O4G+fKIOMps+ZbU0PdGFejFBBZ3Pftf18fn1eG7MAPUSWQ==",
-      "license": "MIT",
       "dependencies": {
         "autoprefixer": "^10.4.12",
         "cssnano-preset-default": "^5.2.14",
@@ -7990,7 +7945,6 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
       "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
-      "license": "MIT",
       "engines": {
         "node": "*"
       },
@@ -9105,7 +9059,6 @@
       "version": "0.2.0-alpha.43",
       "resolved": "https://registry.npmjs.org/infima/-/infima-0.2.0-alpha.43.tgz",
       "integrity": "sha512-2uw57LvUqW0rK/SWYnd/2rRfxNA5DDNOh33jxF7fy46VWoNhGxiUQyVZHbBMjQ33mQem0cjdDVwgWVAmlRfgyQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
@@ -13074,7 +13027,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13106,8 +13058,7 @@
     "node_modules/nprogress": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
-      "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA==",
-      "license": "MIT"
+      "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA=="
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -13962,7 +13913,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-5.1.0.tgz",
       "integrity": "sha512-KwLWymI9hbwXmJa0dkrzpRbSJEh0vVUd7r8t0yOGPcfKzyJJxFM8kLyC5Ev9avji6nY95pOp1W6HqIrfT+0VGw==",
-      "license": "MIT",
       "dependencies": {
         "postcss-selector-parser": "^6.0.5"
       },
@@ -14025,7 +13975,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-5.1.1.tgz",
       "integrity": "sha512-pCijL1TREiCoog5nQp7wUe+TUonA2tC2sQ54UGeMmryK3UFGIYKqDyjnqd6RcuI4znFn9hWSLNN8xKE/vWcUQw==",
-      "license": "MIT",
       "dependencies": {
         "cssnano-utils": "^3.1.0",
         "postcss-value-parser": "^4.2.0"
@@ -14348,7 +14297,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-5.2.0.tgz",
       "integrity": "sha512-BTrLjICoSB6gxbc58D5mdBK8OhXRDqud/zodYfdSi52qvDHdMwk+9kB9xsM8yJThH/sZU5A6QVSmMmaN001gIg==",
-      "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.2.0"
       },
@@ -14407,7 +14355,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-4.4.1.tgz",
       "integrity": "sha512-QDESFzDDGKgpiIh4GYXsSy6sek2yAwQx1JASl5AxBtU1Lq2JfKBljIPNdil989NcSKRQX1ToiaKphImtBuhXWw==",
-      "license": "MIT",
       "dependencies": {
         "sort-css-media-queries": "2.1.0"
       },
@@ -14459,7 +14406,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/postcss-zindex/-/postcss-zindex-5.1.0.tgz",
       "integrity": "sha512-fgFMf0OtVSBR1va1JNHYgMxYk73yhn/qb4uQDq1DLGYolz8gHCyr/sesEuGUaYs58E3ZJRcpoGuPVoB7Meiq9A==",
-      "license": "MIT",
       "engines": {
         "node": "^10 || ^12 || >=14.0"
       },
@@ -14970,10 +14916,9 @@
       "license": "MIT"
     },
     "node_modules/react-json-view-lite": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.2.1.tgz",
-      "integrity": "sha512-Itc0g86fytOmKZoIoJyGgvNqohWSbh3NXIKNgH6W6FT9PC1ck4xas1tT3Rr/b3UlFXyA9Jjaw9QSXdZy2JwGMQ==",
-      "license": "MIT",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.3.0.tgz",
+      "integrity": "sha512-aN1biKC5v4DQkmQBlZjuMFR09MKZGMPtIg+cut8zEeg2HXd6gl2gRy0n4HMacHf0dznQgo0SVXN7eT8zV3hEuQ==",
       "engines": {
         "node": ">=14"
       },
@@ -15796,7 +15741,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-4.1.1.tgz",
       "integrity": "sha512-/oVHgBtnPNcggP2aVXQjSy6N1mMAfHg4GSag0QtZBlD5bdDgAHwr4pydqJGd+SUCu9260+Pjqbjwtvu7EMH1KQ==",
-      "license": "MIT",
       "dependencies": {
         "escalade": "^3.1.1",
         "picocolors": "^1.0.0",
@@ -16016,7 +15960,8 @@
     },
     "node_modules/search-insights": {
       "version": "2.13.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.13.0.tgz",
+      "integrity": "sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==",
       "peer": true
     },
     "node_modules/section-matter": {
@@ -16467,7 +16412,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-7.1.1.tgz",
       "integrity": "sha512-mK3aFtjz4VdJN0igpIJrinf3EO8U8mxOPsTBzSsy06UtjZQJ3YY3o3Xa7zSc5nMqcMrRwlChHZ18Kxg0caiPBg==",
-      "license": "MIT",
       "dependencies": {
         "@types/node": "^17.0.5",
         "@types/sax": "^1.2.1",
@@ -16485,8 +16429,7 @@
     "node_modules/sitemap/node_modules/@types/node": {
       "version": "17.0.45",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.45.tgz",
-      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
-      "license": "MIT"
+      "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="
     },
     "node_modules/skin-tone": {
       "version": "2.0.0",
@@ -16533,7 +16476,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sort-css-media-queries/-/sort-css-media-queries-2.1.0.tgz",
       "integrity": "sha512-IeWvo8NkNiY2vVYdPa27MCQiR0MN0M80johAYFVxWWXQ44KU84WNxjslwBHmc/7ZL2ccwkM7/e6S5aiKZXm7jA==",
-      "license": "MIT",
       "engines": {
         "node": ">= 6.3.0"
       }
@@ -16774,7 +16716,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       },

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "3.1.1",
-    "@docusaurus/preset-classic": "3.1.1",
-    "@docusaurus/theme-mermaid": "^3.1.1",
+    "@docusaurus/core": "^3.2.0",
+    "@docusaurus/preset-classic": "^3.2.0",
+    "@docusaurus/theme-mermaid": "^3.2.0",
     "@mdx-js/react": "^3.0.0",
     "@saucelabs/theme-github-codeblock": "^0.2.3",
     "clsx": "^2.0.0",
@@ -31,8 +31,8 @@
     "sass": "^1.71.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.1.1",
-    "@docusaurus/types": "3.1.1"
+    "@docusaurus/module-type-aliases": "^3.2.0",
+    "@docusaurus/types": "^3.2.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
Update available 3.1.1 → 3.2.0

                                                 To upgrade Docusaurus packages with the latest version, run the following command:
         `npm i @docusaurus/core@latest @docusaurus/preset-classic@latest @docusaurus/theme-mermaid@latest @docusaurus/module-type-aliases@latest @docusaurus/types@latest`