### PR TITLE
DOC-58: Add MySQL example to external database config page

### DIFF
--- a/docs/vcluster/vcluster-yaml/control-plane/components/backing-store/database/external.mdx
+++ b/docs/vcluster/vcluster-yaml/control-plane/components/backing-store/database/external.mdx
@@ -18,7 +18,9 @@ controlPlane:
         dataSource: CONNECTION_STRING
 ```
 
-Replace _`CONNECTION_STRING`_ with the connection string for your database, such as `postgres://username:password@hostname:5432/vcluster-db`.
+Replace _`CONNECTION_STRING`_ with the connection string for your database. Examples:
+- PostgreSQL: `postgres://username:password@hostname:5432/vcluster-db`.
+- MySQL: `mysql://root:password@tcp(192.168.86.9:30360)/vcluster`.
 
 ## Vanilla Kubernetes and EKS distros
 


### PR DESCRIPTION
Fixes DOC-58

![image](https://github.com/loft-sh/vcluster-docs/assets/26799583/9df50901-7bec-4208-a2d4-8fffb74eb3af)
