### PR TITLE
chore(vale): add devspace to vale exceptions

### DIFF
--- a/.github/styles/config/vocabularies/Loft/accept.txt
+++ b/.github/styles/config/vocabularies/Loft/accept.txt
@@ -12,3 +12,4 @@ AWS
 GKE
 GCP
 AKS
+DevSpace


### PR DESCRIPTION
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
DevSpace as a product should have capital D and S, whereas if used as CLI, should be enclosed in backticks and written in lowercase.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
N/A

## Internal Reference
<!--Add the Github or Linear ticket reference-->
Closes DOC-395

