### PR TITLE
[0.21] fix: observability deprecated in beta.12

### DIFF
--- a/vcluster/integrations/metrics/metrics-server.mdx
+++ b/vcluster/integrations/metrics/metrics-server.mdx
@@ -54,11 +54,11 @@ By default, vCluster will create a service for each node that redirects incoming
 
 Create a `vcluster.yaml` with:
 ```yaml
-observability:
-  metrics:
-    proxy:
-      nodes: true
-      pods: true
+integrations:
+  metricsServer:
+    enabled: true
+    nodes: true
+    pods: true
 ```
 
 Then create a vCluster with:


### PR DESCRIPTION
Documentation should reflect changes made in https://github.com/loft-sh/vcluster/pull/1903
`observability --> integrations`