### PR TITLE
vcluster cli throws an error if exportKubeConfig.server does not have a port number when set

### DIFF
--- a/vcluster/manage/accessing-vcluster.mdx
+++ b/vcluster/manage/accessing-vcluster.mdx
@@ -161,7 +161,7 @@ controlPlane:
     scheduling:
       podManagementPolicy: OrderedReady
 exportKubeConfig:
-  server: https://my-domain.org
+  server: https://my-domain.org:443
 ```
 
 Then you can create or upgrade the vCluster with:


### PR DESCRIPTION
when editing the exportKubeConfig.server property you have to specify the port number as well, otherwise an error is thrown from the vcluster cli as there are not 2 instances of a : in the path. This change updates the documentation to include the port number.

see [pkg/cli/connect_helm.go](https://github.com/loft-sh/vcluster/blob/450e5288b68b728222acf5d0046b529a79ac6c8d/pkg/cli/connect_helm.go#L372)
```
splitted := strings.Split(cluster.Server, ":")
if len(splitted) != 3 {
   return nil, fmt.Errorf("unexpected server in kubeconfig: %s", cluster.Server)
}
```