### PR TITLE
do not hardcode partials paths in vCluster partials generation script

### DIFF
--- a/hack/vcluster/partials/main.go
+++ b/hack/vcluster/partials/main.go
@@ -5,94 +5,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+
+	orderedmap "github.com/wk8/go-ordered-map/v2"
 
 	"github.com/ghodss/yaml"
 	"github.com/invopop/jsonschema"
 	"github.com/loft-sh/vcluster-docs/hack/platform/util"
 )
 
-// we only generate paths we actually need
-var paths = []string{
-	"sync/fromHost/customResources",
-	"sync/toHost/customResources",
-	"policies/podSecurityStandard",
-	"telemetry",
-	"sync/toHost/volumeSnapshots",
-	"sync/toHost/storageClasses",
-	"sync/toHost/persistentVolumes",
-	"sync/toHost/persistentVolumeClaims",
-	"sync/toHost/services",
-	"sync/toHost/networkPolicies",
-	"sync/toHost/ingresses",
-	"sync/toHost/endpoints",
-	"sync/toHost/secrets",
-	"sync/toHost/pods",
-	"sync/toHost/configMaps",
-	"sync/toHost/serviceAccounts",
-	"sync/toHost/priorityClasses",
-	"sync/toHost/podDisruptionBudgets",
-	"sync/toHost",
-	"sync/fromHost/storageClasses",
-	"sync/fromHost/nodes",
-	"sync/fromHost/ingressClasses",
-	"sync/fromHost/events",
-	"sync/fromHost/runtimeClasses",
-	"sync/fromHost/priorityClasses",
-	"sync/fromHost/csiStorageCapacities",
-	"sync/fromHost/csiNodes",
-	"sync/fromHost/csiDrivers",
-	"sync/fromHost",
-	"sync",
-	"rbac",
-	"policies/resourceQuota",
-	"policies/networkPolicy",
-	"policies/limitRange",
-	"policies/centralAdmission",
-	"policies",
-	"plugins",
-	"integrations/kubeVirt",
-	"integrations/metricsServer",
-	"integrations/externalSecrets",
-	"integrations/certManager",
-	"integrations",
-	"networking/resolveDNS",
-	"networking/replicateServices",
-	"networking/advanced",
-	"networking",
-	"exportKubeConfig",
-	"experimental/virtualClusterKubeConfig",
-	"experimental/syncSettings",
-	"experimental/multiNamespaceMode",
-	"experimental/isolatedControlPlane",
-	"experimental/genericSync",
-	"experimental/deploy",
-	"experimental/denyProxyRequests",
-	"experimental",
-	"controlPlane/advanced/workloadServiceAccount",
-	"controlPlane/advanced/virtualScheduler",
-	"controlPlane/advanced/serviceAccount",
-	"controlPlane/advanced/headlessService",
-	"controlPlane/advanced/globalMetadata",
-	"controlPlane/advanced/defaultImageRegistry",
-	"controlPlane/advanced",
-	"controlPlane/statefulSet",
-	"controlPlane/service",
-	"controlPlane/serviceMonitor",
-	"controlPlane/ingress",
-	"controlPlane/proxy",
-	"controlPlane/hostPathMapper",
-	"controlPlane/distro/k8s",
-	"controlPlane/distro/k3s",
-	"controlPlane/distro/k0s",
-	"controlPlane/distro",
-	"controlPlane/coredns",
-	"controlPlane/backingStore/etcd/embedded",
-	"controlPlane/backingStore/etcd/deploy",
-	"controlPlane/backingStore/database/embedded",
-	"controlPlane/backingStore/database/external",
-	"controlPlane/backingStore",
-	"controlPlane",
-}
+var paths []string // we will discover all paths by traversing the schema tree
 
 func main() {
 	if len(os.Args) != 3 {
@@ -124,7 +46,47 @@ func main() {
 	if err != nil {
 		panic(fmt.Errorf("failed to parse schema JSON: %w", err))
 	}
-	for _, path := range paths {
-		util.GenerateFromPath(schema, outputDir, path, defaults)
+
+	for pair := schema.Properties.Oldest(); pair != nil; pair = pair.Next() {
+		walkTree(pair.Value, schema, pair.Key, "")
 	}
+
+	for _, path := range paths {
+		util.GenerateFromPath(schema, outputDir, strings.TrimPrefix(path, "/"), defaults)
+	}
+}
+
+func walkTree(node, parent *jsonschema.Schema, name, parentName string) bool {
+	if node == nil {
+		return true
+	}
+
+	children := getChildren(node, parent)
+	if children == nil {
+		return true
+	}
+	parentName = fmt.Sprintf("%s/%s", parentName, name)
+	paths = append(paths, parentName)
+
+	for childNode := children.Oldest(); childNode != nil; childNode = childNode.Next() {
+		if walkTree(childNode.Value, parent, childNode.Key, parentName) {
+			continue
+		}
+	}
+	return true
+}
+
+func getChildren(node *jsonschema.Schema, parentSchema *jsonschema.Schema) *orderedmap.OrderedMap[string, *jsonschema.Schema] {
+	if node == nil {
+		return nil
+	}
+	if node.Ref != "" {
+		refSplit := strings.Split(node.Ref, "/")
+		fieldSchema, ok := parentSchema.Definitions[refSplit[len(refSplit)-1]]
+		if !ok {
+			panic(fmt.Errorf("schema definition %q not found in reference %q", refSplit[len(refSplit)-1], node.Ref))
+		}
+		return fieldSchema.Properties
+	}
+	return nil
 }


### PR DESCRIPTION
instead of hardcoding needed paths, generate paths dynamically by traversing the schema tree

# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

## Internal Reference

<!--Add the Github or Linear ticket reference>
Closes 

