### PR TITLE
Style changes and fixes (DOC-93)

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -19,12 +19,14 @@ const sidebars = {
     {
       "type": "link",
       "label": "vCluster",
-      "href": "/docs/vcluster"
+      "href": "/docs/vcluster",
+      "className": "product-link"
     },
     {
       "type": "link",
       "label": "vCluster Platform",
-      "href": "/docs/platform"
+      "href": "/docs/platform",
+      "className": "product-link"
     }
   ],
 

--- a/src/css/content/markdown.scss
+++ b/src/css/content/markdown.scss
@@ -35,14 +35,14 @@ body .markdown {
 }
 
 .markdown > *:not(header) + h2 {
-  line-height: 1em;
+  line-height: 1.2em;
   border-top: 1px solid #f1f1f1;
   padding-top: 1.8em;
 }
 
 .markdown h3 {
   margin-top: 2.8em;
-  line-height: 0.6em;
+  line-height: 1.2em;
 }
 
 .markdown .step_src-components-Step- {

--- a/src/css/sidebar.scss
+++ b/src/css/sidebar.scss
@@ -313,9 +313,9 @@ body .menu {
 }
 
 button.menu__caret {
-  transform: scale(0.7) rotate(0deg);
-  right: -8px;
-  top: calc(50% - 10px);
+  transform: scale(0.7) rotate(180deg);
+  right: -4px;
+  top: calc(50% - 18px);
 }
 
 .menu__list-item--collapsed .menu__link--sublist:after, .menu__list-item--collapsed .menu__caret:before {

--- a/src/css/sidebar.scss
+++ b/src/css/sidebar.scss
@@ -30,22 +30,22 @@
 
   /* Default-Expanded Logical Groupings in the Nav (e.g. "CORE" under sync.toHost) */
   &.logical-grouping {
+    > .menu__list-item-collapsible .menu__link--active {
+        color: var(--ifm-color-gray-800) !important;
+    }
     > .menu__list-item-collapsible {
       .menu__link {
         font-family: var(--ifm-font-family-base);
-        color: var(--ifm-color-primary-contrast-foreground);
+        color: var(--ifm-color-gray-800) !important;
         text-transform: uppercase;
-        font-weight: 600 !important;
+        letter-spacing: 0.15rem;
+        font-weight: 700 !important;
         font-size: 0.7em !important;
-
-        &::after {
-          content: ":"
-        }
       }
     }
 
     .menu__list .menu__link {
-      text-indent: -0.8rem;
+      text-indent: -1.0rem;
     }
   }
 }
@@ -55,7 +55,6 @@ body .menu {
   margin: 0;
   padding: 0;
   scrollbar-gutter: stable;
-  border-right: 1px solid #fff;
   position: relative;
 
   /* Add border on the right-hand side */
@@ -110,6 +109,7 @@ body .menu {
 
     /* 1st level links */
     .menu__link {
+      font-size: 0.9rem;
       display: block;
       width: 100%;
       padding: 0.8rem 1.8rem;
@@ -157,17 +157,19 @@ body .menu {
     }
 
     .menu__list {
+
       /* 2nd level links */
       .menu__link {
-        padding: 0.5rem 0 0.5rem 2.4rem;
+        padding: 0.5rem 0 0.5rem 2.5rem;
         font-weight: 400;
         transition: 0.3s;
       }
 
       .menu__list {
+
         /* 3rd level links */
         .menu__link {
-          padding-left: 3.8rem;
+          padding-left: 3.5rem;
           font-size: 0.9em;
 
           &:not(:hover) {
@@ -186,10 +188,10 @@ body .menu {
         }
 
         .menu__list {
+
           /* 4th level links */
           .menu__link {
-            padding-left: 6rem;
-            font-size: 0.85em;
+            padding-left: 4.5rem;
 
             &:not(.menu__link--active):not(:hover) {
               color: #3c3c3c;
@@ -197,10 +199,10 @@ body .menu {
           }
 
           .menu__list {
+
             /* 5th level links */
             .menu__link {
-              padding-left: 7.5rem;
-              font-size: 0.8em;
+              padding-left: 5.5rem;
 
               &:not(.menu__link--active):not(:hover) {
                 color: #696969;
@@ -208,13 +210,25 @@ body .menu {
             }
 
             .menu__list {
-              /* 5th level links */
+
+              /* 6th level links */
               .menu__link {
-                padding-left: 8.7rem;
-                font-size: 0.8em;
+                padding-left: 6.5rem;
 
                 &:not(.menu__link--active):not(:hover) {
                   color: #696969;
+                }
+              }
+
+              .menu__list {
+
+                /* 7th level links */
+                .menu__link {
+                  padding-left: 7.5rem;
+
+                  &:not(.menu__link--active):not(:hover) {
+                    color: #696969;
+                  }
                 }
               }
             }
@@ -222,17 +236,6 @@ body .menu {
         }
       }
     }
-  }
-}
-
-/* 1st level categories: add a grey background when expanded (= not collapsed) OR active */
-.theme-doc-sidebar-item-category-level-1.menu__list-item:not(.menu__list-item--collapsed),
-.theme-doc-sidebar-item-category-level-1.menu__list-item.menu__list-item--active,
-.theme-doc-sidebar-item-category-level-2.menu__list-item:not(.menu__list-item--collapsed),
-.theme-doc-sidebar-item-category-level-2.menu__list-item.menu__list-item--active {
-  &,
-  + .menu__list {
-    background-color: rgb(195 207 211 / 14%);
   }
 }
 
@@ -310,8 +313,13 @@ body .menu {
 }
 
 button.menu__caret {
-  transform: scale(0.7);
+  transform: scale(0.7) rotate(0deg);
   right: -8px;
+  top: calc(50% - 10px);
+}
+
+.menu__list-item--collapsed .menu__link--sublist:after, .menu__list-item--collapsed .menu__caret:before {
+  transform: rotateZ(0deg);
 }
 
 .menu__list-item {
@@ -321,7 +329,7 @@ button.menu__caret {
     ::after {
       position: absolute;
       content: " ";
-      transform: scale(0.7) rotate(180deg);
+      transform: scale(0.7) rotate(0deg);
       right: 10px;
     }
   }
@@ -329,8 +337,22 @@ button.menu__caret {
   &.menu__list-item--collapsed {
     > .menu__list-item-collapsible {
       ::after {
-        transform: scale(0.7) rotate(90deg);
+        transform: scale(0.7) rotate(180deg);
       }
     }
   }
+}
+
+// Add arrows to product links
+.product-link .menu__link::after {
+  content: ' ';
+  margin-left: auto;
+  min-width: 1.25rem;
+  background: var(--ifm-menu-link-sublist-icon) 50% / 2rem 2rem;
+  filter: var(--ifm-menu-link-sublist-icon-filter);
+  height: 1.25rem;
+  transform: rotate(90deg) scale(0.7);
+  width: 1.25rem;
+  position: absolute;
+  right: 10px;
 }

--- a/src/theme/DocSidebar/Desktop/Content/styles.module.css
+++ b/src/theme/DocSidebar/Desktop/Content/styles.module.css
@@ -1,19 +1,6 @@
 .version-selector-wrapper {
-  border-right: 1px solid white;
-  padding-right: 11px;
   position: relative;
-}
-
-.version-selector-wrapper::before {
-  position: absolute;
-  right: 11px;
-  bottom: 0;
-  top: 0;
-
-  width: 1px;
-  content: " ";
-  display: block;
-  background-color: rgb(218, 221, 225);
+  border-bottom: 1px solid var(--ifm-toc-border-color);
 }
 
 .version-selector {


### PR DESCRIPTION
- Add right-pointing chevrons to top level product selections
- Change all other chevrons to down/up instead of right/down
- Unify font sizes for different menu items (some where larger?)
- Fix the width gap between the version/product selectors and the rest of the menu
- Add border underneath version/product selectors (to compensate for the lack of background)
- Fix vcluster.yaml logical grouping title styles (more distinct from the other items)
- Fix markdown h<n> line heights

(Corresponds to DOC-93)