### PR TITLE
DOC-40 add redirects for google search result link

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,7 +15,7 @@ command = """
 
 [[redirects]]
   from = "/docs/architecture/*"
-  to = "https://www.vcluster.com/docs/v0.19/architecture/:splat"
+  to = "/docs/architecture/"
 
 [[redirects]]
   from = "/docs/cli/*"
@@ -27,7 +27,7 @@ command = """
 
 [[redirects]]
   from = "/docs/getting-started/*"
-  to = "https://www.vcluster.com/docs/v0.19/getting-started/:splat"  
+  to = "/docs/get-started/"  
 
 [[redirects]]
   from = "/docs/help&tutorials/*"
@@ -63,7 +63,7 @@ command = """
 
 [[redirects]]
   from = "/docs/config-reference/"
-  to = "https://www.vcluster.com/docs/v0.19/config-reference/" 
+  to = "/docs/vcluster/vcluster-yaml/" 
 
 [[redirects]]
   from = "/docs/storage/"
@@ -71,4 +71,4 @@ command = """
 
 [[redirects]]
   from = "/docs/what-are-virtual-clusters/"
-  to = "https://www.vcluster.com/docs/v0.19/stowhat-are-virtual-clusters/" 
+  to = "/docs/" 

--- a/netlify.toml
+++ b/netlify.toml
@@ -30,10 +30,6 @@ command = """
   to = "/docs/get-started/"  
 
 [[redirects]]
-  from = "/docs/help&amp;tutorials/*"
-  to = "https://www.vcluster.com/https://www.vcluster.com/docs/v0.19/help&amp;tutorials/:splat"  
-
-[[redirects]]
   from = "/docs/licenses/vcluster"
   to = "https://www.vcluster.com/docs/v0.19/licenses/vcluster" 
 
@@ -72,3 +68,7 @@ command = """
 [[redirects]]
   from = "/docs/what-are-virtual-clusters/"
   to = "/docs/" 
+
+[[redirects]]
+  from = "/docs/help&tutorials/*"
+  to = "https://www.vcluster.com/docs/v0.19/help&tutorials/:splat"  

--- a/netlify.toml
+++ b/netlify.toml
@@ -30,12 +30,12 @@ command = """
   to = "/docs/get-started/"  
 
 [[redirects]]
-  from = "/docs/help&tutorials/*"
-  to = "https://www.vcluster.com/https://www.vcluster.com/docs/v0.19/help&tutorials/:splat"  
+  from = "/docs/help&amp;tutorials/*"
+  to = "https://www.vcluster.com/https://www.vcluster.com/docs/v0.19/help&amp;tutorials/:splat"  
 
 [[redirects]]
-  from = "/docs/licenses/*"
-  to = "https://www.vcluster.com/docs/v0.19/licenses/:splat" 
+  from = "/docs/licenses/vcluster"
+  to = "https://www.vcluster.com/docs/v0.19/licenses/vcluster" 
 
 [[redirects]]
   from = "/docs/networking/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,11 +11,11 @@ command = """
 
 [[redirects]]
   from = "/docs/advanced-topics/*"
-  to = "https://www.vcluster.com/docs/v0.19/advanced-topics/"
+  to = "https://www.vcluster.com/docs/v0.19/advanced-topics/:splat"
 
 [[redirects]]
   from = "/docs/architecture/*"
-  to = "/docs/architecture/"
+  to = "/docs/vcluster/architecture/"
 
 [[redirects]]
   from = "/docs/cli/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,3 +8,67 @@ command = """
     npm run build
     mv build/ public/docs/
   """
+
+[[redirects]]
+  from = "/docs/advanced-topics/*"
+  to = "https://www.vcluster.com/docs/v0.19/advanced-topics/"
+
+[[redirects]]
+  from = "/docs/architecture/*"
+  to = "https://www.vcluster.com/docs/v0.19/architecture/:splat"
+
+[[redirects]]
+  from = "/docs/cli/*"
+  to = "https://www.vcluster.com/docs/v0.19/cli/:splat"  
+
+[[redirects]]
+  from = "/docs/deploying-vclusters/*"
+  to = "https://www.vcluster.com/docs/v0.19/deploying-vclusters/:splat"  
+
+[[redirects]]
+  from = "/docs/getting-started/*"
+  to = "https://www.vcluster.com/docs/v0.19/getting-started/:splat"  
+
+[[redirects]]
+  from = "/docs/help&tutorials/*"
+  to = "https://www.vcluster.com/https://www.vcluster.com/docs/v0.19/help&tutorials/:splat"  
+
+[[redirects]]
+  from = "/docs/licenses/*"
+  to = "https://www.vcluster.com/docs/v0.19/licenses/:splat" 
+
+[[redirects]]
+  from = "/docs/networking/*"
+  to = "https://www.vcluster.com/docs/v0.19/networking/:splat" 
+
+[[redirects]]
+  from = "/docs/o11y/*"
+  to = "https://www.vcluster.com/docs/v0.19/o11y/:splat" 
+
+[[redirects]]
+  from = "/docs/security/*"
+  to = "https://www.vcluster.com/docs/v0.19/security/:splat" 
+
+[[redirects]]
+  from = "/docs/syncer/*"
+  to = "https://www.vcluster.com/docs/v0.19/syncer/:splat" 
+
+[[redirects]]
+  from = "/docs/use-cases/*"
+  to = "https://www.vcluster.com/docs/v0.19/use-cases/o11y/:splat" 
+
+[[redirects]]
+  from = "/docs/using-vclusters/*"
+  to = "https://www.vcluster.com/docs/v0.19/using-vclusters/:splat" 
+
+[[redirects]]
+  from = "/docs/config-reference/"
+  to = "https://www.vcluster.com/docs/v0.19/config-reference/" 
+
+[[redirects]]
+  from = "/docs/storage/"
+  to = "https://www.vcluster.com/docs/v0.19/storage/" 
+
+[[redirects]]
+  from = "/docs/what-are-virtual-clusters/"
+  to = "https://www.vcluster.com/docs/v0.19/stowhat-are-virtual-clusters/" 


### PR DESCRIPTION
Fixed DOC-40

Test to see if using :splat with external URL works. May have to redirect * to legacy landing page instead.

**Old URLs redirect to current:**
- [x] /docs/getting-started/connect   ->  /docs/get-started/
- [x] /docs/architecture/* -> /docs/architecture/
- [x] /docs/config-reference/  -> /docs/vcluster/vcluster-yaml/
- [x] /docs/what-are-virtual-clusters/ -> /docs/

**Section tests:**
Any page in the section should redirect to same page in v0.19 docs

- [x] /docs/advanced-topics/   
- [x] /docs/cli/
- [x] /docs/deploying-vclusters/
- [x] /docs/help&tutorials/
- [x] /docs/networking/
- [x] /docs/o11y/
- [x] /docs/security/
- [x] /docs/syncer/
- [x] /docs/using-vclusters/

Individual pages:
- [x] /docs/storage/    ->   https://www.vcluster.com/docs/v0.19/storage/
- [x] /docs/licenses/vcluster/

