### PR TITLE
ENG-4153 | Document setting up GKE Workload Identity/EKS Pod Identity

### DIFF
--- a/vcluster/integrations/pod-identity/_category_.json
+++ b/vcluster/integrations/pod-identity/_category_.json
@@ -1,0 +1,6 @@
+{
+    "label": "Pod Identity",
+    "position": "4",
+    "collapsible": true,
+    "collapsed": false
+  }

--- a/vcluster/integrations/pod-identity/_code/eks-pod-identity.sh
+++ b/vcluster/integrations/pod-identity/_code/eks-pod-identity.sh
@@ -1,0 +1,176 @@
+#!/bin/bash
+
+# Set up environment variables
+export AWS_REGION="eu-central-1"  # Replace with your actual AWS region if different
+export CLUSTER_NAME="pod-identity-1"  # Replace with your actual EKS cluster name if different
+export NODE_INSTANCE_TYPE="t3.medium"  # Replace with your actual instance type if different
+export SERVICE_ACCOUNT_NAME="demo-sa"  # Replace with your actual service account name if different
+export SERVICE_ACCOUNT_NAMESPACE="default"  # Replace with your actual namespace if different
+export VCLUSTER_NAME="my-vcluster"  # Replace with your actual vCluster name if different
+export HOST=https://your.loft.host  # Replace with your actual host
+export AUTH_TOKEN=abcd1234  # Replace with your actual auth token
+export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+export SA_ROLE_NAME="AmazonEKSTFEBSCSIRole-${CLUSTER_NAME}"
+
+# Define the function to get the KSA name using curl
+get_ksa_name() {
+  local vcluster_ksa_name=$1
+  local vcluster_ksa_namespace=$2
+  local vcluster_name=$3
+  local host=$4
+  local auth_token=$5
+
+  local resource_path="/kubernetes/management/apis/management.loft.sh/v1/translatevclusterresourcenames"
+  local host_with_scheme=$([[ $host =~ ^(http|https):// ]] && echo "$host" || echo "https://$host")
+  local sanitized_host="${host_with_scheme%/}"
+  local full_url="${sanitized_host}${resource_path}"
+
+  local response=$(curl -s -k -X POST "$full_url" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${auth_token}" \
+    -d @- <<EOF
+{
+  "spec": {
+    "name": "${vcluster_ksa_name}",
+    "namespace": "${vcluster_ksa_namespace}",
+    "vclusterName": "${vcluster_name}"
+  }
+}
+EOF
+  )
+
+  local status_name=$(echo "$response" | jq -r '.status.name')
+  if [[ -z "$status_name" || "$status_name" == "null" ]]; then
+    echo "Error: Unable to fetch KSA name from response: $response"
+    exit 1
+  fi
+  echo "$status_name"
+}
+
+# Get the KSA name
+KSA_NAME=$(get_ksa_name "$SERVICE_ACCOUNT_NAME" "$SERVICE_ACCOUNT_NAMESPACE" "$VCLUSTER_NAME" "$HOST" "$AUTH_TOKEN")
+
+# Create EKS cluster using eksctl
+eksctl create cluster \
+  --name ${CLUSTER_NAME} \
+  --region ${AWS_REGION} \
+  --node-type ${NODE_INSTANCE_TYPE}
+
+# Associate IAM OIDC provider with the EKS cluster
+eksctl utils associate-iam-oidc-provider --region=${AWS_REGION} --cluster=${CLUSTER_NAME} --approve
+
+# Create IAM role for the EBS CSI driver and associate policy
+eksctl create iamserviceaccount \
+  --name ebs-csi-controller-sa \
+  --namespace kube-system \
+  --cluster ${CLUSTER_NAME} \
+  --attach-policy-arn arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy \
+  --approve \
+  --role-only \
+  --role-name ${SA_ROLE_NAME} \
+  --region ${AWS_REGION}
+
+# Install the AWS EBS CSI driver as an EKS managed add-on
+eksctl create addon \
+  --name aws-ebs-csi-driver \
+  --cluster ${CLUSTER_NAME} \
+  --service-account-role-arn arn:aws:iam::${AWS_ACCOUNT_ID}:role/${SA_ROLE_NAME} \
+  --region ${AWS_REGION} \
+  --force
+
+# Deploy EKS Pod Identity Webhook
+aws eks create-addon --region ${AWS_REGION} --cluster-name ${CLUSTER_NAME} --addon-name eks-pod-identity-agent --addon-version v1.0.0-eksbuild.1
+
+# Wait for EKS Pod Identity Webhook to be up and running
+sleep 60
+
+kubectl get pods -n kube-system | grep 'eks-pod-identity-webhook'
+
+# Create vcluster.yaml content dynamically
+cat <<EOF > vcluster.yaml
+sync:
+  toHost:
+    serviceAccounts:
+      enabled: true
+EOF
+
+# Deploy vcluster using vcluster-cli
+vcluster create ${VCLUSTER_NAME} --namespace ${VCLUSTER_NAME} -f vcluster.yaml
+
+# Connect to the vCluster
+vcluster connect ${VCLUSTER_NAME}
+
+# Create example-workload.yaml content dynamically
+cat <<EOF > example-workload.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: demo-sa
+  namespace: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: s3-list-buckets
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: s3-list-buckets
+  template:
+    metadata:
+      labels:
+        app: s3-list-buckets
+    spec:
+      serviceAccountName: demo-sa
+      containers:
+      - image: public.ecr.aws/aws-cli/aws-cli
+        command:
+          - "aws"
+          - "s3"
+          - "ls"
+        name: aws-pod
+EOF
+
+cat >my-policy.json <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::*"
+        }
+    ]
+}
+EOF
+
+aws iam create-policy --policy-name my-policy --policy-document file://my-policy.json
+
+cat >trust-relationship.json <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowEksAuthToAssumeRoleForPodIdentity",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "pods.eks.amazonaws.com"
+            },
+            "Action": [
+                "sts:AssumeRole",
+                "sts:TagSession"
+            ]
+        }
+    ]
+}
+EOF
+
+aws iam create-role --role-name my-role --assume-role-policy-document file://trust-relationship.json --description "my-role-description"
+
+aws iam attach-role-policy --role-name my-role --policy-arn=arn:aws:iam::${AWS_ACCOUNT_ID}:policy/my-policy
+
+aws eks create-pod-identity-association --cluster-name ${CLUSTER_NAME} --role-arn arn:aws:iam::${AWS_ACCOUNT_ID}:role/my-role --namespace ${VCLUSTER_NAME} --service-account ${KSA_NAME}
+
+kubectl logs -l app=s3-list-buckets -n default

--- a/vcluster/integrations/pod-identity/_code/eks-pod-identity.tf
+++ b/vcluster/integrations/pod-identity/_code/eks-pod-identity.tf
@@ -1,0 +1,209 @@
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "http" {
+    alias = "default"
+}
+
+provider "helm" {
+  kubernetes {
+    config_path = "${path.module}/kubeconfig_${var.cluster_name}"
+  }
+}
+
+
+# Filter out local zones, which are not currently supported
+# with managed node groups
+data "aws_availability_zones" "available" {
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
+
+locals {
+  cluster_name = var.cluster_name
+}
+
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+}
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.8.1"
+
+  name = "education-vpc"
+
+  cidr = "10.0.0.0/16"
+  azs  = slice(data.aws_availability_zones.available.names, 0, 3)
+
+  private_subnets = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  public_subnets  = ["10.0.4.0/24", "10.0.5.0/24", "10.0.6.0/24"]
+
+  enable_nat_gateway   = true
+  single_nat_gateway   = true
+  enable_dns_hostnames = true
+
+  public_subnet_tags = {
+    "kubernetes.io/role/elb" = 1
+  }
+
+  private_subnet_tags = {
+    "kubernetes.io/role/internal-elb" = 1
+  }
+}
+
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "20.8.5"
+
+  cluster_name    = local.cluster_name
+  cluster_version = "1.29"
+
+  cluster_endpoint_public_access           = true
+  enable_cluster_creator_admin_permissions = true
+
+  cluster_addons = {
+    aws-ebs-csi-driver = {
+      service_account_role_arn = module.irsa-ebs-csi.iam_role_arn
+    }
+
+    eks-pod-identity-agent = {}
+  }
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  eks_managed_node_group_defaults = {
+    ami_type = "AL2_x86_64"
+
+  }
+
+  eks_managed_node_groups = {
+    one = {
+      name = "node-group-1"
+
+      instance_types = ["t3.small"]
+
+      min_size     = 1
+      max_size     = 3
+      desired_size = 2
+    }
+
+    two = {
+      name = "node-group-2"
+
+      instance_types = ["t3.small"]
+
+      min_size     = 1
+      max_size     = 2
+      desired_size = 1
+    }
+  }
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession"
+    ]
+  }
+}
+
+resource "aws_iam_role" "example" {
+  name               = "eks-pod-identity-example"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "example_s3" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+  role       = aws_iam_role.example.name
+}
+
+
+# https://aws.amazon.com/blogs/containers/amazon-ebs-csi-driver-is-now-generally-available-in-amazon-eks-add-ons/
+data "aws_iam_policy" "ebs_csi_policy" {
+  arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}
+
+module "irsa-ebs-csi" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
+  version = "5.39.0"
+
+  create_role                   = true
+  role_name                     = "AmazonEKSTFEBSCSIRole-${module.eks.cluster_name}"
+  provider_url                  = module.eks.oidc_provider
+  role_policy_arns              = [data.aws_iam_policy.ebs_csi_policy.arn]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:kube-system:ebs-csi-controller-sa"]
+}
+
+resource "null_resource" "update_kubeconfig" {
+  provisioner "local-exec" {
+    command = <<EOT
+eksctl utils write-kubeconfig --cluster=${module.eks.cluster_name} --region=${var.aws_region} --kubeconfig=${path.module}/kubeconfig_${module.eks.cluster_name}
+EOT
+  }
+  depends_on = [ module.eks ]
+}
+
+module "synced_service_account_name" {
+  source        = "github.com/loft-sh/vcluster-terraform-modules//single-namespace-rename"
+
+  providers = {
+    http.default = http.default
+  }
+
+
+  host                 = "https://localhost:8080"
+  auth_token          = var.auth_token
+  resource_name       = var.service_account_name
+  resource_namespace  = var.service_account_namespace
+  vcluster_name       = var.vcluster_name
+}
+
+resource "helm_release" "my_vcluster" {
+  name             = var.vcluster_name
+  namespace        = var.vcluster_name
+  create_namespace = true
+
+  repository       = "https://charts.loft.sh"
+  chart            = "vcluster"
+  version          = "0.20.0-beta.6"
+
+  values = [
+    file("${path.module}/vcluster.yaml")
+  ]
+
+  depends_on = [ null_resource.update_kubeconfig ]
+}
+
+resource "null_resource" "apply_example_workload" {
+  provisioner "local-exec" {
+    command = "vcluster connect ${var.vcluster_name} -n ${var.vcluster_name} -- kubectl apply -f ${path.module}/example-workload.yaml"
+    environment = {
+      "KUBECONFIG" = "${path.module}/kubeconfig_${module.eks.cluster_name}"
+    }
+  }
+
+  depends_on = [ helm_release.my_vcluster ]
+}
+
+resource "aws_eks_pod_identity_association" "example" {
+  cluster_name    = module.eks.cluster_name
+  namespace       = var.vcluster_name
+  service_account = module.synced_service_account_name.name
+  role_arn        = aws_iam_role.example.arn
+
+  depends_on = [ null_resource.apply_example_workload ]
+}

--- a/vcluster/integrations/pod-identity/_code/gcs-list-buckets-deployment.yaml
+++ b/vcluster/integrations/pod-identity/_code/gcs-list-buckets-deployment.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: demo-sa
+  namespace: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gcs-list-buckets
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gcs-list-buckets
+  template:
+    metadata:
+      labels:
+        app: gcs-list-buckets
+    spec:
+      serviceAccountName: demo-sa
+      containers:
+      - image: google/cloud-sdk:slim
+        command:
+          - "gcloud"
+          - "storage"
+          - "buckets"
+          - "list"
+        name: gcs-pod

--- a/vcluster/integrations/pod-identity/_code/get-resource-name.sh
+++ b/vcluster/integrations/pod-identity/_code/get-resource-name.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+get_resource_name() {
+  # Description:
+  # This function retrieves the name of a Kubernetes resource synced back from a vCluster instance to the hosting cluster
+  # by making an HTTP request to the vCluster Platform API.
+  #
+  # Arguments:
+  #   resource_name:        The name of the Kubernetes resource created in virtual cluster.
+  #   resource_namespace:   The namespace of the Kubernetes resource created in virtual cluster.
+  #   vcluster_name:        The name of the virtual cluster.
+  #   host:                 The host URL of the vCluster Platform.
+  #   auth_token:           The authentication token for accessing the vCluster Platform API.
+  #
+  # Returns:
+  #   The name that this Kubernetes resource would have after syncing it back to hosting cluster.
+
+  local resource_name=$1
+  local resource_namespace=$2
+  local vcluster_name=$3
+  local host=$4
+  local auth_token=$5
+
+  local resource_path="/kubernetes/management/apis/management.loft.sh/v1/translatevclusterresourcenames"
+  local host_with_scheme
+  host_with_scheme=$([[ $host =~ ^(http|https):// ]] && echo "$host" || echo "https://$host")
+  local sanitized_host
+  sanitized_host="${host_with_scheme%/}"
+  local full_url
+  full_url="${sanitized_host}${resource_path}"
+
+  local response
+  response=$(curl -s -k -X POST "$full_url" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${auth_token}" \
+    -d @- <<EOF
+{
+  "spec": {
+    "name": "${resource_name}",
+    "namespace": "${resource_namespace}",
+    "vclusterName": "${vcluster_name}"
+  }
+}
+EOF
+  )
+
+  local status_name
+  status_name=$(echo "$response" | jq -r '.status.name')
+  if [[ -z "$status_name" || "$status_name" == "null" ]]; then
+    echo "Error: Unable to fetch resource name from response: $response"
+    exit 1
+  fi
+  echo "$status_name"
+}

--- a/vcluster/integrations/pod-identity/_code/gke-workload-identity.sh
+++ b/vcluster/integrations/pod-identity/_code/gke-workload-identity.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# Set up environment variables
+export GSA_NAME=my-gke-sa
+export VCLUSTER_KSA_NAME=demo-sa  # Replace with your actual resource name
+export VCLUSTER_KSA_NAMESPACE=default  # Replace with your actual resource namespace
+export GCP_PROJECT_ID=my-project-424114
+export VCLUSTER_NAME=my-vcluster
+export HOST=https://my.loft.host  # Replace with your actual host
+export AUTH_TOKEN=...
+
+# Define the function to get the KSA name using curl
+get_ksa_name() {
+  local vcluster_ksa_name=$1
+  local vcluster_ksa_namespace=$2
+  local vcluster_name=$3
+  local host=$4
+  local auth_token=$5
+
+  local resource_path="/kubernetes/management/apis/management.loft.sh/v1/translatevclusterresourcenames"
+  local host_with_scheme=$([[ $host =~ ^(http|https):// ]] && echo "$host" || echo "https://$host")
+  local sanitized_host="${host_with_scheme%/}"
+  local full_url="${sanitized_host}${resource_path}"
+
+  local response=$(curl -s -k -X POST "$full_url" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${auth_token}" \
+    -d @- <<EOF
+{
+  "spec": {
+    "name": "${vcluster_ksa_name}",
+    "namespace": "${vcluster_ksa_namespace}",
+    "vclusterName": "${vcluster_name}"
+  }
+}
+EOF
+  )
+
+  local status_name=$(echo "$response" | jq -r '.status.name')
+  if [[ -z "$status_name" || "$status_name" == "null" ]]; then
+    echo "Error: Unable to fetch KSA name from response: $response"
+    exit 1
+  fi
+  echo "$status_name"
+}
+
+# Connect to the vCluster
+vcluster connect ${VCLUSTER_NAME}
+
+# Apply the Kubernetes deployment
+kubectl apply -f gcs-list-buckets-deployment.yaml
+
+# Get the KSA name
+KSA_NAME=$(get_ksa_name "$VCLUSTER_KSA_NAME" "$VCLUSTER_KSA_NAMESPACE" "$VCLUSTER_NAME" "$HOST" "$AUTH_TOKEN")
+
+# Create a new GCP Service Account
+gcloud iam service-accounts create ${GSA_NAME} \
+  --display-name "Workload Identity experiment SA"
+
+# Bind IAM policy for Workload Identity User
+gcloud iam service-accounts add-iam-policy-binding ${GSA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com \
+  --member "serviceAccount:${GCP_PROJECT_ID}.svc.id.goog[${VCLUSTER_NAME}/${KSA_NAME}]" \
+  --role "roles/iam.workloadIdentityUser"
+
+# Bind IAM policy for Storage Object Viewer
+gcloud projects add-iam-policy-binding ${GCP_PROJECT_ID} \
+  --member "serviceAccount:${GSA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com" \
+  --role "roles/storage.objectViewer"
+
+# Add IAM policy binding to the GCP project
+gcloud projects add-iam-policy-binding ${GCP_PROJECT_ID} \
+  --member "serviceAccount:${GSA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com" \
+  --role "roles/editor"
+
+# Annotate the Kubernetes Service Account
+kubectl annotate serviceaccount \
+  --namespace ${VCLUSTER_KSA_NAMESPACE} \
+  ${VCLUSTER_KSA_NAME} \
+  iam.gke.io/gcp-service-account=${GSA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com

--- a/vcluster/integrations/pod-identity/_code/pod-identity-vcluster.yaml
+++ b/vcluster/integrations/pod-identity/_code/pod-identity-vcluster.yaml
@@ -1,0 +1,4 @@
+sync:
+  toHost:
+    serviceAccounts:
+      enabled: true

--- a/vcluster/integrations/pod-identity/_partials/get-resource-name.mdx
+++ b/vcluster/integrations/pod-identity/_partials/get-resource-name.mdx
@@ -1,0 +1,72 @@
+import Tabs from '@theme/Tabs'
+import TabItem from '@theme/TabItem'
+
+<Tabs>
+<TabItem value="bash">
+Define a function to fetch the KSA name using curl and use it to export `KSA_NAME` environment variable.
+
+```bash
+# Define the function to get the KSA name using curl
+get_ksa_name() {
+  local vcluster_ksa_name=$1
+  local vcluster_ksa_namespace=$2
+  local vcluster_name=$3
+  local host=$4
+  local access_key=$5
+
+  local resource_path="/kubernetes/management/apis/management.loft.sh/v1/translatevclusterresourcenames"
+  local host_with_scheme=$([[ $host =~ ^(http|https):// ]] && echo "$host" || echo "https://$host")
+  local sanitized_host="${host_with_scheme%/}"
+  local full_url="${sanitized_host}${resource_path}"
+
+  local response=$(curl -s -k -X POST "$full_url" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${access_key}" \
+    -d @- <<EOF
+{
+  "spec": {
+    "name": "${vcluster_ksa_name}",
+    "namespace": "${vcluster_ksa_namespace}",
+    "vclusterName": "${vcluster_name}"
+  }
+}
+EOF
+  )
+
+  local status_name=$(echo "$response" | jq -r '.status.name')
+  if [[ -z "$status_name" || "$status_name" == "null" ]]; then
+    echo "Error: Unable to fetch KSA name from response: $response"
+    exit 1
+  fi
+  echo "$status_name"
+}
+
+# Get the KSA name
+export KSA_NAME=$(get_ksa_name "$SERVICE_ACCOUNT_NAME" "$SERVICE_ACCOUNT_NAMESPACE" "$VCLUSTER_NAME" "$HOST" "$ACCESS_KEY")
+```
+</TabItem>
+<TabItem value="Terraform">
+
+We prepared a [Terraform module][single-namespace-rename-module] that you can use in order to easily fetch updated resource name from Platform API.
+
+```hcl
+module "synced_service_account_name" {
+  source        = "github.com/loft-sh/vcluster-terraform-modules//single-namespace-rename"
+
+  providers = {
+    http.default = http.default
+  }
+
+
+  host                = var.vcluster_platform_host
+  access_key          = var.access_key
+  resource_name       = var.service_account_name
+  resource_namespace  = var.service_account_namespace
+  vcluster_name       = var.vcluster_name
+}
+```
+
+</TabItem>
+</Tabs>
+
+[single-namespace-rename-module]: https://github.com/loft-sh/vcluster-terraform-modules/tree/main/single-namespace-rename

--- a/vcluster/integrations/pod-identity/eks-pod-identity.mdx
+++ b/vcluster/integrations/pod-identity/eks-pod-identity.mdx
@@ -1,0 +1,279 @@
+---
+title: EKS Pod Identity
+sidebar_label: EKS Pod Identity
+sidebar_class_name: pro
+sidebar_position: 1
+---
+
+import CodeBlock from '@theme/CodeBlock';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem'
+
+import DeployBeta from '@site/vcluster/_partials/deploy/deploy-beta.mdx'
+import GetResourceName from '@site/vcluster/integrations/pod-identity/_partials/get-resource-name.mdx'
+import EKSPodIdentityScript from '!!raw-loader!@site/vcluster/integrations/pod-identity/_code/eks-pod-identity.sh'
+import EKSPodIdentityTerraform from '!!raw-loader!@site/vcluster/integrations/pod-identity/_code/eks-pod-identity.tf'
+import VClusterYaml from '!!raw-loader!@site/vcluster/integrations/pod-identity/_code/pod-identity-vcluster.yaml'
+
+import ProAdmonition from '@site/vcluster/_partials/admonitions/pro-admonition.mdx'
+
+<ProAdmonition/>
+
+# Integrating EKS Pod Identity with vCluster
+
+This tutorial guides you through the process of integrating AWS Service Accounts with your vCluster using Pod Identity.
+
+Setting up Pod Identity requires you to link an AWS Service Account with the Kubernetes Service Account (KSA) used by your workloads.
+This KSA needs to be available in the host cluster in which your vCluster instance runs.
+
+To achieve this setup, we'll need to use the [sync.toHost feature][sync-toHost-docs] in order to expose the KSA in the host cluster together with the vCluster Platform API to retrieve the updated name of the KSA in the host cluster.
+
+### Prerequisites
+This guide assumes you have the following prerequisites:
+- `kubectl` installed
+- `aws` CLI installed and configured
+- An existing EKS cluster with the CSI driver set up, IAM OIDC provider, and Pod Identity agent deployed
+
+### Step-by-Step Guide
+
+#### 1. Start vCluster Platform and create an access key
+
+In order to integrate your workloads with EKS Pod Identity, you'll need a vCluster Platform instance running.
+If you don't have one already, follow the [vCluster Platform installation guide][vcluster-platform-install-link].
+
+Once you're done, you'll need to create a new access key. This will allow you to use the vCluster Platform API.
+Please follow this [guide to create a new access key][access-key-link].
+
+
+#### 2. Set Up Variables
+
+<Tabs>
+
+<TabItem value="bash">
+Define the necessary environment variables for your EKS cluster, service accounts, and authentication details.
+
+```bash
+#!/bin/bash
+
+# Set up environment variables
+export AWS_REGION="eu-central-1"  # Replace with your AWS region
+export CLUSTER_NAME="pod-identity-1"  # Replace with your EKS cluster name
+export SERVICE_ACCOUNT_NAME="demo-sa"
+export SERVICE_ACCOUNT_NAMESPACE="default"
+export VCLUSTER_NAME="my-vcluster"
+export HOST=https://your.loft.host  # Replace with your host
+export ACCESS_KEY=abcd1234  # Replace with your access key
+export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+```
+</TabItem>
+
+<TabItem value="Terraform">
+```hcl
+variable "aws_region" {
+  description = "The AWS region to deploy the EKS cluster"
+  type        = string
+  default     = "eu-central-1"
+}
+
+variable "cluster_name" {
+  description = "The name of the EKS cluster"
+  type        = string
+  default     = "pod-identity-1"
+}
+
+variable "service_account_name" {
+  description = "K8s SA name for Pod Identity binding"
+  type        = string
+  default     = "demo-sa"
+}
+
+variable "service_account_namespace" {
+  description = "Namespace in which k8s SA is created"
+  type        = string
+  default     = "default"
+}
+
+variable "vcluster_name" {
+  description = "Name of virtual cluster"
+  type        = string
+  default     = "my-vcluster"
+}
+
+variable "auth_token" {
+  description = "Auth token for vCluster.Pro API"
+  type        = string
+  default     = "abcd1234"
+}
+```
+</TabItem>
+
+</Tabs>
+
+#### 3. Create vCluster Configuration
+
+Create the `vcluster.yaml` file with following content:
+
+```yaml
+sync:
+  toHost:
+    serviceAccounts:
+      enabled: true
+```
+
+#### 4. Deploy vCluster
+
+<DeployBeta />
+
+
+#### 5. Connect to vCluster
+
+Establish a connection to your vCluster instance:
+
+```bash
+vcluster connect ${VCLUSTER_NAME}
+```
+
+#### 6. Create Example Workload
+
+Create an example workload to list S3 buckets.
+
+```bash
+# Create example-workload.yaml content dynamically
+cat <<EOF > example-workload.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: demo-sa
+  namespace: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: s3-list-buckets
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: s3-list-buckets
+  template:
+    metadata:
+      labels:
+        app: s3-list-buckets
+    spec:
+      serviceAccountName: demo-sa
+      containers:
+      - image: public.ecr.aws/aws-cli/aws-cli
+        command:
+          - "aws"
+          - "s3"
+          - "ls"
+        name: aws-pod
+EOF
+
+kubectl apply -f example-workload.yaml
+```
+
+#### 7. Read Updated Name From vCluster Platform API
+
+<GetResourceName />
+
+#### 8. Create IAM Policy and Role for Pod Identity
+
+<Tabs>
+
+<TabItem value="bash">
+
+Create IAM policy and role for pod identity.
+
+```bash
+cat >my-policy.json <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::*"
+        }
+    ]
+}
+EOF
+
+aws iam create-policy --policy-name my-policy --policy-document file://my-policy.json
+
+cat >trust-relationship.json <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowEksAuthToAssumeRoleForPodIdentity",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "pods.eks.amazonaws.com"
+            },
+            "Action": [
+                "sts:AssumeRole",
+                "sts:TagSession"
+            ]
+        }
+    ]
+}
+EOF
+
+aws iam create-role --role-name my-role --assume-role-policy-document file://trust-relationship.json --description "my-role-description"
+
+aws iam attach-role-policy --role-name my-role --policy-arn=arn:aws:iam::${AWS_ACCOUNT_ID}:policy/my-policy
+```
+
+Create the pod identity association.
+
+```bash
+aws eks create-pod-identity-association --cluster-name ${CLUSTER_NAME} --role-arn arn:aws:iam::${AWS_ACCOUNT_ID}:role/my-role --namespace ${VCLUSTER_NAME} --service-account ${KSA_NAME}
+```
+
+</TabItem>
+
+<TabItem value="Terraform">
+```hcl
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
+    }
+
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession"
+    ]
+  }
+}
+
+resource "aws_iam_role" "example" {
+  name               = "eks-pod-identity-example"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "example_s3" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess"
+  role       = aws_iam_role.example.name
+}
+```
+</TabItem>
+
+</Tabs>
+
+#### 9. Verify the Setup
+
+Verify the setup by checking the logs.
+
+```bash
+kubectl logs -l app=s3-list-buckets -n default
+```
+
+[vcluster-platform-install-link]: ../../../platform/install/quick-start-guide
+[access-key-link]: ../../../platform/users/advanced/access-keys
+[sync-toHost-docs]: ../../configure/vcluster-yaml/sync/to-host/README.mdx

--- a/vcluster/integrations/pod-identity/gke-workload-identity.mdx
+++ b/vcluster/integrations/pod-identity/gke-workload-identity.mdx
@@ -1,0 +1,155 @@
+---
+title: GKE Workload Identity
+sidebar_label: GKE Workload Identity
+sidebar_class_name: pro
+sidebar_position: 2
+---
+
+import CodeBlock from '@theme/CodeBlock';
+
+import DeployBeta from '@site/vcluster/_partials/deploy/deploy-beta.mdx'
+import ProAdmonition from '@site/vcluster/_partials/admonitions/pro-admonition.mdx'
+import GetResourceName from '@site/vcluster/integrations/pod-identity/_partials/get-resource-name.mdx'
+
+import GKEWorkloadIdentityTestDeployment from '!!raw-loader!@site/vcluster/integrations/pod-identity/_code/gcs-list-buckets-deployment.yaml'
+
+<ProAdmonition/>
+
+# Integrating GCP Workload Identity with vCluster
+
+This tutorial guides you through the process of integrating GCP Service Accounts with your vCluster using Workload Identity.
+
+Setting up Workload Identity requires you to link a GCP Service Account with the Kubernetes Service Account (KSA) used by your workloads.
+This KSA needs to be available in the host cluster in which your vCluster instance runs.
+
+To achieve this setup, we'll need to use the [sync.toHost feature][sync-toHost-docs] in order to expose the KSA in the host cluster together with the vCluster Platform API to retrieve the updated name of the KSA in the host cluster.
+
+### Prerequisites
+This guide assumes you have the following prerequisites:
+- `kubectl` installed
+- `gcloud` CLI installed and configured
+- A running GKE cluster with Workload Identity Federation enabled ([GCP docs][gcloud-gke-workload-identity])
+
+### Step-by-Step Guide
+
+#### 1. Start vCluster Platform and create access key
+
+In order to integrate your workloads with GKE Workload Identity, you'll need a vCluster Platform instance running.
+If you don't have one already, follow the [vCluster Platform installation guide][vcluster-platform-install-link].
+
+Once you're done, you'll need to create a new access key. This will allow you to use the vCluster Platform API.
+Please follow this [guide to create a new access key][access-key-link].
+
+#### 2. Set Up Environment Variables
+
+Next, you need to set up the necessary environment variables. These variables include information about your GCP project, vCluster details, and authentication keys.
+
+```bash
+# Set up environment variables
+export GSA_NAME=my-gke-sa
+export VCLUSTER_KSA_NAME=demo-sa
+export VCLUSTER_KSA_NAMESPACE=default
+export GCP_PROJECT_ID=my-gcp-project-id-12345 # Replace with your actual GCP project ID
+export VCLUSTER_NAME=my-vcluster
+export HOST=https://my.loft.host  # Replace with your actual host
+export ACCESS_KEY=abcd1234 # Replace with your actual vCluster Platform access key
+```
+
+Before proceeding adjust all values to your specific case, make sure to specify correct GCP project ID, vCluster Platform host and auth key.
+
+#### 3. Read Updated Name From vCluster Platform API
+
+<GetResourceName />
+
+#### 4. Create vCluster Configuration
+
+Create `vcluster.yaml` file with following content:
+
+```yaml
+sync:
+  toHost:
+    serviceAccounts:
+      enabled: true
+```
+
+#### 5. Deploy vCluster
+
+<DeployBeta />
+
+#### 6. Connect to vCluster
+
+Establish a connection to your vCluster instance:
+
+```bash
+vcluster connect ${VCLUSTER_NAME}
+```
+
+#### 7. Create Example Workload
+
+Create a file named `gcs-list-buckets-deployment.yaml` with the following content:
+
+<CodeBlock language="yaml">{GKEWorkloadIdentityTestDeployment}</CodeBlock>
+
+Apply the deployment:
+
+```bash
+kubectl apply -f gcs-list-buckets-deployment.yaml
+```
+
+#### 9. Create a GCP Service Account
+
+Create a new GCP Service Account (SA) that will be used for workload identity.
+
+```bash
+# Create a new GCP Service Account
+gcloud iam service-accounts create ${GSA_NAME} \
+  --display-name "Workload Identity experiment SA"
+```
+
+#### 10. Bind IAM Policies to the GCP Service Account
+
+Bind the necessary IAM policies to the GCP Service Account, allowing it to be used by the Kubernetes Service Account and to list GCS buckets.
+
+```bash
+# Bind IAM policy for Workload Identity User
+gcloud iam service-accounts add-iam-policy-binding ${GSA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com \
+  --member "serviceAccount:${GCP_PROJECT_ID}.svc.id.goog[${VCLUSTER_NAME}/${KSA_NAME}]" \
+  --role "roles/iam.workloadIdentityUser"
+
+# Bind IAM policy for Storage Object Viewer
+gcloud projects add-iam-policy-binding ${GCP_PROJECT_ID} \
+  --member "serviceAccount:${GSA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com" \
+  --role "roles/storage.objectViewer"
+
+# Add IAM policy binding to the GCP project
+gcloud projects add-iam-policy-binding ${GCP_PROJECT_ID} \
+  --member "serviceAccount:${GSA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com" \
+  --role "roles/editor"
+```
+
+#### 11. Annotate the Kubernetes Service Account
+
+Annotate the Kubernetes Service Account with the GCP Service Account email.
+
+```bash
+# Annotate the Kubernetes Service Account
+kubectl annotate serviceaccount \
+  --namespace ${VCLUSTER_KSA_NAMESPACE} \
+  ${VCLUSTER_KSA_NAME} \
+  iam.gke.io/gcp-service-account=${GSA_NAME}@${GCP_PROJECT_ID}.iam.gserviceaccount.com
+```
+
+#### 12. Verify the Setup
+
+Verify that the setup is complete and the pod is able to list the GCS buckets using the IAM role.
+
+```bash
+kubectl logs -l app=gcs-list-buckets -n default
+```
+
+Following these steps will integrate your GCP Service Account with your vCluster, allowing you to manage resources securely and efficiently.
+
+[vcluster-platform-install-link]: ../../../platform/install/quick-start-guide
+[access-key-link]: ../../../platform/users/advanced/access-keys
+[gcloud-gke-workload-identity]: https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity#enable_on_clusters_and_node_pools
+[sync-toHost-docs]: ../../configure/vcluster-yaml/sync/to-host/README.mdx


### PR DESCRIPTION
- [x] We want to move this from the platform docs to the vCluster docs as most people will search for this in the vcluster docs. We also want to group both pages under Pod Identity and then have EKS and GKE.
- [x] EKS: Integrations -> Identity -> EKS
- [x] GKE: Integrations -> Identify -> GKE
- [x] Since you need the platform, these pages should be labeled as pro, so it shows up in the side bar: Example front matter that you'll need: https://github.com/loft-sh/vcluster-docs/blob/main/vcluster/configure/vcluster-yaml/experimental/isolated-control-plane.mdx?plain=1#L5
- [x] Since it will be under vCluster now instead of the platform, we should remove the vCluster Platform running as a pre-req and instead it becomes one of the steps of the guide. In that step, it should refer to the install vCluster Platform docs.
- [x] Can the formats of the two guide match and follow the EKS style for the heading? So don't have headings that say Step 1 but instead 1.
- [x] For the steps that are deploying the vcluster, can you either use the partial from the basics page as you can deploy vCluster however you want? https://github.com/loft-sh/vcluster-docs/blob/main/vcluster/deploy/basics.mdx?plain=1#L180
- [x] Include Terraform examples and vcluster-terraform-modules usage
- [ ] Test all possible paths:
  - [ ] GKE using bash + cli's
  - [ ] GKE using terraform
  - [ ] EKS using bash + cli's
  - [ ] EKS using terraform


Preview: https://deploy-preview-200--vcluster-docs-site.netlify.app/docs/platform/integrations/gke-workload-identity