### PR TITLE
Update cert-manager.mdx

### DIFF
--- a/vcluster/_fragments/integrations/cert-manager.mdx
+++ b/vcluster/_fragments/integrations/cert-manager.mdx
@@ -71,11 +71,7 @@ If you don't have cert-manager configured yet, follow these steps:
 <Flow id="cert-manager-integration">
 <Step>
 
-<Highlight color="green">Virtual Cluster</Highlight> Create the `ClusterIssuer`.
-
-:::tip
-This should create a corresponding Issuer in the host cluster.
-:::
+<Highlight color="green">Host Cluster</Highlight> Create the `ClusterIssuer` on ths Host cluster.
 
 Create a file named `issuer.yaml`:
 


### PR DESCRIPTION
Since we are creating the issuer.yaml on the host cluster, we should specify in the heading too as host cluster and also remove the note as we are not creating this on the virtual cluster and creating it on the host cluster.


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


