### PR TITLE
Add Cost Control Dashboard Network Requirements

### DIFF
--- a/platform/configure/cost-control.mdx
+++ b/platform/configure/cost-control.mdx
@@ -32,6 +32,12 @@ By default, the Cost Control Dashboard requests
 dashboard or configuring its resource needs.
 :::
 
+:::warning Network requirements
+In air-gapped or private GKE clusters it may be necessary to add a firewall rule allowing
+incoming traffic to port `9090`. This port is used when aggregating metrics from
+connected clusters.
+:::
+
 ## Configuration
 
 Although the platform manages Prometheus and OpenCost automatically, certain

--- a/platform/install/advanced/air-gapped.mdx
+++ b/platform/install/advanced/air-gapped.mdx
@@ -65,6 +65,10 @@ Although the platform may work with other versions, using the supported versions
   - `8443` (platform agent API service extension - `v1.cluster.loft.sh`)
   - `9443` (platform agent webhook & loft webhook)
   - `9444` (platform API service extension - `v1.management.loft.sh`)
+  :::info
+  The platform's cost control dashboard federates metrics from each connected cluster. In order to scrape these metrics, it utilizes the local cluster agent to proxy to the cluster's Prometheus pods. The agent requires connectivity over TCP port `9090` to access the Prometheus pods.
+  :::
+  - `9090` (cost control dashboard Prometheus pods)
 
 ## Deployment
 


### PR DESCRIPTION
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Add network requirements for the cost control dashboard. Issues with metrics federation were discovered on loft.rocks, and it was due to the connected clusters being private GKE clusters. Similar issues could be expected for air gapped clusters, depending on how their firewalls are configured.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Cost Control Dashboard](https://deploy-preview-409--vcluster-docs-site.netlify.app/docs/platform/configure/cost-control)
[Deploy in Air-Gapped Environments](https://deploy-preview-409--vcluster-docs-site.netlify.app/docs/platform/install/advanced/air-gapped/#resource-requirements)

## Internal Reference
<!--Add the Github or Linear ticket reference-->
Closes DOC-382

