### PR TITLE
Update fips.mdx

### DIFF
--- a/vcluster/deploy/security/fips.mdx
+++ b/vcluster/deploy/security/fips.mdx
@@ -79,16 +79,13 @@ controlPlane:
       apiServer:
         image:
           repository: loft-sh/kubernetes-fips
-          tag: v1.31.1
       controllerManager:
         image:
           repository: loft-sh/kubernetes-fips
-          tag: v1.31.1
       # uncomment to use FIPS compliant virtual scheduler within vCluster
       # scheduler:
       #   image:
       #     repository: loft-sh/kubernetes-fips
-      #     tag: v1.31.1
   coredns:
     embedded: true
   backingStore:

--- a/vcluster/deploy/security/fips.mdx
+++ b/vcluster/deploy/security/fips.mdx
@@ -66,26 +66,40 @@ a FIPS-compliant vCluster Pro instance.
 
 ```yaml
 controlPlane:
+  advanced:
+    defaultImageRegistry: ghcr.io
+    # uncomment to use virtual scheduler within vCluster
+    # virtualScheduler:
+    #   enabled: true
   statefulSet:
     image:
-      repo: vcluster-pro-fips
+      repository: loft-sh/vcluster-pro-fips
   distro:
     k8s:
       apiServer:
         image:
           repository: loft-sh/kubernetes-fips
+          tag: v1.31.1
       controllerManager:
         image:
           repository: loft-sh/kubernetes-fips
-      scheduler:
-        image:
-          repository: loft-sh/kubernetes-fips
+          tag: v1.31.1
+      # uncomment to use FIPS compliant virtual scheduler within vCluster
+      # scheduler:
+      #   image:
+      #     repository: loft-sh/kubernetes-fips
+      #     tag: v1.31.1
   coredns:
     embedded: true
   backingStore:
     etcd:
       embedded:
         enabled: true # The use of embedded etcd is recommended, yet optional
+# uncomment to use virtual scheduler within vCluster
+# sync:
+#   fromHost:
+#     nodes:
+#       enabled: true
 ```
 
 And run:


### PR DESCRIPTION
The `vcluster.yaml` example has a few issues that include:

- the registry for k8s distro images defaults to registry.k8s.io so must be overridden - this can be accomplished for all k8s distro images with the `controlPlane.advanced.defaultImageRegistry` config option set to `ghcr.io`
- The repository for the syncer image must be set using `controlPlane.statefulSet.repository` not `controlPlane.statefulSet.repo` and must include the `loft-sh` Org.
- The k8s distro tag must be set to a tag that is available at https://github.com/loft-sh/fips-builds/pkgs/container/kubernetes-fips - currently just v1.31.1 and v1.28.14
- Added a more robust scheduler example

Tested on vCluster Platform version 4.0.0-beta.18 and vCluster version 0.21.0-beta.1