### PR TITLE
fix: stdout has to be redirected to a file

### DIFF
--- a/docs/vcluster/guides/0-20-migration.mdx
+++ b/docs/vcluster/guides/0-20-migration.mdx
@@ -55,7 +55,7 @@ Flags:
 Convert to the new `vcluster.yaml` configuration file format by running:
 
 ```BASH
-vcluster convert config --distro KUBERNETES_DISTRO -f VALUES_FILE -o vcluster.yaml
+vcluster convert config --distro KUBERNETES_DISTRO -f VALUES_FILE > vcluster.yaml
 ```
 
 Replace:


### PR DESCRIPTION
The -o option tells the command to either display the output as yaml or as json.

https://deploy-preview-89--vcluster-docs-site.netlify.app/docs/vcluster/guides/0-20-migration/#convert-your-valuesyaml-to-vclusteryaml