### PR TITLE
fix: specify namespace in upgrading v3 to v4 doc

### DIFF
--- a/platform/_partials/install/upgrade-v3-v4.mdx
+++ b/platform/_partials/install/upgrade-v3-v4.mdx
@@ -13,7 +13,9 @@ Upgrade vCluster Platform from v3 to v4 via:
 <TabItem value="cli">
 
 To upgrade vCluster Platform from v3 to v4 via vCluster CLI, run. Update `$PLATFORM_VERSION` with a valid vCluster Platform version.
-
+:::info Plaftorm Namsespace
+The following steps assume the existing installation is in the default namespace `loft`. The default namespace for v4 is vcluster-platform, so we specify the namespace in the steps.
+:::
 
 ```bash
 # First set the project namespace prefix to use the v3 format
@@ -22,7 +24,7 @@ config:
   projectNamespacePrefix: loft-p-
 EOF
 
-vcluster platform start --upgrade --version=$PLATFORM_VERSION --values=/tmp/vcluster-platform.yaml
+vcluster platform start --namespace loft --upgrade --version=$PLATFORM_VERSION --values=/tmp/vcluster-platform.yaml
 ```
 
 </TabItem>
@@ -37,7 +39,7 @@ config:
   projectNamespacePrefix: loft-p-
 EOF
 
-helm upgrade loft vcluster-platform -n vcluster-platform --repository-config '' --repo https://charts.loft.sh \
+helm upgrade loft vcluster-platform -n loft --repository-config '' --repo https://charts.loft.sh \
   --version $PLATFORM_VERSION \
   --reuse-values \
   -f /tmp/vcluster-platform.yaml 


### PR DESCRIPTION
namespace must be specified when upgrading from v3 to v4

part of DOC-100

Signed-off-by: Rohan CJ <rohantmp@gmail.com>
