### PR TITLE
chore: update announcement banner for `v4.2` and `v0.22`

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -216,7 +216,7 @@ const config = {
       },
       announcementBar: {
         id: 'platform-upgrade',
-        content: '🚀 <strong>New releases: <a href="https://www.vcluster.com/releases/en/changelog?hideLogo=true&hideMenu=true&theme=dark&embed=true&c=vCluster" target="_blank">platform 4.2 and vCluster 0.22.0</a></strong>',
+        content: '🚀 <strong>New releases: <a href="https://www.vcluster.com/releases/en/changelog?hideLogo=true&hideMenu=true&theme=dark&embed=true&c=vCluster" target="_blank">platform 4.2 and vCluster 0.22</a></strong>',
         backgroundColor: '#4a90e2',
         textColor: '#ffffff',
         isCloseable: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -216,7 +216,7 @@ const config = {
       },
       announcementBar: {
         id: 'platform-upgrade',
-        content: '🚀 <strong>New releases: <a href="https://www.vcluster.com/releases/en/changelog?hideLogo=true&hideMenu=true&theme=dark&embed=true&c=vCluster" target="_blank">platform 4.1 and vCluster 0.21.0</a></strong>',
+        content: '🚀 <strong>New releases: <a href="https://www.vcluster.com/releases/en/changelog?hideLogo=true&hideMenu=true&theme=dark&embed=true&c=vCluster" target="_blank">platform 4.2 and vCluster 0.22.0</a></strong>',
         backgroundColor: '#4a90e2',
         textColor: '#ffffff',
         isCloseable: true,


### PR DESCRIPTION
# Content Description
Update announcement banner with new releases

Merge when the [changelog](https://www.vcluster.com/releases/en/changelog?hideLogo=true&hideMenu=true&theme=dark&embed=true&c=vCluster) versions are ready.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

## Internal Reference

Closes DOC-371

