### PR TITLE
feat: document cert-manager integration

### DIFF
--- a/vcluster/_fragments/integrations/cert-manager.mdx
+++ b/vcluster/_fragments/integrations/cert-manager.mdx
@@ -1,0 +1,80 @@
+import CodeBlock from '@theme/CodeBlock';
+
+import Deploy from '../../_partials/deploy/deploy.mdx'
+import ProAdmonition from '../../_partials/admonitions/pro-admonition.mdx'
+import MetricsServer from '../../_partials/config/integrations/certManager.mdx'  
+
+<ProAdmonition/>
+
+### Prerequisites
+This guide assumes you have the following prerequisites:
+- `kubectl` installed
+- `cert-manager` operator installed on your host cluster. See instructions at https://cert-manager.io
+<br></br>
+
+# Certificate Manager Integration
+
+To enable the cert-manager integration, set the following fields as shown below:
+
+```yaml
+integrations:
+  certManager:
+    enabled: true
+```
+
+This will enable the integration, import cluster scoped ClusterIssuers from the host cluster into the virtual cluster and export namespaced Issuers and Certificates from the virtual cluster into the host cluster.
+
+Once that the virtual cluster is up and running, you can create a Issuer and Certificate inside the virtual cluster. For the purpose of this guide, we will use a `letsencrypt-staging` issuer.
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    # You must replace this email address with your own.
+    # Let's Encrypt will use this to contact you about expiring
+    # certificates, and issues related to your account.
+    email: user@example.com
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      # Secret resource that will be used to store the account's private key.
+      name: example-issuer-account-key
+    # Add a single challenge solver, HTTP01 using nginx
+    solvers:
+    - http01:
+        ingress:
+          ingressClassName: nginx
+
+```
+
+
+
+Inside the virtual cluster, create the store with `kubectl apply -f issuer.yaml`. This should create a corresponding Issuer in the host cluster. You can then observe the status of the Issuer in the virtual cluster, and create a Certificate object.
+
+```yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: quickstart-example-tls
+  namespace: default
+spec:
+  dnsNames:
+  - example.example.com
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: letsencrypt-staging
+  secretName: quickstart-example-tls
+  usages:
+  - digital signature
+  - key encipherment
+```
+
+Once that certificate is created in the virtual cluster, the integration will sync the created secret back to the virtual cluster after the cert-manager operator creates it in the host cluster, and the certificate is ready to use.
+
+
+### Config Reference
+
+<CertManager />

--- a/vcluster/configure/vcluster-yaml/integrations/cert-manager.mdx
+++ b/vcluster/configure/vcluster-yaml/integrations/cert-manager.mdx
@@ -1,0 +1,13 @@
+---
+title: Certifcate Manager
+sidebar_label: certificateManager
+sidebar_class_name: pro
+sidebar_position: 2
+---
+
+import ExternalSecretsGuide from '@site/vcluster/_fragments/integrations/cert-manager.mdx'
+
+<ExternalSecretsGuide />
+
+## Config Reference
+

--- a/vcluster/integrations/cert-manager/cert-manager.mdx
+++ b/vcluster/integrations/cert-manager/cert-manager.mdx
@@ -1,0 +1,11 @@
+---
+title: Cert Manager
+sidebar_label: Cert Manager
+sidebar_class_name: pro
+sidebar_position: 2
+---
+
+import KubeVirt from '../../_fragments/integrations/cert-manager.mdx'
+
+<KubeVirt />
+


### PR DESCRIPTION
Signed-off-by: Rohan CJ <rohantmp@gmail.com>

# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

## Internal Reference

resolves DOC-317
<!--Add the Github or Linear ticket reference>


waiting on updating config reference

