### PR TITLE
Update wrong release url

### DIFF
--- a/vcluster/_partials/deploy/install-cli-beta.mdx
+++ b/vcluster/_partials/deploy/install-cli-beta.mdx
@@ -27,7 +27,7 @@ import TabItem from "@theme/TabItem";
 
 
 ```bash
-curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/<VCLUSTER_VERSION>/download/vcluster-darwin-amd64" && sudo install -c -m 0755 vcluster /usr/local/bin && rm -f vcluster
+curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/download/<VCLUSTER_VERSION>/vcluster-darwin-amd64" && sudo install -c -m 0755 vcluster /usr/local/bin && rm -f vcluster
 ```
 
 Replace `<VCLUSTER_VERSION>` with the version you want to download.
@@ -36,7 +36,7 @@ Replace `<VCLUSTER_VERSION>` with the version you want to download.
 <TabItem value="mac-arm">
 
 ```bash
-curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/<VCLUSTER_VERSION>/download/vcluster-darwin-arm64" && sudo install -c -m 0755 vcluster /usr/local/bin && rm -f vcluster
+curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/download/<VCLUSTER_VERSION>/vcluster-darwin-arm64" && sudo install -c -m 0755 vcluster /usr/local/bin && rm -f vcluster
 ```
 
 Replace `<VCLUSTER_VERSION>` with the version you want to download.
@@ -45,7 +45,7 @@ Replace `<VCLUSTER_VERSION>` with the version you want to download.
 <TabItem value="linux">
 
 ```bash
-curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/<VCLUSTER_VERSION>/download/vcluster-linux-amd64" && sudo install -c -m 0755 vcluster /usr/local/bin && rm -f vcluster
+curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/download/<VCLUSTER_VERSION>/vcluster-linux-amd64" && sudo install -c -m 0755 vcluster /usr/local/bin && rm -f vcluster
 ```
 
 Replace `<VCLUSTER_VERSION>` with the version you want to download.
@@ -54,7 +54,7 @@ Replace `<VCLUSTER_VERSION>` with the version you want to download.
 <TabItem value="linux-arm">
 
 ```bash
-curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/<VCLUSTER_VERSION>/download/vcluster-linux-arm64" && sudo install -c -m 0755 vcluster /usr/local/bin && rm -f vcluster
+curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/download/<VCLUSTER_VERSION>/vcluster-linux-arm64" && sudo install -c -m 0755 vcluster /usr/local/bin && rm -f vcluster
 ```
 
 Replace `<VCLUSTER_VERSION>` with the version you want to download.
@@ -67,7 +67,7 @@ Replace `<VCLUSTER_VERSION>` with the version you want to download.
 
 ```powershell {4}
 md -Force "$Env:APPDATA\vcluster"; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12';
-Invoke-WebRequest -URI "https://github.com/loft-sh/vcluster/releases/<VCLUSTER_VERSION>/download/vcluster-windows-amd64.exe" -o $Env:APPDATA\vcluster\vcluster.exe;
+Invoke-WebRequest -URI "https://github.com/loft-sh/vcluster/releases/download/<VCLUSTER_VERSION>/vcluster-windows-amd64.exe" -o $Env:APPDATA\vcluster\vcluster.exe;
 $env:Path += ";" + $Env:APPDATA + "\vcluster";
 [Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::User);
 ```


### PR DESCRIPTION
Not sure why its different the usual ones where downloads are after the tag :/

Found this while trying to install. 