### PR TITLE
feat: clarify supported kubernetes versions for airgapped installation

### DIFF
--- a/platform/install/advanced/air-gapped.mdx
+++ b/platform/install/advanced/air-gapped.mdx
@@ -41,8 +41,11 @@ accessible to your cluster.
 
 ### Supported Kubernetes versions
 
-<!-- TODO:(piotr1215) figure out which versions are supported -->
-- A running air-gapped Kubernetes cluster `v1.26.x`, `v1.27.x`, or `v1.28.x`
+- A running air-gapped Kubernetes cluster with one of the supported versions: `v1.30.x`, `v1.31.x`, or `v1.32.x`
+
+:::note
+Although the platform may work with other versions, using the supported versions is recommended to avoid potential issues.
+:::
 
 ### Resource requirements
 


### PR DESCRIPTION
Closes DOC-334

Docs Preview: https://deploy-preview-346--vcluster-docs-site.netlify.app/docs/platform/install/advanced/air-gapped#supported-kubernetes-versions
