### PR TITLE
Tweaks to conversion guide

### DIFF
--- a/docs/vcluster/guides/0-20-migration.mdx
+++ b/docs/vcluster/guides/0-20-migration.mdx
@@ -5,15 +5,20 @@ description: How to migrate from pre-v0.20 to v0.20 release.
 ---
 import DeployChanges from '@site/docs/_fragments/deploy-changes.mdx'
 
-This guide shows you how to upgrade your vCluster v0.19 to v0.20+. First, you convert your Helm values configuration file to the new `vcluster.yaml` configuration file. Then use your new `vcluster.yaml` file to upgrade your vCluster.
+As part of the v0.20.0 release, Loft Labs introduced a new `vcluster.yaml` configuration file with a new structure. This file replaces your existing `values.yaml` configuration file. Pre-v0.20.0 `values.yaml` files are not compatible with v0.20.0. You need to convert to the new format in order to use the new vCluster CLI and upgrade existing vCluster instances.
 
-As part of the v0.20.0 release, Loft Labs introduced a new `vcluster.yaml` configuration file with a new structure. This file replaces your existing `values.yaml` that created for a specific Kubernetes distribution of vCluster. Pre-v0.20.0 `values.yaml` files are not compatible with v0.20.0. You need to convert to the new format in order to use the new vCluster CLI and upgrade existing vCluster instances.
+Upgrade vCluster v0.19 to v0.20+ by following these steps: 
 
-[View the v0.20.0-beta.1 release notes](https://github.com/loft-sh/vcluster/releases/tag/v0.20.0-beta.1).
+1. [Upgrade the vCluster CLI](#upgrade-the-cli).
+1. [Convert your Helm values configuration file to the new `vcluster.yaml` configuration file](#convert-your-valuesyaml-to-vclusteryaml). 
+1. [Use your new `vcluster.yaml` file to upgrade your vCluster instance](#upgrade-your-vcluster-instance).
 
 <br></br>
 :::warning Beta Release
 vCluster v0.20.0 is currently in beta. This version contains most of the major features, but is not yet complete. It is intended to give an early preview and gather feedback from our users. Loft Labs strongly discourages using v0.20.0 in production environments. There will be a GA release after Loft Labs has received input and matured the v0.20 release stream.
+
+
+[View the v0.20.0-beta.1 release notes](https://github.com/loft-sh/vcluster/releases/tag/v0.20.0-beta.1).
 :::
 
 ## Supported legacy versions
@@ -66,7 +71,7 @@ Replace:
 For example:
 
 ```BASH
-vcluster convert config --distro k8s -f /my/k8s/values.yaml
+vcluster convert config --distro k8s -f /my/k8s/values.yaml > vcluster.yaml
 ```
 
 If you don’t have your configuration values, use Helm to retrieve those for your currently running virtual cluster.
@@ -82,12 +87,11 @@ Replace:
 
 This uses `--revision 0` under the hood. Adjust this accordingly to receive the values of your latest revision. See the [Helm docs](https://helm.sh/docs/helm/helm_history/) for how to fetch revision history.
 
-### Upgrade your vCluster instance
+## Upgrade your vCluster instance
 
 :::warning Downgrading vCluster instances is NOT supported
 While downgrading to an older version of the vCluster CLI is supported, you cannot downgrade virtual cluster instances to a prior version of vCluster (for example, from 0.20 back to 0.19). Make sure you have tested the upgrade sufficiently before rolling out this change to critical systems.
 :::
-
 
 <DeployChanges/>
 
@@ -101,5 +105,6 @@ vcluster upgrade --version v0.19.5
 
 ## Related content
 
+- [View the v0.20.0-beta.1 release notes](https://github.com/loft-sh/vcluster/releases/tag/v0.20.0-beta.1).
 - [Get started](/get-started.mdx) to learn how to use the new config file.
 - [vCluster config reference](/vcluster/vcluster-yaml/README.mdx) for configuration details.

--- a/docs/vcluster/vcluster-yaml/README.mdx
+++ b/docs/vcluster/vcluster-yaml/README.mdx
@@ -23,6 +23,8 @@ import DeployChanges from '@site/docs/_fragments/deploy-changes.mdx'
 
 Configure your vCluster installation in a `vcluster.yaml` configuration file. Then deploy your changes.
 
+If you are moving from vCluster 0.19.x to 0.20+, see the [conversion guide](vcluster/guides/0-20-migration.mdx) for how to automatically convert your existing `values.yaml` configuration file to the new `vcluster.yaml` format.
+
 <DeployChanges/>
 
 ## Config reference

--- a/docs/vcluster/vcluster-yaml/README.mdx
+++ b/docs/vcluster/vcluster-yaml/README.mdx
@@ -21,9 +21,11 @@ import DeployChanges from '@site/docs/_fragments/deploy-changes.mdx'
 
 ## Create a virtual cluster with a config file
 
-Configure your vCluster installation in a `vcluster.yaml` configuration file. Then deploy your changes.
-
+:::tip
 If you are moving from vCluster 0.19.x to 0.20+, see the [conversion guide](vcluster/guides/0-20-migration.mdx) for how to automatically convert your existing `values.yaml` configuration file to the new `vcluster.yaml` format.
+:::
+
+Configure your vCluster installation in a `vcluster.yaml` configuration file. Then deploy your changes.
 
 <DeployChanges/>
 


### PR DESCRIPTION
Fixes DOC-31

Overview section:
- add list of steps with links to page anchors
- move release notes link to beta admonition

Convert section:
- add `> vcluster.yaml` to example so structure matches the command syntax above

Related content:
- add link to release notes
------
vcluster-yaml section landing page:
- add link to conversion guide

Deploy previews:
- https://deploy-preview-90--vcluster-docs-site.netlify.app/docs/vcluster/vcluster-yaml/
- https://deploy-preview-90--vcluster-docs-site.netlify.app/docs/vcluster/guides/0-20-migration
