### PR TITLE
Changes to PRO tags

### DIFF
--- a/src/css/sidebar.scss
+++ b/src/css/sidebar.scss
@@ -25,6 +25,10 @@
       color: #fff;
       background: #f27506;
       border-radius: 3px;
+      // This is here on purpose. Sometimes text-indent is applied on the parent
+      // element and gets inherited by the PRO label, which it is not supposed
+      // to do:
+      text-indent: 0;
     }
   }
 

--- a/src/css/sidebar.scss
+++ b/src/css/sidebar.scss
@@ -31,8 +31,6 @@
   // In the case of sidebar items that are collapsible, the PRO label should be
   // positioned inwards to prevent overlap with the expand/collapse caret
   &.pro > .menu__list-item-collapsible > .menu__link {
-    outline: 1px solid red;
-    // right: 30px;
     &::after {
       right: 2.5rem;
     }

--- a/src/css/sidebar.scss
+++ b/src/css/sidebar.scss
@@ -7,24 +7,34 @@
   }
 
   /* PRO label */
-  &.pro .menu__link {
+  &.pro > .menu__list-item-collapsible > .menu__link, // With subitems
+  &.pro > .menu__link // Without subitems
+  {
     position: relative;
 
     &::after {
       content: "PRO";
       position: absolute;
-      right: -0.1rem;
+      right: 0.5rem;
       top: 50%;
       transform: translateY(-50%);
-      padding: 0.25em 0.8em 0.25em 0.45em;
-      font-size: 0.8em;
+      padding: 0.25em 0.45em 0.25em 0.45em;
+      font-size: 0.7em;
       font-weight: 700;
       letter-spacing: 0.3px;
       color: #fff;
       background: #f27506;
       border-radius: 3px;
-      line-height: 110%;
-      text-indent: 0;
+    }
+  }
+
+  // In the case of sidebar items that are collapsible, the PRO label should be
+  // positioned inwards to prevent overlap with the expand/collapse caret
+  &.pro > .menu__list-item-collapsible > .menu__link {
+    outline: 1px solid red;
+    // right: 30px;
+    &::after {
+      right: 2.5rem;
     }
   }
 


### PR DESCRIPTION
This change provides a visual means to support collapsible sections with the PRO tag. Currently, doing this causes visual issues.

As a result, this change also changes the style of the PRO tag in order to support this. Namely - the PRO tag no longer sticks to the right edge of the screen.

Here are some screenshots:
![image](https://github.com/user-attachments/assets/db52b0fd-fa88-4021-935c-5f53a0e481ef)
![image](https://github.com/user-attachments/assets/10f6b185-5a75-4a66-8029-6c9c4a0819f4)
![image](https://github.com/user-attachments/assets/08eb7a34-14ec-4a88-b93f-79ba49c901b4)

