### PR TITLE
chore: add exception to vale rule for capitalization

### DIFF
--- a/.github/styles/Google/Headings.yml
+++ b/.github/styles/Google/Headings.yml
@@ -28,3 +28,4 @@ exceptions:
   - Windows
   - JSON
   - vCluster
+  - \bPro\b


### PR DESCRIPTION
Exclude `Pro` from capitalization requirement in the Markdown headings.

Closes DOC-341