### PR TITLE
Updated isolated workloads formatting and info for local deployment

### DIFF
--- a/vcluster/deploy/topologies/isolated-workloads.mdx
+++ b/vcluster/deploy/topologies/isolated-workloads.mdx
@@ -6,16 +6,33 @@ sidebar_position: 2
 
 import Policies from '@site/vcluster/_partials/config/policies.mdx'
 
-vCluster offers several features to automatically isolate workloads in a virtual cluster:
+vCluster offers several features to automatically isolate workloads in a virtual
+cluster:
 
 ## Resource Quota & Pod Security Standard
 
-This feature imposes a couple of restrictions on vCluster workloads to make sure they do not break out of their virtual environment:
-1. vCluster enforces a [Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/) on syncer level, which means that for example pods that try to run as a privileged container or mount a host path will not be synced to the host cluster. Current valid options are either baseline (default in isolated mode) or restricted. This works for every Kubernetes version regardless of Pod Security Standard support, as this is implemented in vCluster directly. Rejected pods will stay pending in the vCluster and in newer Kubernetes version they will be denied by the admission controller as well.
-2. vCluster deploys a [resource quota](https://kubernetes.io/docs/concepts/policy/resource-quotas/) as well as a [limit range](https://kubernetes.io/docs/concepts/policy/limit-range/) alongside the vCluster itself. This allows restricting resource consumption of vCluster workloads. If enabled, sane defaults for those 2 resources are chosen.
-3. vCluster deploys a [network policy](https://kubernetes.io/docs/concepts/services-networking/network-policies/) alongside itself that will restrict access of vCluster workloads as well as the vCluster control plane to other pods in the host cluster. (only works if your host [cluster CNI supports network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/#prerequisites))
+This feature imposes a couple of restrictions on vCluster workloads to make sure
+they do not break out of their virtual environment:
 
-You can adjust isolation settings through helm values (vcluster.yaml). To configure workload isolation:
+1. vCluster enforces a [Pod Security Standard](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+on syncer level, which means that for example pods that try to run as a privileged
+container or mount a host path will not be synced to the host cluster. Current valid
+options are either baseline (default in isolated mode) or restricted. This works
+for every Kubernetes version regardless of Pod Security Standard support, as this
+is implemented in vCluster directly. Rejected pods will stay pending in the vCluster
+and in newer Kubernetes version they will be denied by the admission controller
+as well.
+2. vCluster deploys a [resource quota](https://kubernetes.io/docs/concepts/policy/resource-quotas/)
+as well as a [limit range](https://kubernetes.io/docs/concepts/policy/limit-range/)
+alongside the vCluster itself. This allows restricting resource consumption of
+vCluster workloads. If enabled, sane defaults for those 2 resources are chosen.
+3. vCluster deploys a [network policy](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+alongside itself that will restrict access of vCluster workloads as well as the
+vCluster control plane to other pods in the host cluster. (only works if your host
+[cluster CNI supports network policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/#prerequisites))
+
+Adjust your isolation settings through the vcluster.yaml of the vCluster:
+
 ```yaml
 policies:
   # empty, baseline, restricted can be used here
@@ -28,16 +45,31 @@ policies:
     enabled: true
 ```
 
-For all options and more information take a look at the [policies](/docs/vcluster/configure/vcluster-yaml/policies/) documentation.
+For all options and more information take a look at the
+[policies](/docs/vcluster/configure/vcluster-yaml/policies/) documentation.
+
+:::info
+When enabling resource quotas locally, make sure to add a `--expose-local=false`
+flag to your `vcluster create [...]` command, as by default the vCluster CLI
+will try to automatically expose the vCluster using NodePorts, when interacting
+with a local Kubernetes cluster.
+:::
 
 <Policies/>
 
 ## Network Isolation
 
-Workloads created by vCluster will be able to communicate with other workloads in the host cluster through their cluster ips. This can be sometimes beneficial if you want to purposely access a host cluster service, which is a good method to share services between vClusters. However, you often want to isolate namespaces and do not want the pods running inside vCluster to have access to other workloads in the host cluster.
-This requirement can be accomplished by using [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for the namespace where vCluster is installed in.
+Workloads created by vCluster will be able to communicate with other workloads in
+the host cluster through their cluster IPs. This can be sometimes beneficial if
+you want to purposely access a host cluster service, which is a good method to
+share services between virtual clusters. However, you often want to isolate namespaces
+and do not want the pods running inside vCluster to have access to other workloads
+in the host cluster. This requirement can be accomplished by using [Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+for the namespace where vCluster is installed in.
 
-vCluster can automatically deploy a network policy for you by enabling the following option:
+vCluster can automatically deploy a network policy for you by enabling the
+following option in your `vcluster.yaml`:
+
 ```yaml
 policies:
   networkPolicy:
@@ -45,31 +77,44 @@ policies:
 ```
 
 :::info
-Network policies do not work in all Kubernetes clusters and need to be supported by the underlying CNI plugin.
+Network policies do not work in all Kubernetes clusters and need to be supported
+by the underlying CNI plugin.
 :::
 
-For all options and more information take a look at the [policies](/docs/vcluster/configure/vcluster-yaml/policies/) documentation.
+For all options and more information take a look at the
+[policies](/docs/vcluster/configure/vcluster-yaml/policies/) documentation.
 
 <Policies/>
 
 ## Advanced Isolation
 
-Besides this basic workload isolation, you could also dive into more advanced isolation methods, such as isolating the workloads on separate nodes or through another container runtime.
+Besides this basic workload isolation, you could also dive into more advanced
+isolation methods, such as isolating the workloads on separate nodes or through
+another container runtime.
 
-You should also be aware that pods created in the vCluster will set their [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/), which will affect scheduling decisions. To prevent the pods from being scheduled to the undesirable nodes you can use the `sync.fromHost.nodes.selector.labels` option or admission controller as mentioned above.
+You should also be aware that pods created in the vCluster will set their
+[tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/),
+which will affect scheduling decisions. To prevent the pods from being scheduled
+to the undesirable nodes you can use the `sync.fromHost.nodes.selector.labels`
+option or admission controller as mentioned above.
 
 ### Workload & Network Isolation within the vCluster
 
-The above mentioned methods also work for isolating workloads inside the vCluster itself, as you can just deploy resource quotas, limit ranges, admission controllers and network policies in there. To allow network policies to function correctly, you'll need to enable this in vCluster itself though.
+The above mentioned methods also work for isolating workloads inside the vCluster
+itself, as you can just deploy resource quotas, limit ranges, admission controllers
+and network policies in there. To allow network policies to function correctly,
+you'll need to enable this in vCluster itself though.
 
 ### Secret based Service Account tokens
 
-By default vCluster will create Service Account Tokens for each pod and inject them as an annotation in the respective pods
-metadata. This can be a security risk in certain scenarios. To mitigate this there's an option in vCluster
-which creates separate secrets for each pods Service Account Token and mounts it accordingly using projected volumes. This option
-is not enabled by default but can be enabled on demand. To enable you can use:
+By default vCluster will create Service Account Tokens for each pod and inject
+them as an annotation in the respective pods metadata. If this doesn't comply
+with your security practices, then  you can mitigate this by enabling an option
+in the `vcluster.yaml` which creates separate secrets for each pod's
+Service Account Token and mounts it accordingly using projected volumes. This
+option is not enabled by default but can be enabled on demand in your `vcluster.yaml`:
 
-```
+```yaml
 sync:
   toHost:
     pods:


### PR DESCRIPTION
Added an info box about setting `--expose-local=false` when running `vcluster create` locally.
Also added a missing yaml annotation to the last code block.

Preview link: https://deploy-preview-187--vcluster-docs-site.netlify.app/docs/vcluster/deploy/topologies/isolated-workloads