### PR TITLE
chore(cert manager): backport cert manager fixes to v0.22

### DIFF
--- a/vcluster_versioned_docs/version-0.22.0/_fragments/integrations/cert-manager.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/_fragments/integrations/cert-manager.mdx
@@ -71,7 +71,7 @@ If you don't have cert-manager configured yet, follow these steps:
 <Flow id="cert-manager-integration">
 <Step>
 
-<Highlight color="green">Virtual Cluster</Highlight> Create the `ClusterIssuer`.
+<Highlight color="green">Virtual Cluster</Highlight> Create the `Issuer`.
 
 :::tip
 This should create a corresponding Issuer in the host cluster.
@@ -79,10 +79,10 @@ This should create a corresponding Issuer in the host cluster.
 
 Create a file named `issuer.yaml`:
 
-```yaml title="Create ClusterIssuer"
+```yaml title="Issuer"
 cat <<EOF > issuer.yaml
 apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
+kind: Issuer
 metadata:
   name: letsencrypt-staging
 spec:
@@ -105,15 +105,15 @@ EOF
 
 Apply to the virtual cluster:
 
-```bash title="Apply ClusterIssuer to virtual cluster"
-kubectl --context=$HOST_CTX apply -f issuer.yaml
+```bash title="Apply Issuer to virtual cluster"
+kubectl --context=$VCLUSTER_CTX apply -f issuer.yaml
 ```
 
 </Step>
 
 ## Create a certificate
 
-With the `ClusterIssuers` configured, create a certificate within the virtual cluster.
+With the `Issuer` configured, create a certificate within the virtual cluster.
 
 <Step>
 


### PR DESCRIPTION
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Backport cert manager fixes from PR https://github.com/loft-sh/vcluster-docs/pull/417 to `v0.22`.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

## Internal Reference
<!--Add the Github or Linear ticket reference-->
Closes DOC-389

