### PR TITLE
Adds sleep mode tutorials

### DIFF
--- a/vcluster/_fragments/sleepmode-deployment-example.mdx
+++ b/vcluster/_fragments/sleepmode-deployment-example.mdx
@@ -1,0 +1,67 @@
+import CodeBlock from '@theme/CodeBlock'
+import SleepmodeDeploymentConfig from '!!raw-loader!@site/vcluster/configure/vcluster-yaml/experimental/_code/sleepmode-deployment-config.yaml'
+import SleepModeDeploymentExample from '!!raw-loader!@site/vcluster/configure/vcluster-yaml/experimental/_code/sleepmode-deployment-examples.yaml'
+
+#### Tools used in this example
+ - [Docker](https://www.docker.com/)
+ - [Kind](https://kind.sigs.k8s.io/)
+
+#### Steps in this example
+
+ - [Create a kind cluster](#dep-kind-create)
+ - [Create a virtual cluster with sleepMode enabled, and a label exclusion configured.](#dep-vcluster-create)
+ - [Install two `Deployments` with 2 replicas to verify sleep/wake, one with labels to exclude it from sleeping.](#deployments-install)
+ - [Show one `Deployment` is scaled down after the `30 second` inactivity timeout, while the other remains active.](#dep-verify)
+ - [Show that the slept `Deployment` wakes when the cluster is accessed with `kubectl`.](#dep-verify)
+
+### 1. Create the kind cluster {#dep-kind-create}
+
+```shell title="create kind cluster"
+kind create cluster --name sleep-mode-demo
+```
+### 2. Create the vCluster {#dep-vcluster-create}
+
+Use the following `vcluster.yaml` to create a virtual cluster on your host.  Save this file as `vcluster.yaml`
+
+<CodeBlock title="vCluster config for auto sleep" language="yaml">{SleepmodeDeploymentConfig}</CodeBlock>
+
+And run:
+
+```bash title="Create vCluster with autoSleep config"
+vcluster create my-vcluster -f vcluster.yaml
+```
+
+Note that under the exclude section, workloads with the label `sleep: no-thanks` won't be put to sleep after the 30 seconds.
+So lets put that to the test.
+
+### 3. Create a couple demo deployments in your virtual cluster {#deployments-install}
+
+Use the following deployment yaml to create two deployments
+
+<CodeBlock title="example deployments" language="yaml">{SleepModeDeploymentExample}</CodeBlock>
+
+
+The first deployment has nothing special about it related to sleep mode.  Feel free to use another in its place if you'd
+prefer.  The second has the special label **on the** `Deployment`.  As a result the `Deployment` won't be scaled down after the `30 seconds`.
+
+You can verify this by waiting `30 seconds` and then getting information about the `Deployments`.  For example
+
+
+### 4. Verify `Deployments` sleep status {#dep-verify}
+
+```bash title="deployment sleep check"
+> sleep 30; kubectl get deployments
+NAMESPACE     NAME                  READY   UP-TO-DATE   AVAILABLE   AGE
+default       no-sleep-deployment   2/2     2            2           1m
+default       sleepy-deployment     0/2     0            0           1m
+```
+
+The `sleepy-deployment` reports `0/2` replicas after the 30 seconds.  The act of running `kubectl` counts as cluster activity,
+which is why its reporting `0/2` not `0/0`.  `kubectl` has triggered `vCluster` to update the replicas count back to the original 2,
+they just haven't become ready in the time it took for `kubectl get ...` to return.
+
+
+#### Things to try on your own with this setup
+
+ - Add the `sleep: no-thanks` label to the first deployment and verify neither sleeps.
+ - Remove the `sleep: no-thanks` label from both the deployments and verify that both go to sleep.

--- a/vcluster/_fragments/sleepmode-ingress-example.mdx
+++ b/vcluster/_fragments/sleepmode-ingress-example.mdx
@@ -1,0 +1,90 @@
+import CodeBlock from '@theme/CodeBlock'
+import SleepmodeIngressConfig from '!!raw-loader!@site/vcluster/configure/vcluster-yaml/experimental/_code/sleepmode-host-ingress-config.yaml'
+import SleepmodeIngressExample from '!!raw-loader!@site/vcluster/configure/vcluster-yaml/experimental/_code/sleepmode-ingress-examples.yaml'
+
+#### Tools used in this example
+ - [Docker](https://www.docker.com/)
+ - [Kind](https://kind.sigs.k8s.io/)
+ - [Helm](https://helm.sh/)
+ - [curl](https://curl.se/)
+
+#### Steps in this example
+
+ - [Create a kind cluster with ports necessary for demonstrating `Ingress` capabilities.](#ing-kind-create)
+ - [Install an NGINX ingress controller on the host cluster, with syncing to host enabled.](#ing-nginx-install)
+ - [Create a virtual cluster with sleepMode enabled](#ing-vcluster-create)
+ - [Install several components in the virtual cluster to test the ingress](#ing-create-resources)
+ - [Test the ingress before it goes to sleep](#ing-verify)
+ - [Test the ingress after it has gone to sleep to show that it wakes](#ing-verify-sleep)
+
+### 1. Create the kind cluster {#ing-kind-create}
+
+```shell title="create kind cluster"
+kind create cluster --name ingress-demo --config - <<EOF
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  apiServerAddress: "0.0.0.0"
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 80
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 443
+        hostPort: 443
+        protocol: TCP
+EOF
+```
+
+### 2. Install the NGINX `IngressController` {#ing-nginx-install}
+
+```shell title="install ingress controller"
+helm install ingress-nginx ingress-nginx/ingress-nginx \
+  --namespace ingress-nginx \
+  --create-namespace \
+  --set controller.dnsPolicy=ClusterFirstWithHostNet \
+  --set controller.hostNetwork=true \
+  --set controller.service.type=ClusterIP
+````
+
+### 3. Create the vCluster {#ing-vcluster-create}
+
+Use the following `vcluster.yaml` to create a virtual cluster on your host.  Save this file as `vcluster.yaml`
+
+<CodeBlock title="vCluster config for auto sleep" language="yaml">{SleepmodeIngressConfig}</CodeBlock>
+
+And run:
+
+```bash title="Create vCluster with autoSleep config"
+vcluster create my-vcluster -f vcluster.yaml
+```
+### 4. Edit your `/etc/hosts` for the `Ingress` domain {#ing-host-setup}
+
+Add `127.0.0.1 	backend.local` to your `/etc/hosts` file to match the host configured in the `Ingress` rules of the next
+step.
+
+### 5. Create resources for the `Ingress` such as a `Deployment` and `Service` {#ing-create-resources}
+
+Use the following manifest to create
+
+ - A new `Namespace` called `bar`
+ - A `Deployment` for the pods backing the `Service`
+ - A `Service` to back the `Ingress`
+ - An `Ingress`
+
+<CodeBlock title="example deployments" language="yaml">{SleepmodeIngressExample}</CodeBlock>
+
+### 6. Verify the ingress is working properly with `curl` {#ing-verify}
+
+Keep trying the `Ingress` endpoint within the `30 second` activity window with `curl --silent backend.local/bar` You
+should see the name of whichever pod in the `Deployment` responds.
+
+### 7. Allow the virtual cluster to go to sleep {#ing-verify-sleep}
+
+Wait the `30 seconds` for the cluster to sleep and try the `curl` command again. For convenience with this test you can
+run `watch -d curl --silent backend.local/bar` to continually try the endpoint. This time, because an `HTTP` request was
+sent to the `HTTPS` wake endpoint on the virtual cluster, you should see `Client sent an HTTP request to an HTTPS server.`
+on the first attempt, and new pod names on subsequent requests.
+
+

--- a/vcluster/configure/vcluster-yaml/experimental/_code/sleepmode-deployment-config.yaml
+++ b/vcluster/configure/vcluster-yaml/experimental/_code/sleepmode-deployment-config.yaml
@@ -1,0 +1,10 @@
+pro: true
+experimental:
+  sleepMode:
+    enabled: true
+    autoSleep:
+      afterInactivity: 30s
+      exclude:
+        selector:
+          labels:
+            sleep: no-thanks

--- a/vcluster/configure/vcluster-yaml/experimental/_code/sleepmode-deployment-examples.yaml
+++ b/vcluster/configure/vcluster-yaml/experimental/_code/sleepmode-deployment-examples.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sleepy-deployment
+  labels:
+    app: sleepy-dep
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: demo-dep-1
+  template:
+    metadata:
+      labels:
+        app: demo-dep-1
+    spec:
+      containers:
+        - command:
+            - /agnhost
+            - serve-hostname
+            - --http=true
+            - --port=8080
+          image: registry.k8s.io/e2e-test-images/agnhost:2.39
+          name: sleepy-demo
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: no-sleep-deployment
+  labels:
+    sleep: no-thanks
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: demo-dep-2
+  template:
+    metadata:
+      labels:
+        app: demo-dep-2
+    spec:
+      containers:
+        - command:
+            - /agnhost
+            - serve-hostname
+            - --http=true
+            - --port=8080
+          image: registry.k8s.io/e2e-test-images/agnhost:2.39
+          name: not-sleepy-demo

--- a/vcluster/configure/vcluster-yaml/experimental/_code/sleepmode-host-ingress-config.yaml
+++ b/vcluster/configure/vcluster-yaml/experimental/_code/sleepmode-host-ingress-config.yaml
@@ -1,0 +1,10 @@
+pro: true
+sync:
+  toHost:
+    ingresses:
+      enabled: true
+experimental:
+  sleepMode:
+    enabled: true
+    autoSleep:
+      afterInactivity: 30s

--- a/vcluster/configure/vcluster-yaml/experimental/_code/sleepmode-ingress-examples.yaml
+++ b/vcluster/configure/vcluster-yaml/experimental/_code/sleepmode-ingress-examples.yaml
@@ -1,0 +1,68 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: bar
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bar-deployment
+  namespace: bar
+  labels:
+    app: bar-dep
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: bar
+  template:
+    metadata:
+      labels:
+        app: bar
+    spec:
+      containers:
+        - command:
+            - /agnhost
+            - serve-hostname
+            - --http=true
+            - --port=8080
+          image: registry.k8s.io/e2e-test-images/agnhost:2.39
+          name: bar-app
+
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: bar-service
+  namespace: bar
+spec:
+  selector:
+    app: bar
+  ports:
+    # Default port used by the image
+    - port: 8080
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: example-ingress
+  namespace: bar
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - pathType: Prefix
+            path: /bar
+            backend:
+              service:
+                name: bar-service
+                port:
+                  number: 8080
+      host: backend.local
+

--- a/vcluster/configure/vcluster-yaml/experimental/isolated-control-plane.mdx
+++ b/vcluster/configure/vcluster-yaml/experimental/isolated-control-plane.mdx
@@ -3,7 +3,7 @@ title: Isolated control plane
 sidebar_label: isolatedControlPlane
 sidebar_position: 5
 sidebar_class_name: pro
-description: Configurare a vCluster isolated control plane.
+description: Configure a vCluster isolated control plane.
 ---
 
 import ExperimentalIsolatedControlPlane from '../../../_partials/config/experimental/isolatedControlPlane.mdx'

--- a/vcluster_versioned_docs/version-0.22.0/configure/vcluster-yaml/experimental/native-sleep-mode.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/configure/vcluster-yaml/experimental/native-sleep-mode.mdx
@@ -1,13 +1,14 @@
 ---
-title: Experimental Sleep Mode
+title: Native Sleep Mode
 sidebar_label: sleepMode
 sidebar_position: 7
 sidebar_class_name: pro
 description: Configure a vCluster to sleep/wake without an agent
 ---
-
 import ProAdmonition from '../../../_partials/admonitions/pro-admonition.mdx'
 import ExperimentalSleepMode from '../../../_partials/config/experimental/sleepMode.mdx'
+import SleepModeDeploymentExample from '@site/vcluster/_fragments/sleepmode-deployment-example.mdx'
+import SleepModeIngressExample from '@site/vcluster/_fragments/sleepmode-ingress-example.mdx'
 
 <ProAdmonition />
 
@@ -16,9 +17,62 @@ Native sleep mode is intended for pre-production use cases only, and comes with 
 caveats.
 :::
 
-### Configuration examples
 
+### How it works
 
+**Sleeping** deletes bare pods and scales down the following resources:
+  * Deployments
+  * ReplicaSets
+  * ReplicationControllers
+  * DaemonSets
+
+**Waking** scales sleeping resources back up, however bare pods that were killed cannot be restored.  To exempt resources from being
+put to sleep, either add the annotation `sleepmode.loft.sh/exclude: true` or configure `sleepMode` with a label, or set
+of labels to exclude and add those labels to all the workloads you'd like to keep running.
+
+### Detecting activity
+
+To wake a sleeping cluster or to update the last active time, native sleep mode captures the following:
+
+ * Access of cluster resources.  _Think `kubectl get <resource>`_
+ * Attempts to contact Ingress endpoints (NGINX only).
+
+:::note
+Ingress activity detection is only available for [NGINX](https://github.com/kubernetes/ingress-nginx/tree/main)
+ingress controllers, making use of the [mirror-target](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#mirror)
+annotation.  This has the effect of overwriting any previously set mirror-target annotation.
+:::
+
+### Ingress considerations
+
+#### Sync to host
+
+If you install your ingress controllers in the vCluster you'll need to exempt the controller from sleeping so it remains
+active for requests that would wake the vCluster.  If you install the `Ingress` controller in the host cluster, you'll need to
+enable syncing ingresses to the host.
+
+```yaml title="enable ingress syncing"
+sync:
+  toHost:
+    ingresses:
+      enabled: true
+```
+
+#### Reachability
+
+In order to detect ingress activity, the vCluster pod must be discoverable by the ingress controller. i.e. an `nslookup` for the
+`<vcluster-namespace>.<vcluster-svc-name>.svc.cluster.local` should be able to find the vCluster service.  If you're installing
+the ingress controller with Helm be sure to set the `dnsPolicy` correctly, as is covered in the ingress example.
+
+### Full example with `Deployments`
+
+<SleepModeDeploymentExample />
+
+### Full example with host `Ingress` Controller
+
+<SleepModeIngressExample />
+
+### Additional examples
 
 ```yaml title="Sleep after 3 hours of inactivity, anything that does not have the label dont=sleep"
 experimental:
@@ -32,8 +86,6 @@ experimental:
             dont: sleep
 ```
 
-
-
 ```yaml title="Sleep every Friday at 17:30 and wake every Monday at 7:00 in Mountain timezone"
 experimental:
   sleepMode:
@@ -43,46 +95,6 @@ experimental:
       schedule: 30 17 * * 5
       wakeup:
         schedule: 0 7 * * 1
-```
-
-### How it works
-
-**Sleeping** deletes bare pods and scale down the following resources:
-  * Deployments
-  * ReplicaSets
-  * ReplicationControllers
-  * DaemonSets
-
-**Waking** scales those resources back up, unable to restore bare pods that were killed.  To exempt resources from being
-put to sleep, either add the annotation `sleepmode.loft.sh/exclude: true` or configure sleep mode with labels to exclude and
-add that label to all the workloads you'd like to keep running.
-
-### Detecting activity
-
-To wake a sleeping cluster or to update the last active time, native sleep mode captures the following:
-
- * Access of cluster resources.  _Think `kubectl get <resource>`_
- * Attempts to contact Ingress endpoints (NGINX only).
-
-:::note
-Ingress activity detection is only available for [NGINX](https://github.com/kubernetes/ingress-nginx/tree/main)
-ingress controllers, making use of the [mirror-target](https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#mirror)
-<!-- vale off -->
-annotation.  If you use this annotation, it will be overwritten for the sleep mode to function.
-<!-- vale on -->
-:::
-
-### Ingress considerations
-
-If you install your ingress controllers in the vCluster you'll need to exempt the controller from sleeping so it remains
-active for requests that would wake the vCluster.  If you install the ingress controller in the host cluster, you'll need to
-enable syncing ingresses to the host.
-
-```yaml title="enable ingress syncing"
-sync:
-  toHost:
-    ingresses:
-      enabled: true
 ```
 
 ## Config reference


### PR DESCRIPTION
# Content Description
Adds tutorials for setting up vcluster with sleep mode using deployments and with an Ingress controller on the host.

[Preview Link](https://deploy-preview-414--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml/experimental/native-sleep-mode)

## Internal Reference
<!--Add the Github or Linear ticket reference-->
Closes DOC-378

