### PR TITLE
chore: github icon points to the vcluster repo instead of docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -186,7 +186,7 @@ const config = {
             position: "right",
           },
           {
-            href: "https://github.com/loft-sh/vcluster-docs",
+            href: "https://github.com/loft-sh/vcluster",
             className: "github-link",
             "aria-label": "GitHub",
             position: "right",


### PR DESCRIPTION
Closes DOC-328

[Docs Preview](https://deploy-preview-342--vcluster-docs-site.netlify.app/docs/)