### PR TITLE
feat: add vale rule and bump detect settings to warning

### DIFF
--- a/.github/styles/Loft/no-vcluster-platform.yml
+++ b/.github/styles/Loft/no-vcluster-platform.yml
@@ -1,0 +1,6 @@
+extends: substitution
+message: "Prefer using '%s' instead of '%s'"
+ignorecase: true
+level: warning
+swap:
+  vCluster Platform: the platform

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,5 +1,5 @@
 StylesPath = .github/styles
-MinAlertLevel = error
+MinAlertLevel = warning
 
 Packages = Google
 


### PR DESCRIPTION
Closes DOC-292

- a new vale rule suggesting usage of `the platform` instead of `vcluster platform`
- swapping vale level to `warning` which brings more rules into scope and helps benefit from vale checks.