### PR TITLE
feat: add banner announcing platform v4.0

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -208,9 +208,14 @@ const config = {
       prism: {
         additionalLanguages: ["bash", "hcl"],
       },
+      announcementBar: {
+        id: 'platform-upgrade',
+        content: '🚀 <strong>Platform 4.0 is now available!</strong> Check out the <a href="/docs/platform/administer/upgrade-migrate/upgrade-platform#upgrading-from-v3x-to-v40">latest docs</a> and upgrade today!',
+        backgroundColor: '#4a90e2',
+        textColor: '#ffffff',
+        isCloseable: false,
+     },
     }),
 };
 
 export default config;
-
-

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -210,7 +210,7 @@ const config = {
       },
       announcementBar: {
         id: 'platform-upgrade',
-        content: '🚀 <strong>Platform 4.0 is now available!</strong> Check out the <a href="/docs/platform/administer/upgrade-migrate/upgrade-platform#upgrading-from-v3x-to-v40">latest docs</a> and upgrade today!',
+        content: '🚀 <strong>Platform 4.0 is now available!</strong> Check out the <a href="/docs/platform/reference/migrations/4-0-migration">latest docs</a> and upgrade today!',
         backgroundColor: '#4a90e2',
         textColor: '#ffffff',
         isCloseable: false,


### PR DESCRIPTION
## Summary
<!-- Brief summary of the purpose of this PR -->
This pull request includes a small change to the `docusaurus.config.js` file, adding an announcement bar to inform users about the availability of Platform 4.0. and directing to the upgrade guide.

[Banner Preview](https://deploy-preview-277--vcluster-docs-site.netlify.app/docs/)

## Related

https://github.com/loft-sh/vcluster-docs/pull/311

## TODO
<!-- Checklist of tasks that need to be done before merging -->

- [ ] merge the PR on the release date

<!-- Mention Linear issue the PR closes or fixes -->
Closes DOC-261


