### PR TITLE
ENG-3416 backingStore.database.external PRO and open source note K3s

### DIFF
--- a/docs/vcluster/vcluster-yaml/control-plane/components/backing-store/database/external.mdx
+++ b/docs/vcluster/vcluster-yaml/control-plane/components/backing-store/database/external.mdx
@@ -20,7 +20,7 @@ controlPlane:
 
 Replace _`CONNECTION_STRING`_ with the connection string for your database, such as `postgres://username:password@hostname:5432/vcluster-db`.
 
-## Vanilla Kuberntes and EKS distros
+## Vanilla Kubernetes and EKS distros
 
 This is a Pro feature when you are using vanilla Kubernetes or EKS as your virtual cluster distro.
 


### PR DESCRIPTION
Fixes ENG-3416

https://deploy-preview-83--vcluster-docs-site.netlify.app/docs/vcluster/vcluster-yaml/control-plane/components/backing-store/database/external