### PR TITLE
chore: bump platform version to latest

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -125,7 +125,7 @@ const config = {
         lastVersion: "current",
         versions: {
           current: {
-            label: "v4.x (Stable: v4.1.0)",
+            label: "v4.x (Stable: v4.2.0)",
             banner: "none",
             badge: false,
           },


### PR DESCRIPTION
# Content Description

bump platform version to `v4.2`

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

## Internal Reference

Closes DOC-370


