### PR TITLE
fix: apply to the virtual cluster

### DIFF
--- a/vcluster/_fragments/integrations/cert-manager.mdx
+++ b/vcluster/_fragments/integrations/cert-manager.mdx
@@ -103,7 +103,7 @@ spec:
 EOF
 ```
 
-Apply to the host cluster:
+Apply to the virtual cluster:
 
 ```bash title="Apply ClusterIssuer to host cluster"
 kubectl --context=$HOST_CTX apply -f issuer.yaml

--- a/vcluster_versioned_docs/version-0.22.0/_fragments/integrations/cert-manager.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/_fragments/integrations/cert-manager.mdx
@@ -103,7 +103,7 @@ spec:
 EOF
 ```
 
-Apply to the host cluster:
+Apply to the virtual cluster:
 
 ```bash title="Apply ClusterIssuer to host cluster"
 kubectl --context=$HOST_CTX apply -f issuer.yaml


### PR DESCRIPTION
# Content Description
Cert manager integration points to creating ClusterIssuer on host cluster and it should be on virtual cluster.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Setup the integration](https://deploy-preview-407--vcluster-docs-site.netlify.app/docs/vcluster/integrations/certmanager/#setup-the-integration)

## Internal Reference
<!--Add the Github or Linear ticket reference-->
Closes DOC-381

