### PR TITLE
DOC-57 Add mermaid config and fix diagrams in platform section

### DIFF
--- a/docs/platform/get-started/explore.mdx
+++ b/docs/platform/get-started/explore.mdx
@@ -107,16 +107,16 @@ All requests that are made through vCluster Platform count as activity in the na
 
 ```mermaid
 flowchart LR;
-  kubectl("<code>kubectl get pod my-pod</code>") --> Loft
+  kubectl("<code>kubectl get pod my-pod</code>") --> Platform
 
-  Loft("<img src='/pro/docs/media/vclusterpro_white.svg' width='160' height='80' />")
+  Platform("vCluster Platform")
 
-  Loft --> Cluster("Connected Cluster <br/> Kubernetes API Server")
+  Platform --> Cluster("Connected Cluster <br/> Kubernetes API Server")
   Cluster --> Pod("<pre>apiVersion: v1\nkind: Pod\nmetadata:\n  name: my-pod\n...</pre>")
 
   class kubectl code
   class Pod yaml
-  class Loft loft
+  class Platform platform
 ```
 
 If your kube-context points to vCluster Platform's API server as a proxy before the actual connected

--- a/docs/platform/virtual-clusters/_partials/sleep/activity-detection.mdx
+++ b/docs/platform/virtual-clusters/_partials/sleep/activity-detection.mdx
@@ -4,18 +4,19 @@
 </span>
 .
 
+
 ```mermaid
 flowchart LR;
-  kubectl("<code>kubectl get pod my-pod</code>") --> vCluster Platform
+  kubectl("<code>kubectl get pod my-pod</code>") --> Platform
 
-  vCluster Platform("<img src='/pro/docs/media/vclusterpro_white.svg' width='160' height='80' />")
+  Platform("vCluster Platform")
 
-  vCluster Platform --> Cluster("Connected Cluster <br/> Kubernetes API Server")
+  Platform --> Cluster("Connected Cluster <br/> Kubernetes API Server")
   Cluster --> Pod("<pre>apiVersion: v1\nkind: Pod\nmetadata:\n  name: my-pod\n...</pre>")
 
   class kubectl code
   class Pod yaml
-  class vCluster Platform loft
+  class Platform platform
 ```
 
 If your kube-context points to vCluster Platform's API server as a proxy before the actual connected cluster's API server, every `kubectl` request will be an activity and reset the inactivity timeout.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,8 +1,17 @@
-__webpack_public_path__ = "/docs/";
+// @ts-check
+// `@type` JSDoc annotations allow editor autocompletion and type checking
+// (when paired with `@ts-check`).
+// There are various equivalent ways to declare your Docusaurus config.
+// See: https://docusaurus.io/docs/api/docusaurus-config
+
+import {themes as prismThemes} from 'prism-react-renderer';
+
+const __webpack_public_path__ = "/docs/";
 
 const resolveGlob = require("resolve-glob");
 
-module.exports = {
+/** @type {import('@docusaurus/types').Config} */
+const config = {
   title: "vcluster docs | Virtual Clusters for Kubernetes",
   tagline: "Virtual Clusters for Kubernetes",
   url: "https://vcluster.com",
@@ -10,95 +19,28 @@ module.exports = {
   favicon: "/media/vcluster_symbol.svg",
   organizationName: "loft-sh", // Usually your GitHub org/user name.
   projectName: "vcluster-docs", // Usually your repo name.
+
+  onBrokenLinks: 'throw',
+  onBrokenMarkdownLinks: 'warn',
+
+  // Even if you don't use internationalization, you can use this field to set
+  // useful metadata like html lang. For example, if your site is Chinese, you
+  // may want to replace "en" with "zh-Hans".
   i18n: {
-    defaultLocale: "en",
-    locales: ["en"],
+    defaultLocale: 'en',
+    locales: ['en'],
   },
-  themeConfig: {
-    announcementBar: {
-        id: 'beta',
-        isCloseable: false,
-        content: 'vCluster v0.20 is in beta. Do not use in production. Questions? Join our <a href="https://slack.loft.sh" target="_blank">Slack community</a>.',
-        backgroundColor: '#f2f2f2',
-        textColor: '#17202A',
-    },
-    tableOfContents: {
-      // default is ##, ### so add ####
-      minHeadingLevel: 2,
-      maxHeadingLevel: 4,
-    },
-    colorMode: {
-      defaultMode: "light",
-      disableSwitch: true,
-      respectPrefersColorScheme: false,
-    },
-    navbar: {
-      logo: {
-        alt: "vcluster",
-        src: "/media/vCluster_horizontal-orange.svg",
-        href: "https://vcluster.com/",
-        target: "_self",
-      },
-      items: [
-        {
-          type: "docsVersionDropdown",
-          position: "left",
-          dropdownItemsAfter: [
-            { to: "https://vcluster.com/docs/v0.19", label: "v0.19 Stable" },
-          ],
-          dropdownActiveClassDisabled: true,
-        },
-        {
-          href: "https://vcluster.com/",
-          label: "Website",
-          position: "left",
-          target: "_self",
-        },
-        {
-          label: "Docs",
-          position: "left",
-          to: "/",
-        },
-        {
-          href: "https://loft.sh/blog",
-          label: "Blog",
-          position: "left",
-          target: "_self",
-        },
-        {
-          href: "https://slack.loft.sh/",
-          className: "slack-link",
-          "aria-label": "Slack",
-          position: "right",
-        },
-        {
-          href: "https://github.com/loft-sh/vcluster-docs",
-          className: "github-link",
-          "aria-label": "GitHub",
-          position: "right",
-        },
-      ],
-    },
-    algolia: {
-      appId: "K85RIQNFGF",
-      apiKey: "42375731adc726ebb99849e9051aa9b4",
-      indexName: "vcluster",
-      placeholder: "Search...",
-      algoliaOptions: {},
-    },
-    footer: {
-      style: "light",
-      links: [],
-      copyright: `Copyright © ${new Date().getFullYear()} <a href="https://loft.sh/">Loft Labs, Inc.</a>`,
-    },
-    prism: {
-      additionalLanguages: ["bash", "hcl"],
-    },
+
+  themes: ["@saucelabs/theme-github-codeblock", "@docusaurus/theme-mermaid"],
+  markdown: {
+    mermaid: true,
   },
+
   presets: [
     [
-      "@docusaurus/preset-classic",
-      {
+      'classic',
+      /** @type {import('@docusaurus/preset-classic').Options} */
+      ({
         docs: {
           path: "docs",
           routeBasePath: "/",
@@ -113,10 +55,11 @@ module.exports = {
             },
           },
         },
+        
         theme: {
           customCss: resolveGlob.sync(["./src/css/**/*.scss"]),
         },
-      },
+      }),
     ],
     [
       "redocusaurus",
@@ -142,7 +85,6 @@ module.exports = {
       },
     ],
   ],
-  themes: ["@saucelabs/theme-github-codeblock"],
   plugins: ["docusaurus-plugin-sass", "plugin-image-zoom"],
   scripts: [
     {
@@ -155,4 +97,96 @@ module.exports = {
     },
   ],
   clientModules: resolveGlob.sync(["./src/js/**/*.js"]),
+
+  themeConfig: (
+    /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
+    
+      {
+      mermaid: {
+        theme: {light: 'default', dark: 'dark'},        
+      },
+      announcementBar: {
+        id: 'beta',
+        isCloseable: false,
+        content: 'vCluster v0.20 is in beta. Do not use in production. Questions? Join our <a href="https://slack.loft.sh" target="_blank">Slack community</a>.',
+        backgroundColor: '#f2f2f2',
+        textColor: '#17202A',
+      },
+      tableOfContents: {
+        // default is ##, ### so add ####
+        minHeadingLevel: 2,
+        maxHeadingLevel: 4,
+      },
+      colorMode: {
+        defaultMode: "light",
+        disableSwitch: true,
+        respectPrefersColorScheme: false,
+      },
+      navbar: {
+        logo: {
+          alt: "vcluster",
+          src: "/media/vCluster_horizontal-orange.svg",
+          href: "https://vcluster.com/",
+          target: "_self",
+        },
+        items: [
+          {
+            type: "docsVersionDropdown",
+            position: "left",
+            dropdownItemsAfter: [
+              { to: "https://vcluster.com/docs/v0.19", label: "v0.19 Stable" },
+            ],
+            dropdownActiveClassDisabled: true,
+          },
+          {
+            href: "https://vcluster.com/",
+            label: "Website",
+            position: "left",
+            target: "_self",
+          },
+          {
+            label: "Docs",
+            position: "left",
+            to: "/",
+          },
+          {
+            href: "https://loft.sh/blog",
+            label: "Blog",
+            position: "left",
+            target: "_self",
+          },
+          {
+            href: "https://slack.loft.sh/",
+            className: "slack-link",
+            "aria-label": "Slack",
+            position: "right",
+          },
+          {
+            href: "https://github.com/loft-sh/vcluster-docs",
+            className: "github-link",
+            "aria-label": "GitHub",
+            position: "right",
+          },          
+        ],
+      },
+      algolia: {
+        appId: "K85RIQNFGF",
+        apiKey: "42375731adc726ebb99849e9051aa9b4",
+        indexName: "vcluster",
+        placeholder: "Search...",
+        algoliaOptions: {},
+      },
+      footer: {
+        style: "light",
+        links: [],
+        copyright: `Copyright © ${new Date().getFullYear()} <a href="https://loft.sh/">Loft Labs, Inc.</a>`,
+      },
+      prism: {
+        additionalLanguages: ["bash", "hcl"],
+      },
+    }),
 };
+
+export default config;
+
+


### PR DESCRIPTION
Fixes DOC-57

- Add mermaid config so diagrams in platform section render.
- Update docusaurus.config.js to match v3.x format.
- Fix broken images that I found when looking at the mermaid diagrams


https://deploy-preview-108--vcluster-docs-site.netlify.app/docs/

Diagram previews:
https://deploy-preview-108--vcluster-docs-site.netlify.app/docs/platform/get-started/explore#inactivity-detection
https://deploy-preview-108--vcluster-docs-site.netlify.app/docs/platform/virtual-clusters/sleep-mode#inactivity-detection