### PR TITLE
feat(platform): install platform on GKE

### DIFF
--- a/platform/install/environments/_category_.json
+++ b/platform/install/environments/_category_.json
@@ -1,0 +1,6 @@
+{
+  "label": "Environments",
+  "position": "3.1",
+  "collapsible": true,
+  "collapsed": false
+}

--- a/platform/install/environments/gcp.mdx
+++ b/platform/install/environments/gcp.mdx
@@ -1,18 +1,18 @@
 ---
 title: Deploy vCluster Platform on Google Cloud
-sidebar_label: On GCP
+sidebar_label: GCP
 sidebar_position: 4
 description: Learn how to deploy and configure the platform on Google Cloud Platform (GPC)
 ---
 
 import Image from "@site/src/components/Image";
-import InstallNextSteps from "../_partials/install/install-next-steps.mdx";
-import ListHelmVersions from '../_partials/install/list-helm-versions.mdx';
-import BasePrerequisites from '../_partials/install/base-prerequisites.mdx';
-import InstallCli from '../../vcluster/_partials/deploy/install-cli.mdx';
-import KubeconfigUpdate from '../../docs/_partials/kubeconfig_update.mdx';
-import ManagedK8sInstallVcluster from '../../docs/_partials/managed_k8s_install_vcluster.mdx';
-import ProAdmonition from '../../vcluster/_partials/admonitions/pro-admonition.mdx';
+import InstallNextSteps from "../../_partials/install/install-next-steps.mdx";
+import ListHelmVersions from '../../_partials/install/list-helm-versions.mdx';
+import BasePrerequisites from '../../_partials/install/base-prerequisites.mdx';
+import InstallCli from '../../../vcluster/_partials/deploy/install-cli.mdx';
+import KubeconfigUpdate from '../../../docs/_partials/kubeconfig_update.mdx';
+import ManagedK8sInstallVcluster from '../../../docs/_partials/managed_k8s_install_vcluster.mdx';
+import ProAdmonition from '../../../vcluster/_partials/admonitions/pro-admonition.mdx';
 
 import Flow, { Step } from '@site/src/components/Flow';
 
@@ -268,7 +268,7 @@ tutorial](https://cloud.google.com/dns/docs/tutorials/create-domain-tutorial).
 
 </Flow>
 
-## Next Steps
+## Next steps
 
 There are a few additional steps you can take to further configure the platform.
 

--- a/platform/install/gcp.mdx
+++ b/platform/install/gcp.mdx
@@ -1,0 +1,292 @@
+---
+title: Deploy vCluster Platform on Google Cloud
+sidebar_label: On GCP
+sidebar_position: 4
+description: Learn how to deploy and configure the platform on Google Cloud Platform (GPC)
+---
+
+import Image from "@site/src/components/Image";
+import InstallNextSteps from "../_partials/install/install-next-steps.mdx";
+import ListHelmVersions from '../_partials/install/list-helm-versions.mdx';
+import BasePrerequisites from '../_partials/install/base-prerequisites.mdx';
+import InstallCli from '../../vcluster/_partials/deploy/install-cli.mdx';
+import KubeconfigUpdate from '../../docs/_partials/kubeconfig_update.mdx';
+import ManagedK8sInstallVcluster from '../../docs/_partials/managed_k8s_install_vcluster.mdx';
+import ProAdmonition from '../../vcluster/_partials/admonitions/pro-admonition.mdx';
+
+import Flow, { Step } from '@site/src/components/Flow';
+
+import Label from '@site/src/components/Label';
+
+
+This guide provides step-by-step instructions for deploying `vCluster platform` on [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine).
+
+## Prerequisites
+
+Before starting, ensure you have the following tools installed:
+<BasePrerequisites />
+- vCluster CLI <InstallCli />
+- [Google Cloud SDK (`gcloud` CLI)](https://cloud.google.com/sdk/docs/install)
+  :::note
+  Ensure you have the necessary IAM permissions to create clusters and manage cloud services.
+  :::
+
+## Create GKE cluster
+
+<Flow id="create-gke-cluster">
+
+<Step>
+Prepare the environment.
+
+Start by creating a zonal GKE cluster using the `gcloud` CLI. First, set up your environment variables:
+
+:::tip
+Project ID can be found in the Google Cloud Console under the project name.
+Alternatively use `gcloud project list` to list all projects and their IDs.
+To check which project is active, use `gcloud config get-value project`.
+:::
+
+```bash title="Set environment variables"
+export PROJECT_ID=development
+export CLUSTER_NAME=vcluster-demo
+export ZONE=europe-west1-b
+export MACHINE_TYPE=e2-standard-4
+```
+
+Configure `gcloud` and enable the required APIs and set default project:
+
+```bash title="Configure gcloud"
+gcloud config set project $PROJECT_ID
+gcloud services enable container.googleapis.com
+```
+</Step>
+
+<Step>
+Create the cluster.
+
+```bash title="Create GKE cluster"
+gcloud container clusters create $CLUSTER_NAME \
+    --zone $ZONE \
+    --machine-type $MACHINE_TYPE \
+    --num-nodes 2
+```
+
+  :::info
+  This process typically takes about 10-15 minutes.
+  :::
+
+This command creates a GKE cluster named vcluster-demo in the europe-west1-b
+zone with two nodes of type e2-standard-4.
+
+<KubeconfigUpdate />
+
+</Step>
+
+<Step>
+Verify the cluster creation.
+
+Verify that the GKE was created successfully by listing the nodes:
+
+```bash title="List cluster nodes"
+kubectl get nodes
+```
+
+You should see output similar to:
+```
+NAME           LOCATION        MASTER_VERSION      MASTER_IP      MACHINE_TYPE   NODE_VERSION        NUM_NODES  STATUS
+vcluster-demo  europe-west1-b  1.30.5-gke.1443001  35.187.66.218  e2-standard-4  1.30.5-gke.1443001  2          RUNNING
+```
+<ManagedK8sInstallVcluster />
+
+</Step>
+
+</Flow>
+
+## Platform setup
+
+With the GKE cluster up and running, you can now deploy the platform in a few
+easy steps.
+
+<Flow>
+
+### Install the platform
+
+<Step>
+Deploy platform using the vCluster CLI
+
+Now that you have vCluster running on GKE, set up the [platform
+](/platform/install/quick-start-guide) and configure GPC in the following steps.
+
+Easiest way to deploy a platform is using the `vcluster CLI`
+
+```bash title="deploy the platform using vcluster cli
+vcluster platform start
+```
+The command asks you for providing email address for the admin user
+
+```bash title="deployment expected output"
+By providing your email, you accept our Terms of Service and Privacy Statement:
+Terms of Service: https://www.loft.sh/legal/terms
+Privacy Statement: https://www.loft.sh/legal/privacy
+? Please specify an email address for the admin user
+```
+
+:::tip retry
+if the command takes to long to execute, for example due to other cluster
+operations, simply run the command one more time
+:::
+</Step>
+
+<Step>
+Connect to the platform.
+
+Once the platform is deployed, default browser with the platform UI opens and you should see the output similar to this:
+
+```bash title="platform deployment output"
+##########################   LOGIN   ############################
+
+Username: admin
+Password: 9758c908-b931-4edd-b3cb-3f034e50651a  # Change via UI or via: vcluster platform reset password
+
+Login via UI:  https://hyx4907.loft.host
+Login via CLI: vcluster login https://hyx4907.loft.host
+
+#################################################################
+
+vCluster Platform was successfully installed and can now be reached at: https://hyx4907.loft.host
+
+Thanks for using vCluster Platform!
+19:34:46 done You are successfully logged into vCluster Platform!
+- Use `vcluster platform create vcluster` to create a new virtual cluster
+- Use `vcluster platform add vcluster` to add an existing virtual cluster to a vCluster platform instance
+```
+
+When logging in via UI, provide: <Label>First Name</Label>, <Label>Last Name</Label>, <Label>Email</Label> (should default to
+the one supplied earlier) and <Label>Organization</Label>.
+
+To login via CLI, simply copy/pasted the `Login via CLI` command.
+
+This is the basic platform deployment, from there you can refer to the
+#post-install-steps to start using the platform. However there are a few
+additional configuration steps that can be done.
+</Step>
+
+</Flow>
+
+<Flow>
+
+### Expose platform UI via load balancer
+
+<Step>
+Create a LoadBalancer service to expose the platform UI.
+
+:::note
+Please note that this
+assumes the platform is deployed in the `vcluster-platform` namespace which is a
+default deployment namespace.
+:::
+
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Service
+metadata:
+  name: vcluster-platform-loadbalancer
+  namespace: vcluster-platform
+spec:
+  type: LoadBalancer
+  externalTrafficPolicy: Cluster
+  selector:
+    app: loft
+  ports:
+  - name: https
+    protocol: TCP
+    port: 443
+    targetPort: 10443
+EOF
+```
+</Step>
+
+<Step>
+Once the service is active, obtain the external IP address:
+
+```bash
+kubectl get svc vcluster-platform-loadbalancer -n vcluster-platform
+```
+
+and navigate to the IP address in your browser `https://<EXTERNAL_IP>`.
+
+:::note certificate
+Note that the platform uses a self-signed certificate, so you need to
+accept the warning in your browser. For production use, you should replace the
+certificate with a valid one.
+:::
+
+To learn more about how to configure certificate and TLS, read the [TLS
+configuration guide](/platform/configure/domain#configure-tls)
+</Step>
+
+</Flow>
+
+<Flow>
+
+### Setup custom domain and configure DNS
+
+<Step>
+Configure DNS in Google Cloud DNS.
+To use a custom domain, you need to configure the DNS to point to the LoadBalancer IP address.
+
+```bash title="Configure DNS"
+gcloud dns managed-zones create vcluster-platform --dns-name="yourdomain.tld."
+
+gcloud dns record-sets transaction start --zone=vcluster-platform
+
+gcloud dns record-sets transaction add <EXTERNAL_IP> \
+    --name="vcluster-platform.yourdomain.tld." \
+    --ttl=300 \
+    --type=A \
+    --zone=vcluster-platform
+
+gcloud dns record-sets transaction execute --zone=vcluster-platform
+```
+</Step>
+
+<Step>
+Connect the platform to the custom domain.
+
+Once the DNS is setup, the platform can be started with the command `vcluster
+platform start --host=vcluster-platform.yourdomain.tld`
+
+:::info
+Read more about how to configure a custom [domain](/platform/configure/domain).
+
+If you do not have a custom domain setup, [follow this
+tutorial](https://cloud.google.com/dns/docs/tutorials/create-domain-tutorial).
+:::
+
+</Step>
+
+</Flow>
+
+## Next Steps
+
+There are a few additional steps you can take to further configure the platform.
+
+### Workload Identity
+
+<ProAdmonition />
+
+When using the platform you can easily enable [Workload Identity](/vcluster/integrations/pod-identity/gke-workload-identity).
+
+### Post install {#post-install-steps}
+
+<InstallNextSteps />
+
+## Cleanup
+
+If you deployed the GKE cluster with this tutorial, and want to clean up the resources, run the
+following command:
+
+```bash title="Clean up resources"
+gcloud container clusters delete $CLUSTER_NAME --zone $ZONE --quiet
+```


### PR DESCRIPTION
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
How to set up the platform on a GKE cluster, including cluster creation.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Deploy vCluster Platform on Google Cloud](https://deploy-preview-411--vcluster-docs-site.netlify.app/docs/platform/install/environments/gcp)
## Internal Reference
<!--Add the Github or Linear ticket reference-->
Closes DOC-383

