### PR TITLE
Fix typo for deployment name in the quickstart guide

### DIFF
--- a/vcluster/_partials/quick-start-guide/deploy-resources.mdx
+++ b/vcluster/_partials/quick-start-guide/deploy-resources.mdx
@@ -3,7 +3,7 @@ To illustrate what happens in the host cluster, create a namespace and deploy NG
 
 ```bash
 kubectl create namespace demo-nginx
-kubectl create deployment ngnix-deployment -n demo-nginx --image=nginx -r 2
+kubectl create deployment nginx-deployment -n demo-nginx --image=nginx -r 2
 ```
 
 Check that this deployment creates two pods inside the virtual cluster.

--- a/vcluster_versioned_docs/version-0.20.0/_partials/quick-start-guide/deploy-resources.mdx
+++ b/vcluster_versioned_docs/version-0.20.0/_partials/quick-start-guide/deploy-resources.mdx
@@ -3,7 +3,7 @@ To illustrate what happens in the host cluster, create a namespace and deploy NG
 
 ```bash
 kubectl create namespace demo-nginx
-kubectl create deployment ngnix-deployment -n demo-nginx --image=nginx -r 2
+kubectl create deployment nginx-deployment -n demo-nginx --image=nginx -r 2
 ```
 
 Check that this deployment creates two pods inside the virtual cluster.

--- a/vcluster_versioned_docs/version-0.21.0/_partials/quick-start-guide/deploy-resources.mdx
+++ b/vcluster_versioned_docs/version-0.21.0/_partials/quick-start-guide/deploy-resources.mdx
@@ -3,7 +3,7 @@ To illustrate what happens in the host cluster, create a namespace and deploy NG
 
 ```bash
 kubectl create namespace demo-nginx
-kubectl create deployment ngnix-deployment -n demo-nginx --image=nginx -r 2
+kubectl create deployment nginx-deployment -n demo-nginx --image=nginx -r 2
 ```
 
 Check that this deployment creates two pods inside the virtual cluster.

--- a/vcluster_versioned_docs/version-0.22.0/_partials/quick-start-guide/deploy-resources.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/_partials/quick-start-guide/deploy-resources.mdx
@@ -3,7 +3,7 @@ To illustrate what happens in the host cluster, create a namespace and deploy NG
 
 ```bash
 kubectl create namespace demo-nginx
-kubectl create deployment ngnix-deployment -n demo-nginx --image=nginx -r 2
+kubectl create deployment nginx-deployment -n demo-nginx --image=nginx -r 2
 ```
 
 Check that this deployment creates two pods inside the virtual cluster.


### PR DESCRIPTION
# Content Description
Just a little typo fix on something I saw while reading the docs.

I'm not very sure about changing the older versions, but here it is...
