### PR TITLE
fix: pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,6 @@
 If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
 
 ## Internal Reference
-
 <!--Add the Github or Linear ticket reference>
-Closes 
+Closes DOC-
 


### PR DESCRIPTION
Fixing PR template where the Closes DOC- text wouldnt' appear

# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

## Internal Reference

<!--Add the Github or Linear ticket reference>
Closes 

