### PR TITLE
Update workload service account page

### DIFF
--- a/vcluster/configure/vcluster-yaml/control-plane/other/advanced/workload-service-account.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/other/advanced/workload-service-account.mdx
@@ -10,7 +10,7 @@ import WorkloadServiceAccount from '../../../../../_partials/config/controlPlane
 This has similar usage to `controlPlane.advanced.serviceAccount` but for use with workloads deployed to the virtual cluster.
 
 :::info
-If you also enable [syncing ServiceAccount resources from the virtual cluster to the host cluster](../../../sync/to-host/advanced/service-accounts.mdx), then the `workloadServiceAccount` will be ignored.
+If [syncing ServiceAccount resources from the virtual cluster to the host cluster](../../../sync/to-host/advanced/service-accounts.mdx) is enabled, the `workloadServiceAccount` setting is ignored.
 :::
 
 ## Config reference

--- a/vcluster/configure/vcluster-yaml/control-plane/other/advanced/workload-service-account.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/other/advanced/workload-service-account.mdx
@@ -9,6 +9,10 @@ import WorkloadServiceAccount from '../../../../../_partials/config/controlPlane
 
 This has similar usage to `controlPlane.advanced.serviceAccount` but for use with workloads deployed to the virtual cluster.
 
+:::info
+If you also enable [syncing ServiceAccount resources from the virtual cluster to the host cluster](../../../sync/to-host/advanced/service-accounts.mdx), then the `workloadServiceAccount` will be ignored.
+:::
+
 ## Config reference
 
 <WorkloadServiceAccount/>

--- a/vcluster/configure/vcluster-yaml/control-plane/other/advanced/workload-service-account.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/other/advanced/workload-service-account.mdx
@@ -7,7 +7,7 @@ description: Configuration for ...
 
 import WorkloadServiceAccount from '../../../../../_partials/config/controlPlane/advanced/workloadServiceAccount.mdx'
 
-This has similar usage to `controlPlane.deployment.advanced.serviceAccount` but for use with workloads deployed to the virtual cluster.
+This has similar usage to `controlPlane.advanced.serviceAccount` but for use with workloads deployed to the virtual cluster.
 
 ## Config reference
 


### PR DESCRIPTION
Call out that these configuration is overridden by the `sync.toHost.serviceAccounts: enabled` configuration.