### PR TITLE
fix(search): fixing pages not loading after search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -208,6 +208,7 @@ const config = {
         apiKey: "057a9f939df7215d92c8171d47352c54",
         indexName: "vcluster",
         placeholder: "Search...",
+        externalUrlRegex: 'vcluster\\.com\/docs\/v0\\.19',
         algoliaOptions: {},
       },
       footer: {

--- a/vcluster/deploy/upgrade/upgrade-version.mdx
+++ b/vcluster/deploy/upgrade/upgrade-version.mdx
@@ -6,22 +6,22 @@ sidebar_position: 2.1
 
 import UpgradeVersion from '../../_partials/manage/upgrade-version.mdx'
 
-At any time, you can upgrade the version of your vCluster. During the upgrade, you can also apply 
-configuration option changes. 
+At any time, you can upgrade the version of your vCluster. During the upgrade, you can also apply
+configuration option changes.
 
 <p></p>
 
 :::tip
-If you are moving from vCluster 0.19.x to 0.20+, see the [conversion guide](../reference/migrations/0-20-migration) for how to automatically convert your existing `values.yaml` configuration file to the new `vcluster.yaml` format.
+If you are moving from vCluster 0.19.x to 0.20+, see the [conversion guide](/vcluster/reference/migrations/0-20-migration) for how to automatically convert your existing `values.yaml` configuration file to the new `vcluster.yaml` format.
 :::
 
-## (Optional) Update `vcluster.yaml` 
+## (Optional) Update `vcluster.yaml`
 
 Update your `vcluster.yaml` to change your configuration options during a vCluster version upgrade.
 
 <p></p>
-:::warning 
-Remember that you can't change distros or backing store once a vCluster is deployed. 
+:::warning
+Remember that you can't change distros or backing store once a vCluster is deployed.
 :::
 
 ## Upgrade vCluster Version

--- a/vcluster/deploy/upgrade/upgrade-version.mdx
+++ b/vcluster/deploy/upgrade/upgrade-version.mdx
@@ -15,7 +15,7 @@ configuration option changes.
 If you are moving from vCluster 0.19.x to 0.20+, see the [conversion guide](/vcluster/reference/migrations/0-20-migration) for how to automatically convert your existing `values.yaml` configuration file to the new `vcluster.yaml` format.
 :::
 
-## (Optional) Update `vcluster.yaml`
+## (Optional) update `vcluster.yaml`
 
 Update your `vcluster.yaml` to change your configuration options during a vCluster version upgrade.
 
@@ -24,7 +24,7 @@ Update your `vcluster.yaml` to change your configuration options during a vClust
 Remember that you can't change distros or backing store once a vCluster is deployed.
 :::
 
-## Upgrade vCluster Version
+## Upgrade vCluster version
 
 These steps assume that you have been a `vcluster.yaml`, but there are variables in the code blocks for you to replace for:
 


### PR DESCRIPTION
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
When search results lead to the `0.19` version, the page is no correctly loaded. What happens is that the search result shows "page not found" and only after refresh, the page is loaded.

Using the `externalUrlRegex` to load all the searches related to the `0.19` version in a separate window, using `window.location.href` results in the search on `0.19` to load correctly.

The drawback of this is that search results for `0.19` load a bit slower because they need to render in a separate window.

## Test the PR

To test the change go to the [preview link](https://deploy-preview-416--vcluster-docs-site.netlify.app/docs/) and insert serach for "synced resources", the top search should take you to the `0.19` docs opening in new tab/window (depending on your browser configuraiton).

Searches for the current version should render normally on the same page.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[What are virtual clusters?](https://deploy-preview-416--vcluster-docs-site.netlify.app/docs/)

## Internal Reference
<!--Add the Github or Linear ticket reference-->
Closes DOC-380

