### PR TITLE
generate partial for certManager config

### DIFF
--- a/hack/vcluster/partials/main.go
+++ b/hack/vcluster/partials/main.go
@@ -53,6 +53,7 @@ var paths = []string{
 	"integrations/kubeVirt",
 	"integrations/metricsServer",
 	"integrations/externalSecrets",
+	"integrations/certManager",
 	"integrations",
 	"networking/resolveDNS",
 	"networking/replicateServices",

--- a/vcluster/_partials/config/integrations/certManager.mdx
+++ b/vcluster/_partials/config/integrations/certManager.mdx
@@ -1,1 +1,195 @@
-## Cert manager
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager}
+
+CertManager reuses a host cert-manager and makes its CRDs from it available inside the vCluster.
+- Certificates and Issuers will be synced from the virtual cluster to the host cluster.
+- ClusterIssuers will be synced from the host cluster to the virtual cluster.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-enabled}
+
+Enabled defines if this option should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync}
+
+Sync contains advanced configuration for syncing cert-manager resources.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-certificates}
+
+Certificates defines if certificates should get synced from the virtual cluster to the host cluster.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-certificates-enabled}
+
+Enabled defines if this option should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-issuers}
+
+Issuers defines if issuers should get synced from the virtual cluster to the host cluster.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-issuers-enabled}
+
+Enabled defines if this option should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers}
+
+ClusterIssuers defines if (and which) cluster issuers should get synced from the host cluster to the virtual cluster.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers-enabled}
+
+Enabled defines if this option should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers-selector}
+
+Selector defines what cluster issuers should be imported.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers-selector-labels}
+
+Labels defines what labels should be looked for
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>


### PR DESCRIPTION
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
adds `integrations/certManager` so we generate a partial containing certManager feature configuration.
There is another PR coming that gets rid of hardcoded paths from vCluster partial generation script.

## Preview Link 
Deploy preview https://deploy-preview-397--vcluster-docs-site.netlify.app/

## Internal Reference

<!--Add the Github or Linear ticket reference>
Closes DOC-368

