### PR TITLE
feat: Add vale rule to block use of site in local partials

### DIFF
--- a/.github/styles/Loft/centralize-partials-fragments.yml
+++ b/.github/styles/Loft/centralize-partials-fragments.yml
@@ -1,0 +1,6 @@
+extends: existence
+message: "Avoid using @site directive for referencing docs-specific partials and fragments. Use relative paths instead."
+level: error
+scope: raw
+raw:
+  - '@site/(?:vcluster|platform|.*versioned.*)/[_partials|_fragments]'

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -5,6 +5,6 @@ sidebar_position: 1
 hide_table_of_contents: false
 ---
 
-import PartialWhatAreVirtualClusters from '@site/vcluster/_partials/what-are-virtual-clusters.mdx'
+import PartialWhatAreVirtualClusters from '../vcluster/_partials/what-are-virtual-clusters.mdx'
 
 <PartialWhatAreVirtualClusters />

--- a/vcluster/_partials/deploy/deploy.mdx
+++ b/vcluster/_partials/deploy/deploy.mdx
@@ -3,7 +3,7 @@ import Flow, { Step } from "@site/src/components/Flow";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import CodeBlock from '@theme/CodeBlock';
-import TerraformDeploy from '!!raw-loader!@site/vcluster/_partials/deploy/terraform-deploy.tf'
+import TerraformDeploy from '!!raw-loader!./terraform-deploy.tf'
 import InstallCLIFragment from './install-cli-beta.mdx'
 
 <Tabs

--- a/vcluster_versioned_docs/version-0.21.0/_partials/deploy/deploy.mdx
+++ b/vcluster_versioned_docs/version-0.21.0/_partials/deploy/deploy.mdx
@@ -3,7 +3,7 @@ import Flow, { Step } from "@site/src/components/Flow";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import CodeBlock from '@theme/CodeBlock';
-import TerraformDeploy from '!!raw-loader!@site/vcluster/_partials/deploy/terraform-deploy.tf'
+import TerraformDeploy from '!!raw-loader!../../../../vcluster/_partials/deploy/terraform-deploy.tf'
 import InstallCLIFragment from './install-cli.mdx'
 
 <Tabs

--- a/vcluster_versioned_docs/version-0.22.0/_fragments/integrations/cert-manager.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/_fragments/integrations/cert-manager.mdx
@@ -7,7 +7,7 @@ import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
 import CertManagerPartial from "../../_partials/config/integrations/certManager.mdx";
-import BasePrerequisites from "@site/platform/_partials/install/base-prerequisites.mdx";
+import BasePrerequisites from "../../../../platform/_partials/install/base-prerequisites.mdx";
 import CodeBlock from "@theme/CodeBlock";
 import Deploy from "../../_partials/deploy/deploy.mdx";
 import ProAdmonition from "../../_partials/admonitions/pro-admonition.mdx";

--- a/vcluster_versioned_docs/version-0.22.0/_partials/deploy/deploy.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/_partials/deploy/deploy.mdx
@@ -3,7 +3,7 @@ import Flow, { Step } from "@site/src/components/Flow";
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 import CodeBlock from '@theme/CodeBlock';
-import TerraformDeploy from '!!raw-loader!@site/vcluster/_partials/deploy/terraform-deploy.tf'
+import TerraformDeploy from '!!raw-loader!../../../../vcluster/_partials/deploy/terraform-deploy.tf'
 import InstallCLIFragment from './install-cli-beta.mdx'
 
 <Tabs

--- a/vcluster_versioned_docs/version-0.22.0/deploy/environment/gke.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/deploy/environment/gke.mdx
@@ -6,7 +6,7 @@ id: gke
 description: Learn how to deploy vCluster on Google Kubernetes Engine (GKE), including storage provisioning and Workload Identity configuration.
 ---
 
-import BasePrerequisites from '@site/platform/_partials/install/base-prerequisites.mdx';
+import BasePrerequisites from '../../../../platform/_partials/install/base-prerequisites.mdx';
 import Mark from "@site/src/components/Mark";
 import InstallCli from '../../_partials/deploy/install-cli.mdx';
 import KubeconfigUpdate from '@site/docs/_partials/kubeconfig_update.mdx';

--- a/vcluster_versioned_docs/version-0.22.0/deploy/topologies/air-gapped.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/deploy/topologies/air-gapped.mdx
@@ -9,7 +9,7 @@ sidebar_class_name: pro
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import Flow, { Step } from "@site/src/components/Flow";
-import BasePrerequisites from '@site/platform/_partials/install/base-prerequisites.mdx';
+import BasePrerequisites from '../../../../platform/_partials/install/base-prerequisites.mdx';
 
 import FipsConfig from '../../_partials/deploy/fips-config.mdx';
 


### PR DESCRIPTION
# Content Description

Add vale rule to block use of site in local partials. Also fix existing partials to conform to the rule.

Didn't fix usage of fragments because there were too many existing violations.

>We want to avoid using `@site` directive to reference docs specific `_partials` (references inside vcluster, platform or versioned folders). 
>
>To make this check automated, we would like to a create a vale rule to capture and enforce the logic. 

## Preview link

https://deploy-preview-425--vcluster-docs-site.netlify.app/docs/

## Internal Reference
Closes DOC-287

