### PR TITLE
refactor(gcp-platform): address feedback from first PR

### DIFF
--- a/platform/_partials/install/install-next-steps.mdx
+++ b/platform/_partials/install/install-next-steps.mdx
@@ -13,3 +13,4 @@ Otherwise, read more about some primary concepts:
 * [Virtual Clusters](../../understand/what-are-virtual-clusters.mdx) - How to create and manage virtual clusters
 * [Templates](../../understand/what-are-templates.mdx) - How to use templates to control what type of resources that can be made
 * [Host Clusters](../../understand/what-are-clusters.mdx) - How to add more host clusters to the platform
+* [Sleep & Wakeup](/vcluster/manage/sleep-wakeup) - How to temporarily scale down unused virtual clusters and bring them back up

--- a/platform/install/environments/gcp.mdx
+++ b/platform/install/environments/gcp.mdx
@@ -2,7 +2,7 @@
 title: Deploy vCluster Platform on Google Cloud
 sidebar_label: GCP
 sidebar_position: 4
-description: Learn how to deploy and configure the platform on Google Cloud Platform (GPC)
+description: Learn how to deploy and configure vCluster Platform on Google Cloud Platform (GPC)
 ---
 
 import Image from "@site/src/components/Image";
@@ -11,7 +11,6 @@ import ListHelmVersions from '../../_partials/install/list-helm-versions.mdx';
 import BasePrerequisites from '../../_partials/install/base-prerequisites.mdx';
 import InstallCli from '../../../vcluster/_partials/deploy/install-cli.mdx';
 import KubeconfigUpdate from '../../../docs/_partials/kubeconfig_update.mdx';
-import ManagedK8sInstallVcluster from '../../../docs/_partials/managed_k8s_install_vcluster.mdx';
 import ProAdmonition from '../../../vcluster/_partials/admonitions/pro-admonition.mdx';
 
 import Flow, { Step } from '@site/src/components/Flow';
@@ -19,7 +18,7 @@ import Flow, { Step } from '@site/src/components/Flow';
 import Label from '@site/src/components/Label';
 
 
-This guide provides step-by-step instructions for deploying `vCluster platform` on [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine).
+This guide provides step-by-step instructions for deploying the platform on [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine).
 
 ## Prerequisites
 
@@ -96,7 +95,6 @@ You should see output similar to:
 NAME           LOCATION        MASTER_VERSION      MASTER_IP      MACHINE_TYPE   NODE_VERSION        NUM_NODES  STATUS
 vcluster-demo  europe-west1-b  1.30.5-gke.1443001  35.187.66.218  e2-standard-4  1.30.5-gke.1443001  2          RUNNING
 ```
-<ManagedK8sInstallVcluster />
 
 </Step>
 
@@ -112,12 +110,17 @@ easy steps.
 ### Install the platform
 
 <Step>
-Deploy platform using the vCluster CLI
+Deploy platform using the vCluster CLI.
 
 Now that you have vCluster running on GKE, set up the [platform
 ](/platform/install/quick-start-guide) and configure GPC in the following steps.
 
 Easiest way to deploy a platform is using the `vcluster CLI`
+
+:::note idempotency
+Please note that the command is _idempotent_, meaning that running it again does
+not result it creating another cluster with the same name.
+:::
 
 ```bash title="deploy the platform using vcluster cli
 vcluster platform start
@@ -132,7 +135,7 @@ Privacy Statement: https://www.loft.sh/legal/privacy
 ```
 
 :::tip retry
-if the command takes to long to execute, for example due to other cluster
+If the command takes to long to execute, for example due to other cluster
 operations, simply run the command one more time
 :::
 </Step>
@@ -166,16 +169,20 @@ the one supplied earlier) and <Label>Organization</Label>.
 
 To login via CLI, simply copy/pasted the `Login via CLI` command.
 
-This is the basic platform deployment, from there you can refer to the
-#post-install-steps to start using the platform. However there are a few
-additional configuration steps that can be done.
+This is the basic platform deployment, from there you can refer to the [Next
+steps seciton](#post-install-steps) to learn about platform features.
+
+There are a few additional **optional** configuration steps that can be done.
+
+- [Expose platform UI via load balancer](#load-balancer)
+- [Setup custom domain and configure DNS](#setup-domain-dns)
 </Step>
 
 </Flow>
 
 <Flow>
 
-### Expose platform UI via load balancer
+### [Optional] expose platform UI via load balancer {#load-balancer}
 
 <Step>
 Create a LoadBalancer service to expose the platform UI.
@@ -216,32 +223,31 @@ kubectl get svc vcluster-platform-loadbalancer -n vcluster-platform
 
 and navigate to the IP address in your browser `https://<EXTERNAL_IP>`.
 
-:::note certificate
+:::tip certificate
 Note that the platform uses a self-signed certificate, so you need to
-accept the warning in your browser. For production use, you should replace the
-certificate with a valid one.
+accept the warning in your browser. For production use, you should [replace the certificate with a valid one.](/platform/configure/domain#configure-tls)
 :::
 
-To learn more about how to configure certificate and TLS, read the [TLS
-configuration guide](/platform/configure/domain#configure-tls)
 </Step>
 
 </Flow>
 
 <Flow>
 
-### Setup custom domain and configure DNS
+### [Optional] setup custom domain and configure DNS {#setup-domain-dns}
 
 <Step>
 Configure DNS in Google Cloud DNS.
 To use a custom domain, you need to configure the DNS to point to the LoadBalancer IP address.
 
 ```bash title="Configure DNS"
+EXTERNAL_IP="provide the load balancer external IP"
+
 gcloud dns managed-zones create vcluster-platform --dns-name="yourdomain.tld."
 
 gcloud dns record-sets transaction start --zone=vcluster-platform
 
-gcloud dns record-sets transaction add <EXTERNAL_IP> \
+gcloud dns record-sets transaction add "${EXTERNAL_IP}" \
     --name="vcluster-platform.yourdomain.tld." \
     --ttl=300 \
     --type=A \
@@ -268,19 +274,12 @@ tutorial](https://cloud.google.com/dns/docs/tutorials/create-domain-tutorial).
 
 </Flow>
 
-## Next steps
-
-There are a few additional steps you can take to further configure the platform.
-
-### Workload Identity
-
-<ProAdmonition />
-
-When using the platform you can easily enable [Workload Identity](/vcluster/integrations/pod-identity/gke-workload-identity).
-
-### Post install {#post-install-steps}
+## Next steps {#post-install-steps}
 
 <InstallNextSteps />
+
+You can also use Google as identity provider and [configure SSO ](/platform/configure/single-sign-on/providers/google)to enable user
+authentication to the platform.
 
 ## Cleanup
 


### PR DESCRIPTION
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- remove create virtual cluster instructions
- make the load balancer and dns steps optional
- add sleep & wakeup to the next steps section
- mention using Google for SSO
- remove workload identity
- cluster creation command is idempotent
- add link to configuring TLS
- improve DNS commands

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Deploy vCluster Platform on Google Cloud](https://deploy-preview-421--vcluster-docs-site.netlify.app/docs/platform/install/environments/gcp)

## Internal Reference
<!--Add the Github or Linear ticket reference-->
Closes DOC-390

