### PR TITLE
DOC-42 Add version to Helm chart

### DIFF
--- a/docs/_fragments/deploy-changes-beta.mdx
+++ b/docs/_fragments/deploy-changes-beta.mdx
@@ -1,0 +1,140 @@
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+<Tabs
+  groupId="get-started"
+  defaultValue="cli"
+  values={[
+	{ label: "vCluster CLI", value: "cli" },
+    { label: 'Helm', value: 'helm', },
+    { label: 'kubectl', value: 'kubectl', },
+    { label: 'Terraform', value: 'terraform', },
+    { label: 'Argo CD', value: 'argo', },
+    { label: 'Cluster API', value: 'cluster-api', },
+  ]
+}>
+<TabItem value="cli">
+
+```bash
+vcluster create --upgrade VCLUSTER_NAME -n VCLUSTER_NAMESPACE -f vcluster.yaml
+```
+
+Replace:
+
+- _`VCLUSTER_NAME`_ with your vCluster instance name.
+- _`VCLUSTER_NAMESPACE`_ with the namespace where you deployed vCluster.
+
+</TabItem>
+<TabItem value="helm">
+
+Since the v0.20 release is a beta, you need to specify the version or Helm uses the latest GA version.
+
+```bash
+helm upgrade --install VCLUSTER_NAME vcluster \
+  --values vcluster.yaml \
+  --repo https://charts.loft.sh \
+  --namespace VCLUSTER_NAMESPACE \
+  --repository-config='' \
+  --version 0.20.0-beta.1
+```
+
+Replace:
+
+- _`VCLUSTER_NAME`_ with your vCluster instance name.
+- _`VCLUSTER_NAMESPACE`_ with the namespace where you deployed vCluster.
+
+</TabItem>
+<TabItem value="kubectl">
+
+Since the v0.20 release is a beta, you need to specify the version or Helm uses the latest GA version.
+
+```bash
+helm template VCLUSTER_NAME vcluster --repo https://charts.loft.sh --version 0.20.0-beta.1 -n VCLUSTER_NAMESPACE -f vcluster.yaml | kubectl apply -f -
+```
+
+Replace:
+
+- _`VCLUSTER_NAME`_ with your vCluster instance name.
+- _`VCLUSTER_NAMESPACE`_ with the namespace where you deployed vCluster.
+
+</TabItem>
+<TabItem value="terraform">
+
+Apply vCluster config changes by editing the `vcluster.yaml` file and running `terraform plan`:
+
+```bash
+terraform plan
+```
+
+Review the planned changes and apply them if they look appropriate:
+
+```bash
+terraform apply
+```
+
+</TabItem>
+<TabItem value="argo">
+
+Add your `vcluster.yaml` config file to the `valueFiles` array in your ArgoCD `Application` file.
+
+ Since the v0.20 release is a beta, you need to specify the `targetRevision` or Helm uses the latest GA version.
+
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: VCLUSTER_NAME
+  namespace: argocd
+spec:
+  project: default
+  source:
+    chart: vcluster
+    repoURL: https://charts.loft.sh
+    targetRevision: 0.20.0-beta.1
+    helm:
+      releaseName: VCLUSTER_NAME
+      valueFiles:
+        - vcluster.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: VCLUSTER_NAMESPACE
+```
+
+Replace:
+
+- _`VCLUSTER_NAME`_ with your vCluster instance name.
+- _`VCLUSTER_NAMESPACE`_ with the namespace where you deployed vCluster.
+
+</TabItem>
+<TabItem value="cluster-api">
+
+Apply Cluster API changes by regenerating the cluster custom resource using `clusterctl`.
+
+Since the v0.20 release is a beta, you need to export the chart version, or Helm uses the latest GA version.
+
+```bash
+export CLUSTER_NAME=VCLUSTER_NAME
+export CLUSTER_NAMESPACE=VCLUSTER_NAMESPACE
+export KUBERNETES_VERSION=1.29.3
+export HELM_VALUES=$(cat vcluster.yaml)
+export CHART_VERSION=0.20.0-beta.1
+
+clusterctl generate cluster ${CLUSTER_NAME} \
+    --infrastructure vcluster \
+    --kubernetes-version ${KUBERNETES_VERSION} \
+    --target-namespace ${CLUSTER_NAMESPACE} | kubectl apply -f -
+```
+
+Replace:
+
+- _`VCLUSTER_NAME`_ with your vCluster instance name.
+- _`VCLUSTER_NAMESPACE`_ with the namespace where you deployed vCluster.
+
+After the changes have been applied, wait for the vCluster custom resource to report a ready status:
+
+```bash
+kubectl wait --for=condition=ready vcluster -n $CLUSTER_NAMESPACE $CLUSTER_NAME --timeout=300s
+```
+
+</TabItem>
+</Tabs>

--- a/docs/_fragments/quickstart/deploy-beta.mdx
+++ b/docs/_fragments/quickstart/deploy-beta.mdx
@@ -1,0 +1,317 @@
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import CodeBlock from '@theme/CodeBlock';
+import TerraformDeployCustomBeta from '!!raw-loader!@site/docs/_fragments/quickstart/terraform-deploy-custom-beta.tf'
+import TerraformDeployDefaultBeta from '!!raw-loader!@site/docs/_fragments/quickstart/terraform-deploy-default-beta.tf'
+
+<Tabs
+  groupId="get-started"
+  defaultValue="cli"
+  values={[
+	{ label: "vCluster CLI", value: "cli" },
+    { label: 'Helm', value: 'helm', },
+    { label: 'kubectl', value: 'kubectl', },
+    { label: 'Terraform', value: 'terraform', },
+    { label: 'Argo CD', value: 'argo', },
+    { label: 'Cluster API', value: 'cluster-api', },
+  ]
+}>
+<TabItem value="cli">
+
+1. Create the "team-x" namespace.
+
+   ```bash
+   kubectl create namespace team-x
+   ```
+
+1. Deploy vCluster.
+   
+   <Tabs
+   groupId="cli-deploy"
+   defaultValue="default"
+   values={[
+      { label: "Default config", value: "default" },
+      { label: 'Custom config', value: 'custom', },
+   ]
+   }>    
+   <TabItem value="default">
+
+   ```bash
+   vcluster create my-vcluster --namespace team-x
+   ```
+
+   </TabItem>
+   <TabItem value="custom">
+   Include your `vcluster-yaml` config file.
+   
+   ```bash
+   vcluster create my-vcluster --namespace team-x --values vcluster.yaml
+   ```
+
+   </TabItem>
+   </Tabs>
+
+   When the installation finishes, you are automatically connected to the virtual cluster and can run kubectl commands within the virtual cluster.
+
+</TabItem>
+<TabItem value="helm">
+
+1. Create the "team-x" namespace.
+
+   ```bash
+   kubectl create namespace team-x
+   ```
+
+1. Deploy vCluster.
+
+   Since the v0.20 release is a beta, you need to specify the version or Helm uses the latest GA version.
+   
+   <Tabs
+   groupId="helm-deploy"
+   defaultValue="default"
+   values={[
+      { label: "Default config", value: "default" },
+      { label: 'Custom config', value: 'custom', },
+   ]
+   }>    
+   <TabItem value="default">
+
+   ```bash
+   helm upgrade --install my-vcluster vcluster \
+   --repo https://charts.loft.sh \
+   --namespace team-x \
+   --repository-config='' \
+   --version 0.20.0-beta.1
+   ```
+
+   </TabItem>
+   <TabItem value="custom">
+   Include your `vcluster-yaml` config file.
+   
+   ```bash
+   helm upgrade --install my-vcluster vcluster \
+   --values vcluster.yaml \
+   --repo https://charts.loft.sh \
+   --namespace team-x \
+   --repository-config='' \
+   --version 0.20.0-beta.1
+   ```
+
+   </TabItem>
+   </Tabs>
+
+</TabItem>
+
+<TabItem value="kubectl">
+
+This uses Helm to generate the Kubernetes deployment files before applying with `kubectl`. Since the v0.20 release is a beta, you need to specify the version or Helm uses the latest GA version.
+
+1. Create the "team-x" namespace.
+
+   ```bash
+   kubectl create namespace team-x
+   ```
+
+1. Deploy vCluster.
+
+   <Tabs
+   groupId="kubetcl-deploy"
+   defaultValue="default"
+   values={[
+   { label: "Default config", value: "default" },
+   { label: 'Custom config', value: 'custom', },
+   ]
+   } >    
+   <TabItem value="default">
+
+   ```bash
+   helm template my-vcluster vcluster --repo https://charts.loft.sh --version 0.20.0-beta.1 -n team-x | kubectl apply -f -
+   ```
+   </TabItem>
+   <TabItem value="custom">
+   Include your `vcluster-yaml` config file.
+
+   ```bash
+   helm template my-vcluster vcluster --repo https://charts.loft.sh --version 0.20.0-beta.1 -n team-x -f vcluster.yaml | kubectl apply -f -
+   ```
+   </TabItem>
+   </Tabs>   
+
+</TabItem>
+<TabItem value="terraform">
+
+1. Create a `main.tf` file.
+
+   Since the v0.20 release is a beta, you need to specify the version or Helm uses the latest GA version.
+
+   <Tabs
+    groupId="terraform-config"
+    defaultValue="default"
+    values={[
+	   { label: "Default config", value: "default" },
+      { label: 'Custom config', value: 'custom', },
+     ]
+    } >    
+    <TabItem value="default">
+     <CodeBlock language="hcl">{TerraformDeployDefaultBeta}</CodeBlock>
+    </TabItem>
+    <TabItem value="custom">
+    Include your `vcluster-yaml` config file.
+    <CodeBlock language="hcl">{TerraformDeployCustomBeta}</CodeBlock>
+    </TabItem>
+    </Tabs>   
+
+1. Install the required [Helm provider](https://registry.terraform.io/providers/hashicorp/helm/latest).
+
+   ```bash
+   terraform init
+   ```
+
+1. Generate a plan. 
+    
+    ```bash
+    terraform plan
+    ```
+
+   Verify that the provider can access your cluster and that the proposed changes are correct.
+
+1. Deploy vCluster.
+
+   ```bash
+   terraform apply
+   ```
+
+</TabItem>
+<TabItem value="argo">
+
+To deploy vCluster using ArgoCD, you need the following files:
+
+- `vcluster.yaml` for your vCluster configuration. This is optional if you are deploying with default configuration.
+- `my-vcluster.yaml` for your ArgoCD `Application` definition.
+
+
+1. Create the ArgoCD `Application` file `my-vcluster.yaml`. 
+
+   Deployment uses the vCluster Helm chart. Since the v0.20 release is a beta, you need to specify the `targetRevision` or Helm uses the latest GA version.
+
+   <Tabs
+    groupId="argo-config"
+    defaultValue="default"
+    values={[
+	   { label: "Default config", value: "default" },
+      { label: 'Custom config', value: 'custom', },
+     ]
+    } >    
+    <TabItem value="default">
+     ```yaml
+     apiVersion: argoproj.io/v1alpha1
+     kind: Application
+     metadata:
+       name: my-vcluster
+       namespace: argocd
+     spec:
+       project: default
+       source:
+         chart: vcluster
+         repoURL: https://charts.loft.sh
+         targetRevision: 0.20.0-beta.1
+         helm:
+           releaseName: my-vcluster
+       destination:
+         server: https://kubernetes.default.svc
+         namespace: team-x
+    ```
+    </TabItem>
+    <TabItem value="custom">
+    Use your `vcluster.yaml` file to pass the chart values.
+
+    ```yaml
+    apiVersion: argoproj.io/v1alpha1
+    kind: Application
+    metadata:
+      name: my-vcluster
+      namespace: argocd
+    spec:
+      project: default
+      source:
+        chart: vcluster
+        repoURL: https://charts.loft.sh
+        targetRevision: 0.20.0-beta.1
+        helm:
+          releaseName: my-vcluster
+          valueFiles:
+            - vcluster.yaml
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: team-x
+    ```
+    </TabItem>
+    </Tabs>   
+
+1. Commit and push these files to your configured ArgoCD repository and synchronize it with your configured cluster.
+
+</TabItem>
+<TabItem value="cluster-api">
+
+1. [Install](https://cluster-api.sigs.k8s.io/user/quick-start.html#install-clusterctl) the `clusterctl` CLI.
+1. Install the vCluster provider.
+
+   ```bash
+   clusterctl init --infrastructure vcluster
+   ```
+
+1. Generate the required manifests and apply using `clusterctl generate cluster` and `kubectl`.
+
+   Deployment uses the vCluster Helm chart. Since the v0.20 release is a beta, you need to export the chart version, or Helm uses the latest GA version.
+
+   <Tabs
+    groupId="clusterapi-config"
+    defaultValue="default"
+    values={[
+	   { label: "Default config", value: "default" },
+      { label: 'Custom config', value: 'custom', },
+     ]
+    } >    
+    <TabItem value="default">
+     ```bash
+   export CLUSTER_NAME=my-vcluster
+   export CLUSTER_NAMESPACE=team-x
+   export KUBERNETES_VERSION=1.29.3
+   export CHART_VERSION=0.20.0-beta.1
+
+   kubectl create namespace ${CLUSTER_NAMESPACE}
+
+   clusterctl generate cluster ${CLUSTER_NAME} \
+    --infrastructure vcluster \
+    --kubernetes-version ${KUBERNETES_VERSION} \
+    --target-namespace ${CLUSTER_NAMESPACE} | kubectl apply -f -
+   ```
+    </TabItem>
+    <TabItem value="custom">
+    Include your `vcluster-yaml` config file.
+    ```bash
+    export CLUSTER_NAME=my-vcluster
+    export CLUSTER_NAMESPACE=team-x
+    export KUBERNETES_VERSION=1.29.3
+    export HELM_VALUES=$(cat vcluster.yaml)
+    export CHART_VERSION=0.20.0-beta.1
+
+    kubectl create namespace ${CLUSTER_NAMESPACE}
+
+    clusterctl generate cluster ${CLUSTER_NAME} \
+      --infrastructure vcluster \
+      --kubernetes-version ${KUBERNETES_VERSION} \
+      --target-namespace ${CLUSTER_NAMESPACE} | kubectl apply -f -
+    ```
+    </TabItem>
+    </Tabs> 
+
+1. Execute the following command to wait for the vCluster custom resource to report a ready status.
+
+   ```bash
+   kubectl wait --for=condition=ready vcluster -n $CLUSTER_NAMESPACE $CLUSTER_NAME --timeout=300s
+   ```
+
+Learn more about [Cluster API Provider for vCluster](https://github.com/loft-sh/cluster-api-provider-vcluster)
+</TabItem>
+</Tabs>

--- a/docs/_fragments/quickstart/terraform-deploy-custom-beta.tf
+++ b/docs/_fragments/quickstart/terraform-deploy-custom-beta.tf
@@ -1,0 +1,19 @@
+provider "helm" {
+  kubernetes {
+    config_path = "~/.kube/config"
+  }
+}
+
+resource "helm_release" "my_vcluster" {
+  name             = "my-vcluster"
+  namespace        = "team-x"
+  create_namespace = true
+
+  repository       = "https://charts.loft.sh"
+  chart            = "vcluster"
+  version          = "0.20.0-beta.1"
+
+  values = [
+    file("${path.module}/vcluster.yaml")
+  ]
+}

--- a/docs/_fragments/quickstart/terraform-deploy-default-beta.tf
+++ b/docs/_fragments/quickstart/terraform-deploy-default-beta.tf
@@ -1,0 +1,15 @@
+provider "helm" {
+  kubernetes {
+    config_path = "~/.kube/config"
+  }
+}
+
+resource "helm_release" "my_vcluster" {
+  name             = "my-vcluster"
+  namespace        = "team-x"
+  create_namespace = true
+
+  repository       = "https://charts.loft.sh"
+  chart            = "vcluster"
+  version          = "0.20.0-beta.1"
+}

--- a/docs/get-started.mdx
+++ b/docs/get-started.mdx
@@ -8,10 +8,10 @@ import TabItem from '@theme/TabItem'
 import CodeBlock from '@theme/CodeBlock';
 
 import InstallBetaCLIFragment from '@site/docs/_fragments/quickstart/install-beta-cli.mdx'
-import DeployVirtualCluster from '@site/docs/_fragments/quickstart/deploy.mdx'
+import DeployBeta from '@site/docs/_fragments/quickstart/deploy-beta.mdx'
 import Cleanup from '@site/docs/_fragments/quickstart/cleanup.mdx'
 import Connect from '@site/docs/_fragments/quickstart/connect.mdx'
-import DeployChanges from '@site/docs/_fragments/deploy-changes.mdx'
+import DeployChangesBeta from '@site/docs/_fragments/deploy-changes-beta.mdx'
 
 
 ## Key concepts
@@ -53,7 +53,7 @@ Deploy a vCluster instance called `my-vcluster` to namespace `team-x`. The insta
 
 1. Deploy vCluster
 
-   <DeployVirtualCluster/>
+   <DeployBeta/>
 
 ## Use your virtual cluster
 
@@ -157,7 +157,7 @@ There are multiple ways of granting access to the vCluster control plane for ext
 
 1. Apply your changes.
    
-   <DeployChanges/>
+   <DeployChangesBeta/>
 
 ### Show real nodes
 
@@ -176,7 +176,7 @@ Pseudo nodes only have real values for the CPU, architecture, and operating syst
 
 1. Apply your changes.
 
-      <DeployChanges/>
+      <DeployChangesBeta/>
 
 ### Sync ingress from host to virtual
 
@@ -192,7 +192,7 @@ If you want to use an ingress controller from the host cluster inside your virtu
     ```
 
 2. Apply your changes.
-      <DeployChanges/>
+      <DeployChangesBeta/>
 
 ### Sync ingress from virtual to host
 
@@ -208,7 +208,7 @@ Create an ingress in a virtual cluster to make a service in that virtual cluster
     ```
 
 2. Apply your changes.
-      <DeployChanges/>
+      <DeployChangesBeta/>
 
 ### Sync services from host to virtual cluster
 
@@ -225,7 +225,7 @@ In this example, you map a service `my-host-service` in the namespace `my-host-n
 
 1. Apply your changes.
    
-   <DeployChanges/>
+   <DeployChangesBeta/>
 
 
 ## Delete vCluster


### PR DESCRIPTION
Fixes DOC-42

Helm pulls the latest GA version, so add version to deploy examples.
