### PR TITLE
chore: remove url from google word list

### DIFF
--- a/.github/styles/Google/WordList.yml
+++ b/.github/styles/Google/WordList.yml
@@ -72,6 +72,5 @@ swap:
   tablename: table name
   tablet: device
   touch: tap
-  url: URL
   vs\.: versus
   World Wide Web: web


### PR DESCRIPTION
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Word list rules still trigger even if text is enclosed in backticks

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
N/A

## Internal Reference
<!--Add the Github or Linear ticket reference-->
Closes DOC-

