### PR TITLE
Update eso.mdx

### DIFF
--- a/vcluster/_fragments/eso.mdx
+++ b/vcluster/_fragments/eso.mdx
@@ -76,8 +76,8 @@ spec:
       version: v1beta1
 ```
 
-Once that external secret is created in the virtual cluster, the integration will take care or creating a corresponding secret inside the host cluster,
-the external secret operator running in the host will take care of creating the corresponding kubernetes secret, and the integration will import this
-secret in the virtual cluster. Running `kubectl get secrets` in the virtual cluster should now include the `secret-to-be-created` in its output.
+Once that external secret is created in the virtual cluster, the integration will take care or creating a corresponding external secret inside the host cluster,
+the external secret operator running in the host will take care of creating the corresponding Kubernetes secret, and the integration will import this
+Kubernetes secret into the virtual cluster. Running `kubectl get secrets` in the virtual cluster should now include the `secret-to-be-created` in its output.
 
 


### PR DESCRIPTION
Make it clear that the integration first copies the `ExternalSecret` to the host cluster where the External Secrets Operator with generate the Kubernetes `Secret`