### PR TITLE
feat: review sso configuration section (#279) 

### DIFF
--- a/.github/styles/Google/WordList.yml
+++ b/.github/styles/Google/WordList.yml
@@ -20,7 +20,6 @@ swap:
   'Google (?:I\-O|IO)': Google I/O
   "tap (?:&|and) hold": touch & hold
   "un(?:check|select)": clear
-  above: preceding
   account name: username
   action bar: app bar
   admin: administrator
@@ -40,7 +39,6 @@ swap:
   check box: checkbox
   CLI: command-line tool
   click on: click|click in
-  Cloud: Google Cloud Platform|GCP
   Container Engine: Kubernetes Engine
   content type: media type
   curated roles: predefined roles

--- a/.github/styles/config/vocabularies/Loft/accept.txt
+++ b/.github/styles/config/vocabularies/Loft/accept.txt
@@ -1,2 +1,4 @@
 CLI
 admin
+OAuth2
+[aA]pplication

--- a/.vale.ini
+++ b/.vale.ini
@@ -13,7 +13,7 @@ BasedOnStyles = Loft, Google, Vale
 Vale.Spelling = NO
 
 # Ignore JSX tags in .mdx files
-BlockIgnores = '(<([a-zA-Z]+)(?:\s+[^>]*)?>)([\s\S]*?)(<\/\2>)'
+BlockIgnores = '(<(?!(?i:Flow|Step)\b)([a-zA-Z]+)(?:\s+[^>]*)?>)([\s\S]*?)(<\/\2>)'
 BlockIgnores = 'import .*'
 TokenIgnores = (\(#.*\)),(\]\(),(http.*),({{<\s*\/?expand),(\!\[),(\d.*px),(\d\.\d\.\d)
 

--- a/platform/_partials/auth/disable-password-auth.mdx
+++ b/platform/_partials/auth/disable-password-auth.mdx
@@ -1,6 +1,6 @@
-To disable password-based authentication, navigate to `Admin > Config` add these two lines to your config:
+To turn off password-based authentication, navigate to `Admin > Config` add these two lines to your config:
 
-```yaml {3-4}
+```yaml {3-4} title="Disable password-based authentication"
 auth:
   oidc: ...             # This is your SSO configuration (make sure this is working!)
   password:

--- a/platform/_partials/auth/sso/dex/config.mdx
+++ b/platform/_partials/auth/sso/dex/config.mdx
@@ -1,6 +1,6 @@
-To tell vCluster Platform to use dex for SSO, navigate to `Admin > Config` in vCluster Platform and adjust your config as shown below:
+To tell the platform to use dex for SSO, navigate to `Admin > Config` in the platform and adjust your config as shown below:
 
-```yaml
+```yaml title="Platform OIDC config for dex"
 auth:
   oidc:
     issuerUrl: https://dex.mycompany.tld # Use $DEX_HOSTNAME (see above)

--- a/platform/_partials/auth/sso/dex/connectors/generic.mdx
+++ b/platform/_partials/auth/sso/dex/connectors/generic.mdx
@@ -1,5 +1,6 @@
 Create the file `dex-config.yaml` with the following dex configuration:
-```yaml {4,6,8,11-14}
+
+```yaml {4,6,8,11-14} title="dex-config.yaml"
 ingress:
   enabled: true
   hosts:

--- a/platform/_partials/auth/sso/dex/hostname.mdx
+++ b/platform/_partials/auth/sso/dex/hostname.mdx
@@ -1,6 +1,6 @@
-vCluster Platform uses the CNCF project dex for single sign-on.
+The platform uses the CNCF project [dex](https://dexidp.io/) for single sign-on.
 
 The easiest case is this one:
 
-- `$VCLUSTER_PRO_HOSTNAME = vcluster-platform.mycompany.tld` (where vCluster Platform is running)
+- `$VCLUSTER_PRO_HOSTNAME = vcluster-platform.mycompany.tld` (where platform is running)
 - `$DEX_HOSTNAME = dex.mycompany.tld` (where dex should be running)

--- a/platform/_partials/auth/sso/generic.mdx
+++ b/platform/_partials/auth/sso/generic.mdx
@@ -5,7 +5,7 @@ import DexConfigPartial from "./dex/config.mdx";
 import GenericDexConfigPartial from "./dex/connectors/generic.mdx";
 import DisablePasswordAuthPartial from "../disable-password-auth.mdx";
 
-vCluster Platform supports a variety of other auth providers. You can follow this generic guide to configure SSO for any of the auth providers, including:
+Platform supports a variety of other auth providers. You can follow this generic guide to configure SSO for any of the auth providers, including:
 
 - OpenShift
 - LinkedIn
@@ -38,16 +38,16 @@ vCluster Platform supports a variety of other auth providers. You can follow thi
 </Step>
 <Step>
 
-**Configure vCluster Platform To Use Dex For Authentication**
+**Configure the platform to use dex for authentication**
 
 <DexConfigPartial />
 
 </Step>
 <Step>
 
-**Authenticate via Dex + $OTHER_PROVIDER**
+**Authenticate via dex + $OTHER_PROVIDER**
 
-After saving the new vCluster Platform configuration, vCluster Platform will restart itself and you should be able to log in via $OTHER_PROVIDER and dex.
+After saving the new platform configuration, platform is going to restart itself and you should be able to log in via $OTHER_PROVIDER and dex.
 
 </Step>
 <Step>

--- a/platform/_partials/auth/sso/github.mdx
+++ b/platform/_partials/auth/sso/github.mdx
@@ -6,22 +6,33 @@ import DisablePasswordAuthPartial from "../disable-password-auth.mdx";
 
 **Create A GitHub App**
 
-In GitHub, navigate to `Settings > Developer Settings > OAuth Apps` and [create a new OAuth App](https://github.com/settings/applications/new) with the following settings:
+GitHub Apps allow external services to authenticate users through GitHub's OAuth system. To set up SSO for the platform, create a new OAuth App in GitHub:
 
-- Application name: vCluster Platform Login via GitHub
-- Homepage URL: https://vcluster-platform.yourcompany.tld = `https:// + $VCLUSTER_PRO_HOSTNAME`
-- Auth callback URL: https://vcluster-platform.yourcompany.tld/auth/github/callback = `https:// + $VCLUSTER_PRO_HOSTNAME + /auth/github/callback`
+- Navigate to `Settings > Developer Settings > OAuth Apps` in GitHub.
+- Click on [Create a new OAuth App](https://github.com/settings/applications/new).
+- Configure the OAuth App with the following settings:
 
-Remember the `$GITHUB_CLIENT_ID` and `$GITHUB_CLIENT_SECRET` that GitHub generates for your OAuth application because you will need it in the next step.
+   - Application name: Platform Login via GitHub
+   - Homepage URL: `https://$VCLUSTER_PRO_HOSTNAME`
+   - Authorization callback URL: `https://$VCLUSTER_PRO_HOSTNAME/auth/github/callback`
+
+- After creating the app, note the `$GITHUB_CLIENT_ID` and `$GITHUB_CLIENT_SECRET`. These is required in the next step.
+
+:::info
+Replace `$VCLUSTER_PRO_HOSTNAME` with your actual platform hostname.
+:::
 
 </Step>
 <Step>
 
-**Create vCluster Platform Config For GitHub**
+**Create platform config for GitHub**
 
-To tell vCluster Platform to use github for SSO, navigate to `Admin > Config` in vCluster Platform and adjust your config as shown below:
+To enable GitHub SSO for the platform, update the configuration:
 
-```yaml
+- Navigate to `Admin > Config` in the platform interface.
+- Adjust your configuration as shown below:
+
+```yaml title="GitHub SSO Configuration"
 auth:
   # Tell loft to use github authentication
   github:
@@ -31,9 +42,9 @@ auth:
     #
     #
     # ClientID of the github application. Can be string literal or pulled from the environment.
-    clientId: $CLIENTID
+    clientId: $GITHUB_CLIENT_ID
     # ClientSecret of the github application. Can be string literal or pulled from the environment.
-    clientSecret: $CLIENTSECRET
+    clientSecret: $GITHUB_CLIENT_SECRET
     # Callback URL in the form of https://your-loft-domain/auth/github/callback
     redirectURI: https://vcluster-platform.my.domain/auth/github/callback
     #
@@ -64,15 +75,29 @@ auth:
     rootCA: /certs/github.ca
 ```
 
+Configuration options explained:
+
+- `clientId`: The Client ID from the GitHub OAuth App.
+- `clientSecret`: The Client Secret from the GitHub OAuth App.
+- `redirectURI`: The Authorization callback URL specified in the GitHub OAuth App.
+- `orgs`: Specify GitHub organizations and teams allowed to access the platform.
+- `hostName`: Custom GitHub Enterprise hostname (if applicable).
+- `rootCA`: Path to a custom root certificate for GitHub Enterprise (if applicable).
+
 </Step>
 <Step>
 
 **Authenticate via GitHub**
 
-After saving the new vCluster Platform configuration, vCluster Platform will restart and you should be able to log in via GitHub. Beware that only members of your organization on GitHub can sign in and that everyone must grant access to view their organization during the login process.
+After saving the new configuration, the platform should restart. Users can now log in via GitHub:
 
-:::warning Must Grant Access To Organization
-Users **must** grant access to the organization you configured dex for in step 2 above, otherwise they will **not** be able to log in.
+- Access the platform login page.
+- Click on the "Login with GitHub" option.
+- Authenticate with GitHub credentials.
+- Grant the requested permissions to the GitHub OAuth App.
+
+:::warning
+Users **must** grant access to the organization configured in step 2. Without this access, they are not going to be able to log in.
 :::
 
 </Step>

--- a/platform/_partials/auth/sso/gitlab.mdx
+++ b/platform/_partials/auth/sso/gitlab.mdx
@@ -1,27 +1,35 @@
 import Flow, { Step } from "@site/src/components/Flow";
 import DisablePasswordAuthPartial from "../disable-password-auth.mdx";
 
+This guide explains how to integrate GitLab Single Sign-On (SSO) with the platform, allowing users to authenticate using their GitLab credentials.
+
 <Flow id="sso-gitlab">
 <Step>
 
 **Create A GitLab App**
 
-In GitLab, navigate to `User Settings > Applications` and create a new application with the following settings:
+Navigate to the [GitLab User Settings > Applications](https://gitlab.com/-/profile/applications) page and create a new application with the following settings:
 
-- Application name: vCluster Platform Login via GitLab
+- Application name: Platform Login via GitLab
 - Redirect URI: https://vcluster-platform.yourcompany.tld/auth/gitlab/callback = `https:// + $VCLUSTER_PRO_HOSTNAME + /auth/gitlab/callback`
 - Scopes: `read_user` + `openid`
 
-Remember the `$GITLAB_CLIENT_ID` and `$GITLAB_CLIENT_SECRET` that GitLab generates for your OAuth application because you will need it in the next step.
+:::info
+GitLab generates a `$GITLAB_CLIENT_ID` and `$GITLAB_CLIENT_SECRET` for your OAuth application. These credentials are required for the next step.
+:::
 
 </Step>
 <Step>
 
-**Create vCluster Platform Config For GitLab**
+**Create Platform config For GitLab**
 
-To tell vCluster Platform to use gitlab for SSO, navigate to `Admin > Config` in vCluster Platform and adjust your config as shown below:
+To set up GitLab SSO in the platform:
 
-```yaml
+- Access the platform's administrative interface.
+- Navigate to the `Admin > Config` section.
+- Modify your configuration as shown in the example below:
+
+```yaml title="GitLab SSO configuration"
 auth:
   # Tell loft to use gitlab authentication
   gitlab:
@@ -31,9 +39,9 @@ auth:
     #
     #
     # ClientID for the gitlab authentication. Can be string literal or pulled from the environment.
-    clientId: $CLIENTID
+    clientId: $GITLAB_CLIENT_ID
     # ClientSecret for the gitlab authentication. Can be string literal or pulled from the environment.
-    clientSecret: $CLIENTSECRET
+    clientSecret: $GITLAB_CLIENT_SECRET
     # Callback URL in the form of https://your-loft-domain/auth/gitlab/callback
     redirectURI: https://vcluster-platform.my.domain/auth/gitlab/callback
     #
@@ -59,7 +67,7 @@ auth:
 
 **Authenticate via GitLab**
 
-After saving the new vCluster Platform configuration, vCluster Platform will restart itself and you should be able to log in via GitLab.
+After saving the new configuration, the platform should restart automatically. Users can now log in using their GitLab credentials.
 
 </Step>
 <Step>

--- a/platform/_partials/auth/sso/google.mdx
+++ b/platform/_partials/auth/sso/google.mdx
@@ -1,16 +1,38 @@
 import Flow, { Step } from "@site/src/components/Flow";
 import DisablePasswordAuthPartial from "../disable-password-auth.mdx";
 
+## Introduction
+
+Google Single Sign-On (SSO) allows users to access the platform using their Google credentials. This integration enhances security and simplifies user management by leveraging Google's authentication infrastructure.
+
+## Prerequisites
+
+Before setting up Google SSO, ensure you have:
+
+- A Google Account with admin privileges
+- Administrator access to the platform
+- Access to GPC console for creating OAuth2.0 credentials
+
+## Configuration steps
+
 <Flow id="sso-google">
 <Step>
 
-**Create vCluster Platform Config For Google**
+**Create platform config for Google**
 
-vCluster Platform is able to use Google’s OpenID Connect provider as an authentication source.
+The platform can use Google's OpenID Connect provider as an authentication source.
 
-To tell vCluster Platform to use Google for SSO, navigate to `Admin > Config` in vCluster Platform and adjust your config as shown below:
+:::info Obtaining Google OAuth2.0 credentials
+To get the required `clientId` and `clientSecret`, follow these steps:
+- Go to the [GCP Console](https://console.cloud.google.com/)
+- Navigate to "APIs & Services" > "Credentials"
+- Click "Create Credentials" and select "OAuth client ID"
+- Follow the prompts to set up your OAuth consent screen and create your credentials
+:::
 
-```yaml
+To configure the platform to use Google for SSO, navigate to `Admin > Config` in the platform and adjust your config as shown below:
+
+```yaml title="Google SSO Configuration"
 auth:
   # Tell vCluster Platform to use google authentication
   google:
@@ -48,12 +70,27 @@ auth:
     adminEmail: myuser@mydomain.com
 ```
 
+:::warning Security best practice
+Always store sensitive information like `clientSecret` securely. Consider using environment variables or secure secret management solutions.
+:::
+
+:::note
+Replace the `redirectURI` with your actual domain where the platform is hosted.
+:::
+
 </Step>
 <Step>
 
 **Authenticate via Google**
 
-After saving the new vCluster Platform configuration, vCluster Platform will restart itself and you should be able to log in via Google.
+After saving the new configuration, the platform should restart itself. To authenticate:
+
+- Navigate to the platform login page
+- Click on the "Login with Google" button
+- You should be redirected to Google's login page
+- Enter your Google credentials
+- Grant the necessary permissions when prompted
+- You should be redirected back to the platform, now authenticated
 
 </Step>
 <Step>

--- a/platform/_partials/auth/sso/ldap.mdx
+++ b/platform/_partials/auth/sso/ldap.mdx
@@ -29,7 +29,7 @@ import DisablePasswordAuthPartial from "../disable-password-auth.mdx";
 </Step>
 <Step>
 
-**Configure vCluster Platform To Use Dex For Authentication**
+**Configure the platform to use dex for authentication**
 
 <DexConfigPartial />
 
@@ -38,7 +38,7 @@ import DisablePasswordAuthPartial from "../disable-password-auth.mdx";
 
 **Authenticate via Dex + LDAP**
 
-After saving the new vCluster Platform configuration, vCluster Platform will restart itself and you should be able to log in via LDAP and dex.
+After saving the new platform configuration, the platform is going to restart itself and you should be able to log in via LDAP and dex.
 
 </Step>
 <Step>

--- a/platform/_partials/auth/sso/microsoft.mdx
+++ b/platform/_partials/auth/sso/microsoft.mdx
@@ -4,26 +4,32 @@ import DisablePasswordAuthPartial from "../disable-password-auth.mdx";
 <Flow id="sso-ms">
 <Step>
 
-**Create vCluster Platform Config For Microsoft**
+**Create platform config for Microsoft**
 
-vCluster Platform is able to use Microsoft OAuth2 flow to identify the end user through their Microsoft account.
+The platform is able to use Microsoft Single Sign-On (SSO) OAuth2 flow to
+identify the end user through their Microsoft account.
 
 :::warning Tenant Must Be Specified in Microsoft Connector Config to Sync SSO Groups
-groups claim is only supported when tenant is specified in Microsoft connector config. Furthermore, tenant must also be configured to either `<tenant uuid> or <tenant name>`. In order for vCluster Platform to be able to list groups on behalf of logged in user, an explicit organization administrator consent is required. To obtain the consent do the following:
+groups claim is only supported when tenant is specified in Microsoft connector
+config. Furthermore, tenant must also be configured to either `<tenant uuid> or
+<tenant name>`. In order for the platform to be able to list groups on behalf of logged in user, an explicit organization administrator consent is required. To obtain the consent do the following:
 
-- when registering the vCluster Platform application on https://apps.dev.microsoft.com add an explicit Directory.Read.All permission to the list of Delegated Permissions
-- open the following link in your browser and log in under organization administrator account:
+The platform can use Microsoft OAuth2 flow to identify end users through their Microsoft accounts.
+
+The groups claim is only supported when the tenant is specified in the Microsoft connector config. The tenant must be configured to either `<tenant uuid>` or `<tenant name>`. For the platform to list groups on behalf of the logged-in user, explicit organization administrator consent is required. To obtain consent:
+
+- When registering the platform application on https://apps.dev.microsoft.com, add an explicit Directory.Read.All permission to the list of Delegated Permissions.
+- Open the following link in your browser and log in under an organization administrator account:
 
 `https://login.microsoftonline.com/<tenant>/adminconsent?client_id=<client id>`
 
 :::
 
+To configure the platform to use Microsoft for SSO, navigate to `Admin > Config` in the platform and adjust your config as shown below:
 
-To tell vCluster Platform to use Microsoft for SSO, navigate to `Admin > Config` in vCluster Platform and adjust your config as shown below:
-
-```yaml
+```yaml title="Microsoft SSO configuration"
 auth:
-  # Tell vCluster Platform to use microsoft authentication
+  # Tell the platform to use microsoft authentication
   microsoft:
     #
     #
@@ -62,12 +68,31 @@ auth:
     useGroupsAsWhitelist: false
 ```
 
+:::info Optional configuration parameters
+- `tenant`: Controls what kinds of accounts may be authenticated. Options include:
+  - `common`: Both personal and business accounts (default)
+  - `consumers`: Only personal accounts
+  - `organizations`: Only business/school accounts
+  - `'tenant uuid'` or `'tenant name'`: Only accounts belonging to a specific tenant
+- `groups`: Require users to be members of specific groups for authentication
+- `onlySecurityGroups`: Restricts the list to include only security groups
+- `useGroupsAsWhitelist`: Restricts the groups claims to include only the user's groups that are in the configured groups
+:::
+
+:::tip Obtaining ClientID and ClientSecret
+To obtain the `$CLIENTID` and `$CLIENTSECRET` values:
+- Register your application in the Azure Portal
+- Navigate to "App registrations"
+- Select your application and find the "Application (client) ID" for `$CLIENTID`
+- Under "Certificates & secrets", create a new client secret for `$CLIENTSECRET`
+:::
+
 </Step>
 <Step>
 
 **Authenticate via Microsoft**
 
-After saving the new vCluster Platform configuration, vCluster Platform will restart itself and you should be able to log in via Microsoft.
+After saving the new platform configuration, the platform should restart. Users should then be able to log in via Microsoft.
 
 </Step>
 <Step>

--- a/platform/_partials/auth/sso/oidc.mdx
+++ b/platform/_partials/auth/sso/oidc.mdx
@@ -1,16 +1,25 @@
 import Flow, { Step } from "@site/src/components/Flow";
 import DisablePasswordAuthPartial from "../disable-password-auth.mdx";
 
+## OIDC authentication
+
+[OpenID Connect Specification](https://openid.net/specs/openid-connect-core-1_0.html) is an authentication layer built on top of OAuth 2.0, providing secure and standardized user authentication for applications. Implementing OIDC in the platform offers several benefits:
+
+- Enhanced security through token-based authentication
+- Simplified user management with centralized identity providers
+- Improved user experience with `single sign-on` (SSO) capabilities
+
 <Flow id="sso-oidc">
 <Step>
 
-**Create vCluster Platform Config For OIDC**
+**Create platform config for OIDC**
 
-vCluster Platform is able to use an OIDC provider as an authentication source.
+To configure OIDC for SSO, follow these steps:
 
-To tell vCluster Platform to use OIDC for SSO, navigate to `Admin > Config` in vCluster Platform and adjust your config as shown below:
+- Navigate to `Admin > Config` in the platform.
+- Adjust your configuration as shown in the example below.
 
-```yaml
+```yaml title="Platform OIDC configuration"
 auth:
   # Tell vCluster Platform to allow OIDC for authentication
   oidc:
@@ -66,12 +75,19 @@ auth:
     preferredUsername: "preferred_username"
 ```
 
+:::info Obtaining OIDC credentials
+To obtain the required `clientId` and `clientSecret`, refer to your OIDC provider's documentation. Common providers include:
+- [Google Identity](https://developers.google.com/identity/openid-connect/openid-connect)
+- [Okta OpenID](https://developer.okta.com/docs/concepts/oauth-openid/)
+- [Keycloak](https://www.keycloak.org/documentation)
+:::
+
 </Step>
 <Step>
 
 **Authenticate via OIDC**
 
-After saving the new vCluster Platform configuration, vCluster Platform will restart itself and you should be able to log in via your OIDC provider.
+After saving the new configuration, the platform should restart. You should then be able to log in via your OIDC provider.
 
 </Step>
 <Step>

--- a/platform/_partials/auth/sso/okta.mdx
+++ b/platform/_partials/auth/sso/okta.mdx
@@ -1,44 +1,48 @@
 import Flow, { Step } from "@site/src/components/Flow";
 import DisablePasswordAuthPartial from "../disable-password-auth.mdx";
 
+This guide walks you through the process of setting up Single Sign-On (SSO) with Okta for the platform. By following these steps, you'll enable seamless authentication for your users through Okta.
+
 <Flow id="sso-okta">
 <Step>
 
 **Create A New App In Okta**
 
-The first step is to create a new Okta App for vCluster Platform.
+Start by creating a new Okta App for the platform.
 
 <figure class="frame">
   <img
     src={require("@site/static/media/platform/v1/ui/auth/create-app-okta.png").default}
-    alt="Create App for vCluster Platform"
+    alt="Create App for the platform"
   />
   <figcaption>Okta - Create a new App in Okta</figcaption>
 </figure>
 
-Next select "Web" App and make sure OpenID Connect is the single sign on method.
+<!-- vale off -->
+Select "Web" App and ensure OpenID Connect is the single sign-on method.
+<!-- vale on -->
 
 <figure class="frame">
   <img
     src={require("@site/static/media/platform/v1/ui/auth/okta-select-web.png").default}
-    alt="Create App for vCluster Platform"
+    alt="Create App for the platform"
   />
   <figcaption>
     Okta - Web App with OpenID Connect as single sign on method
   </figcaption>
 </figure>
 
-In the next screen make sure the login redirect URIs contain your vCluster Platform instance domain:
+On the next screen, configure the login redirect URIs to include your platform instance domain:
 
-```bash
-# Exchange the ${my-loft-domain.com} with your vCluster Platform domain
+```bash title="Configure login redirect URI"
+# Replace ${my-loft-domain.com} with your platform domain
 https://${my-loft-domain.com}/auth/oidc/callback
 ```
 
 <figure class="frame">
   <img src={require("@site/static/media/platform/v1/ui/auth/okta-app-settings.png").default}
-   alt="Create App for vCluster Platform" />
-  <figcaption>Okta - The App settings for vCluster Platform</figcaption>
+   alt="Create App for the platform" />
+  <figcaption>Okta - The App settings for the platform</figcaption>
 </figure>
 </Step>
 
@@ -46,12 +50,12 @@ https://${my-loft-domain.com}/auth/oidc/callback
 
 **Enable Refresh Tokens**
 
-After creating an Okta app for vCluster Platform, ensure that "Refresh Token" is checked under "Allowed grant types" - otherwise your users will have to re-login everytime after a session expires.
+After creating the Okta app for the platform, enable "Refresh Token" under "Allowed grant types". This step is crucial as it allows users to maintain their session without frequent re-logins.
 
 <figure class="frame">
   <img
     src={require("@site/static/media/platform/v1/ui/auth/okta-refresh-token.png").default}
-    alt="Create App for vCluster Platform"
+    alt="Create App for the platform"
   />
   <figcaption>Okta - App Settings: Enable Refresh Tokens</figcaption>
 </figure>
@@ -61,49 +65,51 @@ After creating an Okta app for vCluster Platform, ensure that "Refresh Token" is
 
 **Enable Group Claims**
 
-If you want to propagate the users groups to vCluster Platform, then make sure the Group Filters in Okta are set accordingly. If you want to propagate all groups, add a RegEx filter with '.\*'
+If you want to propagate the users groups to the platform, then make sure the Group Filters in Okta are set accordingly. If you want to propagate all groups, add a RegEx filter with '.\*'
 
 <figure class="frame">
   <img
     src={require("@site/static/media/platform/v1/ui/auth/okta-group-filter.png").default}
-    alt="Okta Assign Peoples"
+    alt="Okta Assign People"
   />
-  <figcaption>Okta - Propagate User Groups To vCluster Platform</figcaption>
+  <figcaption>Okta - Propagate User Groups To the platform</figcaption>
 </figure>
 
 </Step>
 <Step>
 
-**Configure vCluster Platform To Use Okta**
+**Configure platform to use Okta**
 
 <figure class="frame">
   <img
     src={require("@site/static/media/platform/v1/ui/auth/okta-client-secret.png").default}
-    alt="Create App for vCluster Platform"
+    alt="Create App for the platform"
   />
   <figcaption>Okta - Client ID and Secret For App</figcaption>
 </figure>
 
-After configuring Okta for vCluster Platform, navigate to `Admin > Config` in vCluster Platform and enter the following configuration:
+Navigate to `Admin > Config` in the platform and enter the following configuration:
 
-```yaml
+```yaml title="Configure the platform for Okta integration"
 auth:
   oidc:
     issuerUrl: "https://${MY-OKTA-SUBDOMAIN}.okta.com"
     clientId: CLIENT_ID
     clientSecret: CLIENT_SECRET
     groupsClaim: groups
-    # This is needed because okta uses thin id tokens
+    # This is needed because Okta uses thin id tokens
     # that do not contain the groups directly
     getUserInfo: true
 ```
+
+The `groupsClaim` field specifies where to find group information in the token, and `getUserInfo` is set to `true` to retrieve additional user information from Okta.
 
 <figure class="frame">
   <img
     src={require("@site/static/media/platform/v1/ui/auth/okta-loft-config.png").default}
     alt="Okta Assign Peoples"
   />
-  <figcaption>vCluster Platform - Configure vCluster Platform To Use Okta</figcaption>
+  <figcaption>Configure the platform To Use Okta</figcaption>
 </figure>
 
 </Step>
@@ -111,21 +117,21 @@ auth:
 
 **Add Users via Okta Assigments**
 
-Please make also sure that you have assigned the correct Users and Groups that you would like to access vCluster Platform in Okta.
+Assign the appropriate Users and Groups to access the platform in Okta.
 
 <figure class="frame">
   <img
     src={require("@site/static/media/platform/v1/ui/auth/okta-assign-people.png").default}
-    alt="Okta Assign Peoples"
+    alt="Okta Assign People"
   />
-  <figcaption>Okta - Assign Users &amp; Groups To vCluster Platform</figcaption>
+  <figcaption>Okta - Assign Users &amp; Groups To the platform</figcaption>
 </figure>
 
-After users or their groups are assigned to vCluster Platform, they will be able to log in via Okta:
+Once users or their groups are assigned to the platform, they can log in via Okta:
 
 <figure class="frame">
-  <img src={require("@site/static/media/platform/v1/ui/auth/okta-loft-login.png").default} alt="Okta Assign Peoples" />
-  <figcaption>vCluster Platform - SSO via Okta</figcaption>
+  <img src={require("@site/static/media/platform/v1/ui/auth/okta-loft-login.png").default} alt="Okta Assign People" />
+  <figcaption>The platform - SSO via Okta</figcaption>
 </figure>
 </Step>
 

--- a/platform/_partials/auth/sso/saml.mdx
+++ b/platform/_partials/auth/sso/saml.mdx
@@ -1,19 +1,28 @@
 import Flow, { Step } from "@site/src/components/Flow";
 import DisablePasswordAuthPartial from "../disable-password-auth.mdx";
 
-:::caution Refresh Tokens
-The SAML 2.0 connector in vCluster Platform does **not** support refresh tokens "since the SAML 2.0 protocol doesn't provide a way to requery a provider without interaction" (see [dex documentation for SAML 2.0](https://dexidp.io/docs/connectors/saml/)).
+<!-- vale off -->
+## Introduction to SAML authentication
+<!-- vale on -->
+
+[Security Assertion Markup Language (SAML)
+Specification](https://saml.xml.org/saml-specifications) is an open standard for exchanging authentication and authorization data between parties, particularly between an identity provider and a service provider. SAML is useful for implementing secure single sign-on (SSO) in enterprise environments, allowing users to access multiple applications with a single set of credentials.
+
+:::caution Refresh tokens are not supported
+The SAML 2.0 connector in the platform does not support refresh tokens as the SAML 2.0 protocol does not provide a way to requery a provider without interaction. For more information, see the [dex documentation for SAML 2.0](https://dexidp.io/docs/connectors/saml/).
 :::
 
 <Flow id="sso-saml">
 <Step>
-**Create vCluster Platform Config For SAML v2.0**
+**Create platform Config For SAML v2.0**
 
-vCluster Platform is able to use SAML v2.0 flow to identify the end user.
+The platform can use SAML v2.0 flow to identify the end user. To configure the platform to use SAML for SSO, follow these steps:
 
-To tell vCluster Platform to use SAML for SSO, navigate to `Admin > Config` in vCluster Platform and adjust your config as shown below:
+1. Navigate to `Admin > Config` in the platform.
+2. Adjust your configuration as shown in the example below.
+3. Obtain the necessary values from your SAML identity provider (IdP) for the required fields.
 
-```yaml
+```yaml title="Configure the platform to use SAML"
 auth:
   # Tell vCluster Platform to use saml authentication
   saml:
@@ -26,9 +35,8 @@ auth:
     ssoURL: https://saml.example.com/sso
     # CA to use when validating the signature of the SAML response.
     ca: /path/to/ca.pem
-    # CA's can also be provided inline as a base64'd blob.
-    #
-    # caData: ( RAW base64'd PEM encoded CA )
+    # Alternatively, CA can be provided inline as a base64-encoded blob
+    # caData: (RAW base64-encoded PEM encoded CA)
     # Callback URL in the form of https://your-vcluster-platform-domain/auth/saml/callback
     redirectURI: https://vcluster-platform.my.domain/auth/saml/callback
     # Name of attributes in the returned assertions to map to ID token claims.
@@ -82,7 +90,9 @@ auth:
 
 **Authenticate via SAML**
 
-After saving the new vCluster Platform configuration, vCluster Platform will restart itself and you should be able to log in via SAML.
+1. The platform should restart automatically.
+2. You should now be able to log in via SAML.
+3. Test the authentication by logging out and logging back in.
 
 </Step>
 <Step>

--- a/platform/_partials/install/multiple-sso.mdx
+++ b/platform/_partials/install/multiple-sso.mdx
@@ -1,12 +1,14 @@
-In vCluster Platform, you can also configure _multiple_ SSO providers together. This can be a very handy feature if you
-have multiple groups using different authentication providers based on team or geographical
-region. Configuration of multiple SSO providers _of the same type_ is also possible.
-The latter is configured by using the "connectors" option. Below is an example vCluster Platform config "auth"
-section that contains three SSO providers (one OIDC, and two GitHub providers). When users log
-into vCluster Platform with such a configuration present, they will see three options for authentication as
-well as the default user/password box (which can be disabled if desired).
+In the Platform, you can also configure _multiple_ SSO providers together. This
+can be a very handy feature if you have multiple groups using different
+authentication providers based on team or geographical region. Configuration of
+multiple SSO providers _of the same type_ is also possible. The latter is
+configured by using the "connectors" option. Below is an example platform config
+"auth" section that contains three SSO providers (one OIDC, and two GitHub
+providers). Users logging into the platform with such a configuration present
+see three options for authentication as well as the default username/password
+box (which you can turn off if desired).
 
-```yaml
+```yaml title="platform-config.yaml with multiple SSO providers"
 auth:
   github:
     clientId: test123

--- a/platform/configure/single-sign-on/group-sync.mdx
+++ b/platform/configure/single-sign-on/group-sync.mdx
@@ -1,7 +1,8 @@
 ---
 title: SSO Group Sync
 sidebar_label: SSO Group Sync
-sidebar_position: 4 
+sidebar_position: 4
+description: Learn how to configure and use SSO Group Sync in the platform for efficient user authentication and team management.
 ---
 
 import Flow, { Step } from "@site/src/components/Flow";
@@ -9,26 +10,25 @@ import NavStep from "@site/src/components/NavStep";
 import Button from "@site/src/components/Button";
 import Label from "@site/src/components/Label";
 
-vCluster Platform can be configured to allow for user authentication via Single-Sign-On (SSO). This feature
-allows for users who have a valid account on some other service (ex: GitHub), to authenticate
-and log into vCluster Platform via that service. This is a great way for administrators to not need to
-manage individual users, however administrators still need a mechanism in place to ensure that
-these users have appropriate permissions applied. That is where SSO groups come into play.
+The platform can be configured to allow user authentication via Single-Sign-On (SSO). SSO is an authentication method that enables users to access multiple applications with a single set of login credentials. This feature allows users with a valid account on another service (e.g., GitHub) to authenticate and log into the platform using that service. While this approach simplifies user management for administrators, a mechanism is still needed to ensure appropriate permissions are applied to these users. SSO groups address this need.
 
-Most, if not all, SSO providers allow for administrators of that service to configure data that
-is shared with platforms authenticating against the provider. Perhaps most important of this
-shared data, is a list of groups of which the authenticating user is a part of. Upon
-authentication via SSO in vCluster Platform, this group data is inspected, the user is automatically joined to any
-Teams that include any of the provided group names in the `SSO Groups as Members` field.
-Any SSO group names that are not set in any Team's `SSO Groups as Members` field will be
-dynamically created as a new Team, with the group name automatically set in the `SSO Groups as Members` field.
+Most SSO providers allow administrators to configure data shared with
+authenticating platforms. Among this shared data, the list of groups to which
+the authenticating user belongs is particularly important. Upon SSO
+authentication in the platform, this group data is inspected. The user is
+automatically joined to any Teams that include any of the provided group names
+in the `SSO Groups as Members` field. Any SSO group names not set in any Team's
+`SSO Groups as Members` field is going to be dynamically created as a new Team, with the group name automatically set in the `SSO Groups as Members` field.
 
-This group behavior allows administrators to create Teams in vCluster Platform that correspond to teams (groups) in
-the SSO identity provider, set the appropriate policy for those Teams in vCluster Platform, and for users to be
-automatically assigned the appropriate team, and thus privileges, upon logging in via SSO.
+This group behavior allows administrators to create Teams in the platform that correspond to teams (groups) in the SSO identity provider, set the appropriate policy for those Teams, and enable users to be automatically assigned to the appropriate team, and thus privileges, upon logging in via SSO.
 
-## Creating a Team With SSO Group Membership
+:::info
+If a user belongs to multiple SSO groups that correspond to different Teams in
+the platform, they are going to be added to all matching Teams.
+:::
 
+## Creating a team with SSO group membership
+<!-- vale off -->
 <Flow id="create-team-with-sso-group-membership">
   <Step>
     Select the <NavStep>Users</NavStep> field on the left menu bar.
@@ -41,17 +41,18 @@ automatically assigned the appropriate team, and thus privileges, upon logging i
   </Step>
   <Step>
     In the drawer that appears from the right, give your new team a name by
-    replacing the 'my-team' placeholder name, or by updating the manifest YAML
+    replacing the  'my-team' placeholder name, or by updating the manifest YAML
     'metadata.name' field.
   </Step>
   <Step>
     In the <Label>Team Members</Label> tab enter any desired groups into the{" "}
     <Label>SSO Groups as Members</Label> field. You can add as many groups as
     you would like here. These group names must exactly match the group name
-    that the SSO provider shares with vCluster Platform during SSO authentication.
+    that the SSO provider shares with the platform during SSO authentication.
   </Step>
   <Step>Make any additional desired modifications to your new Team.</Step>
   <Step>
     Click on the <Button>Save Changes</Button> button.
   </Step>
 </Flow>
+<!-- vale on -->

--- a/platform/configure/single-sign-on/overview.mdx
+++ b/platform/configure/single-sign-on/overview.mdx
@@ -16,16 +16,19 @@ import PartialAuthOther from "../../_partials/auth/sso/generic.mdx";
 
 import PartialMultipleSSO from "../../_partials/install/multiple-sso.mdx";
 
-vCluster Platform supports all major Single-Sign-On (SSO) providers. To configure SSO for vCluster Platform, expand the
+The platform supports all major Single-Sign-On (SSO) providers. To configure SSO
+for the platform, expand the
 desired SSO provider (for example Google, Okta, GitHub) field listed below and follow the instructions
 provided.
 
 :::caution Domain Required
 Most SSO provider connections do not allow `localhost` and require that you
-[set up a domain for your vCluster Platform instance](../domain.mdx) first.
+[set up a domain for your platform instance](../domain.mdx) first.
 :::
 
-## SSO Configuration Examples
+<!-- vale off -->
+## SSO configuration examples
+<!-- vale on -->
 
 <details>
   <summary>GitHub</summary>
@@ -72,6 +75,8 @@ Most SSO provider connections do not allow `localhost` and require that you
   <PartialAuthOther />
 </details>
 
-## Multiple SSO Providers
+<!-- vale off -->
+## Multiple SSO providers
+<!-- vale on -->
 
 <PartialMultipleSSO />


### PR DESCRIPTION
Closes DOC-279, DOC-280, DOC-281, DOC-282

```text
- Single Sign On (SSO)
  - Overview
  - SSO Providers
    - GitHub
    - GitLab
    - Google
    - LDAP
    - Microsoft
    - Okta
    - OpenID Connect
    - Other (Dex)
    - SAML
  - Multiple SSO Providers
  - SSO Group Sync
```

[SSO Section Preview](https://deploy-preview-305--vcluster-docs-site.netlify.app/docs/platform/configure/single-sign-on/overview)

> [!IMPORTANT]
> https://github.com/loft-sh/vcluster-docs/pull/303 must be merged first