### PR TITLE
feat: add warning about deploying external charts in airgapped environments

### DIFF
--- a/platform/install/advanced/air-gapped.mdx
+++ b/platform/install/advanced/air-gapped.mdx
@@ -69,6 +69,11 @@ accessible to your cluster.
 
 For clusters unable to pull images from Docker Hub, you need to push the platform images to your private registry. Each platform release includes a `loft-images.txt` file that lists the necessary images.
 
+:::warning
+When using virtual clusters in air-gapped environments, the
+`config.experimental.deploy.vcluster.helm` [configuration setting](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster) does not work with external Helm repositories since they cannot be accessed. This means custom Helm charts from repositories like `charts.bitnami.com` cannot be used for virtual cluster deployments.
+:::
+
 Follow these instructions to download all platform images and import them to your private registry:
 
 <Flow id="offline-images">


### PR DESCRIPTION
Closed DOC-325

Docs Preview: https://deploy-preview-345--vcluster-docs-site.netlify.app/docs/platform/install/advanced/air-gapped#offline-images