### PR TITLE
Change base64 decode flag to lowercase

### DIFF
--- a/docs/_fragments/quickstart/secret-kubeconfig.mdx
+++ b/docs/_fragments/quickstart/secret-kubeconfig.mdx
@@ -3,8 +3,8 @@ The secret is prefixed with `vc-` and ends with the vCluster name, so a vCluster
 
 Switch to your host cluster's context before running this command:
 
-```bash 
-kubectl get secret vc-my-vcluster -n team-x --template={{.data.config}} | base64 -D
+```bash
+kubectl get secret vc-my-vcluster -n team-x --template={{.data.config}} | base64 -d
 ```
 
 The secret holds a kubeconfig in this format:


### PR DESCRIPTION
Linux only accepts -d while Mac accepts both -D and -d.

Resolves https://github.com/loft-sh/vcluster-docs/issues/94