### PR TITLE
fix: file detection and reviewdog configuration

### DIFF
--- a/.github/workflows/reviewdog.yaml
+++ b/.github/workflows/reviewdog.yaml
@@ -53,6 +53,7 @@ jobs:
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           sha: ${{ github.event.pull_request.head.sha }}
+          separator: ","
           files: |
             platform/**/*.mdx
             platform/**/*.md
@@ -75,3 +76,5 @@ jobs:
           reporter: github-pr-review
           version: 3.7.1
           files: ${{ steps.changed-files.outputs.all_changed_files }}
+          separator: ","
+          filter_mode: file


### PR DESCRIPTION
- using space as separator (default) didn't work with reviewdog
- swapping to comma as separator helpd solve the issue where reviewdog action was not able to parse the files correctly
- setting filter_mode to `file` forces reviewdog to report all errors before  exiting with 0