### PR TITLE
dx: Add info box containing version change in FIPS docs

### DIFF
--- a/vcluster/deploy/security/fips.mdx
+++ b/vcluster/deploy/security/fips.mdx
@@ -30,7 +30,7 @@ more details.
 NIST validates [Google's BoringCrypto](https://boringssl.googlesource.com/boringssl/+/master/crypto/fipsmodule/FIPS.md)
 modules on a wide range of systems.
 
-### FIPS Support in vCluster Components
+### FIPS Support In vCluster Components
 
 Most of the components used in vCluster are statically compiled with the
 boringcrypto Go compiler. vCluster, from a components perspective, contains
@@ -48,7 +48,7 @@ The list below contains components built in a FIPS-compliant manner:
 
 :::caution
 vCluster Pro currently does not provide FIPS-compliant builds of
-CoreDNS or Helm. One will have to use the integrated CoreDNS feature
+CoreDNS or Helm. One must use the integrated CoreDNS feature
 of vCluster Pro.
 :::
 
@@ -58,7 +58,7 @@ The vCluster Pro FIPS-compliant images can be found in our [GitHub Container Reg
 
 ## Running vCluster FIPS-compliant
 
-To run vCluster in a FIPS environment, one will have to reconfigure the
+To run vCluster in a FIPS environment, one has to reconfigure the
 repositories used to reference the FIPS images and enable CoreDNS.
 
 The following is an example of a `vcluster.yaml` file that one can use to create
@@ -104,3 +104,16 @@ And run:
 ```bash
 vcluster create my-fips-vcluster -f vcluster.yaml
 ```
+
+:::info
+If you wish to configure a different Kubernetes version in your virtual cluster
+than the current host cluster version, you can do so by setting the `controlPlane.distro.k8s.version`.
+
+```yaml
+controlPlane:
+  distro:
+    k8s:
+      version: v1.31.1 # or v1.28.14
+```
+
+:::

--- a/vcluster/deploy/security/fips.mdx
+++ b/vcluster/deploy/security/fips.mdx
@@ -30,7 +30,7 @@ more details.
 NIST validates [Google's BoringCrypto](https://boringssl.googlesource.com/boringssl/+/master/crypto/fipsmodule/FIPS.md)
 modules on a wide range of systems.
 
-### FIPS Support In vCluster Components
+### FIPS support in vCluster components
 
 Most of the components used in vCluster are statically compiled with the
 boringcrypto Go compiler. vCluster, from a components perspective, contains


### PR DESCRIPTION
Fixes ENG-4916

Changed page:
- https://deploy-preview-328--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/security/fips#running-vcluster-fips-compliant