### PR TITLE
refactor: change google style quotation rule severity 

### DIFF
--- a/.github/styles/Google/Quotes.yml
+++ b/.github/styles/Google/Quotes.yml
@@ -1,7 +1,7 @@
 extends: existence
 message: "Commas and periods go inside quotation marks."
 link: 'https://developers.google.com/style/quotation-marks'
-level: error
+level: suggestion
 nonword: true
 tokens:
   - '"[^"]+"[.,?]'

--- a/.vale.ini
+++ b/.vale.ini
@@ -8,8 +8,8 @@ BasedOnStyles = Loft, Google
 
 [markup.mdx]
 extends = markdown
-ignore = (\<[^>]*\>)  # Ignore JSX tags in .mdx files
+BlockIgnores = (\<[^>]*\>)  # Ignore JSX tags in .mdx files
 TokenIgnores = (\(#.*\)),(\]\(),(http.*),({{<\s*\/?expand),(\!\[),(\d.*px),(\d\.\d\.\d)
-BlockIgnores = (\{\{<\s*\/?.*>\}\}),(\{\{\<\/\*.*\*\/\>\}\})
 
 Google.OxfordComma = YES
+Google.Quotes = NO


### PR DESCRIPTION
Google style quotation rule is now downgraded to `suggestion`. This was necessary so that nested `mdx` components wouldn't trigger alerts.