### PR TITLE
Add Pro tag to navigation for HostPathMapper

### DIFF
--- a/docs/vcluster/vcluster-yaml/control-plane/components/host-path-mapper.mdx
+++ b/docs/vcluster/vcluster-yaml/control-plane/components/host-path-mapper.mdx
@@ -2,6 +2,7 @@
 title: Host Path Mapper
 sidebar_label: hostPathMapper
 sidebar_position: 5
+sidebar_class_name: pro
 description: Configuration for ...
 ---
 


### PR DESCRIPTION
Since HostPathMapper only makes sense with Central enabled which is a pro feature, we've decided to show it as Pro only. Updated in the Nav bar to reflect it. 

Fixes ENG-3218