### PR TITLE
Added namespace to v3 to v4 upgrade instructions

### DIFF
--- a/platform/_partials/install/upgrade-v3-v4.mdx
+++ b/platform/_partials/install/upgrade-v3-v4.mdx
@@ -13,18 +13,16 @@ Upgrade vCluster Platform from v3 to v4 via:
 <TabItem value="cli">
 
 To upgrade vCluster Platform from v3 to v4 via vCluster CLI, run. Update `$PLATFORM_VERSION` with a valid vCluster Platform version.
+
 :::info Plaftorm Namsespace
 The following steps assume the existing installation is in the default namespace `loft`. The default namespace for v4 is vcluster-platform, so we specify the namespace in the steps.
 :::
 
 ```bash
-# First set the project namespace prefix to use the v3 format
-cat > /tmp/vcluster-platform.yaml <<EOF
+vcluster platform start --upgrade --namespace loft --version=$PLATFORM_VERSION --values=<(cat <<EOF
 config:
   projectNamespacePrefix: loft-p-
 EOF
-
-vcluster platform start --namespace loft --upgrade --version=$PLATFORM_VERSION --values=/tmp/vcluster-platform.yaml
 ```
 
 </TabItem>
@@ -33,18 +31,14 @@ vcluster platform start --namespace loft --upgrade --version=$PLATFORM_VERSION -
 To upgrade vCluster Platform from v3 to v4 via `helm`, run. Update `$PLATFORM_VERSION` with a valid vCluster Platform version.
 
 ```bash
-# First set the project namespace prefix to use the v3 format
-cat > /tmp/vcluster-platform.yaml <<EOF
-config:
-  projectNamespacePrefix: loft-p-
-EOF
-
 helm upgrade loft vcluster-platform -n loft --repository-config '' --repo https://charts.loft.sh \
   --version $PLATFORM_VERSION \
   --reuse-values \
-  -f /tmp/vcluster-platform.yaml 
+  -f <(cat <<EOF
+config:
+  projectNamespacePrefix: loft-p-
+EOF
 ```
 
 </TabItem>
 </Tabs>
-


### PR DESCRIPTION
Link to the section containing the `loft` namespace: https://deploy-preview-198--vcluster-docs-site.netlify.app/docs/platform/manage/upgrade-platform#upgrading-from-v3x-to-v40