### PR TITLE
docs: adding info about etcd migration path for pro users

### DIFF
--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/deploy.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/deploy.mdx
@@ -7,6 +7,9 @@ description: Configure an external etcd instance as the virtual cluster's backin
 
 import ConfigReference from '../../../../../../_partials/config/controlPlane/backingStore/etcd/deploy.mdx'
 
+import ProAdmonition from '../../../../../../_partials/admonitions/pro-admonition.mdx';
+
+
 Enabling this feature deploys [etcd](https://etcd.io/) on the host cluster in the same namespace as the virtual cluster and configures the control plane to use it as the backing store. vCluster deploys etcd with a `StatefulSet`, `Service`, and headless `Service`.
 ```yaml
 controlPlane:
@@ -53,6 +56,13 @@ controlPlane:
 :::warning
 After deploying your vCluster, changing the backing store of vCluster is not supported.
 :::
+
+### Migrate to embedded etcd
+
+<ProAdmonition />
+
+For vCluster Pro users, it is possible to migrate the backing store of a virtual
+cluster from the external to [embedded etcd](https://www.vcluster.com/docs/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded#embedded) `controlPlane.backingstore.etcd.embedded`.
 
 ## Config reference
 

--- a/vcluster_versioned_docs/version-0.21.0/configure/vcluster-yaml/control-plane/components/backing-store/etcd/deploy.mdx
+++ b/vcluster_versioned_docs/version-0.21.0/configure/vcluster-yaml/control-plane/components/backing-store/etcd/deploy.mdx
@@ -7,6 +7,9 @@ description: Configure an external etcd instance as the virtual cluster's backin
 
 import ConfigReference from '../../../../../../_partials/config/controlPlane/backingStore/etcd/deploy.mdx'
 
+import ProAdmonition from '../../../../../../_partials/admonitions/pro-admonition.mdx';
+
+
 Enabling this feature deploys [etcd](https://etcd.io/) on the host cluster in the same namespace as the virtual cluster and configures the control plane to use it as the backing store. vCluster deploys etcd with a `StatefulSet`, `Service`, and headless `Service`.
 ```yaml
 controlPlane:
@@ -53,6 +56,13 @@ controlPlane:
 :::warning
 After deploying your vCluster, changing the backing store of vCluster is not supported.
 :::
+
+### Migrate to embedded etcd
+
+<ProAdmonition />
+
+For vCluster Pro users, it is possible to migrate the backing store of a virtual
+cluster from the external to [embedded etcd](https://www.vcluster.com/docs/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded#embedded) `controlPlane.backingstore.etcd.embedded`.
 
 ## Config reference
 


### PR DESCRIPTION
Closes DOC-326

[Backing Store Preview](https://deploy-preview-359--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/control-plane/components/backing-store/)