### PR TITLE
Update hpm installation instructions under versioned

### DIFF
--- a/.github/styles/Google/Headings.yml
+++ b/.github/styles/Google/Headings.yml
@@ -11,6 +11,7 @@ exceptions:
   - CLI
   - Cosmos
   - Docker
+  - DNS
   - Emmet
   - gRPC
   - I

--- a/vcluster/configure/vcluster-yaml/control-plane/components/host-path-mapper.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/host-path-mapper.mdx
@@ -15,11 +15,32 @@ Virtual cluster internal logging relies on a separate component called the [Host
 
 If you don't map host paths, logs for vCluster pods are incorrectly resolved by log collectors such as Loki, ELK, and Fluentd.
 
-## vCluster open source
+## vCluster Open Source
 
-Set `enabled: true` to configure vCluster to deploy a HostPath Mapper DaemonSet per Node per vCluster instance.
+### Enabling the HostPath Mapper
+Set `enabled: true` in the vCluster config to allow it to use the HostPath Mapper daemonset, which would be created in the next step.
+```yaml title="vcluster.yaml"
+controlPlane:
+  hostPathMapper:
+    enabled: true
+```
 
-## vCluster pro
+### Deploy the HostPath Mapper daemonset
+Now that the vCluster itself is ready, the HostPath Mapper component can be deployed. The following 2 pieces of information are needed for this:
+* The HostPath Mapper has to be deployed in the same namespace as the target vCluster
+* The `.Values.VclusterReleaseName` value when deploying this Helm Chart needs to be equal to the name of the target vCluster
+
+For example if your vCluster is named `my-vcluster` and is deployed in namespace `my-namespace` then you should run
+```bash title="Installing the HostPath Mapper daemonset"
+helm install vcluster-hpm vcluster-hpm \
+    --repo https://charts.loft.sh \
+    -n my-namespace \
+    --set VclusterReleaseName=my-vcluster
+```
+
+Once deployed successfully a new Daemonset component of the HostPath Mapper would start running on every node used by the vCluster workloads.
+
+## vCluster Pro
 
 The Centralized HostPath Mapper feature supports the following use cases in the virtual cluster:
 
@@ -28,7 +49,7 @@ The Centralized HostPath Mapper feature supports the following use cases in the 
 - Velero restic backups.
 - KubeVirt workloads.
 
-Set `central: true` to configure vCluster to deploy one HostPath Mapper DaemonSet that is used by multiple virtual clusters.
+For details on configuring the vCluster and installing the Central HostPath Mapper, refer to the [central-hostpath-mapper](../../../../../../platform/administer/monitoring/central-hostpath-mapper) page under the platform documentation.
 
 ## Config reference
 

--- a/vcluster/introduction/architecture.mdx
+++ b/vcluster/introduction/architecture.mdx
@@ -17,7 +17,7 @@ Virtual clusters are fully functional Kubernetes clusters nested inside a physic
   <figcaption>vCluster - Pod Scheduling</figcaption>
 </figure>
 
-## Virtual cluster compoments
+## Virtual cluster components
 
 ### Virtual control plane
 

--- a/vcluster_versioned_docs/version-0.20.0/configure/vcluster-yaml/control-plane/components/host-path-mapper.mdx
+++ b/vcluster_versioned_docs/version-0.20.0/configure/vcluster-yaml/control-plane/components/host-path-mapper.mdx
@@ -37,6 +37,9 @@ helm install vcluster-hpm vcluster-hpm \
     -n my-namespace \
     --set VclusterReleaseName=my-vcluster
 ```
+:::note
+Only versions v0.1.x of the HostPathMapper Chart are compatible with virtual clusters running v0.20.0. Versions 0.2.x and later are not supported.
+:::
 
 Once deployed successfully a new Daemonset component of the HostPath Mapper would start running on every node used by the vCluster workloads.
 

--- a/vcluster_versioned_docs/version-0.20.0/introduction/architecture.mdx
+++ b/vcluster_versioned_docs/version-0.20.0/introduction/architecture.mdx
@@ -15,7 +15,7 @@ Virtual clusters are fully functional Kubernetes clusters nested inside a physic
   <figcaption>vCluster - Pod Scheduling</figcaption>
 </figure>
 
-## Virtual cluster compoments
+## Virtual cluster components
 
 ### Virtual control plane
 

--- a/vcluster_versioned_docs/version-0.21.0/configure/vcluster-yaml/control-plane/components/host-path-mapper.mdx
+++ b/vcluster_versioned_docs/version-0.21.0/configure/vcluster-yaml/control-plane/components/host-path-mapper.mdx
@@ -15,11 +15,32 @@ Virtual cluster internal logging relies on a separate component called the [Host
 
 If you don't map host paths, logs for vCluster pods are incorrectly resolved by log collectors such as Loki, ELK, and Fluentd.
 
-## vCluster open source
+## vCluster Open Source
 
-Set `enabled: true` to configure vCluster to deploy a HostPath Mapper DaemonSet per Node per vCluster instance.
+### Enabling the HostPath Mapper
+Set `enabled: true` in the vCluster config to allow it to use the HostPath Mapper daemonset, which would be created in the next step.
+```yaml title="vcluster.yaml"
+controlPlane:
+  hostPathMapper:
+    enabled: true
+```
 
-## vCluster pro
+### Deploy the HostPath Mapper daemonset
+Now that the vCluster itself is ready, the HostPath Mapper component can be deployed. The following 2 pieces of information are needed for this:
+* The HostPath Mapper has to be deployed in the same namespace as the target vCluster
+* The `.Values.VclusterReleaseName` value when deploying this Helm Chart needs to be equal to the name of the target vCluster
+
+For example if your vCluster is named `my-vcluster` and is deployed in namespace `my-namespace` then you should run
+```bash title="Installing the HostPath Mapper daemonset"
+helm install vcluster-hpm vcluster-hpm \
+    --repo https://charts.loft.sh \
+    -n my-namespace \
+    --set VclusterReleaseName=my-vcluster
+```
+
+Once deployed successfully a new Daemonset component of the HostPath Mapper would start running on every node used by the vCluster workloads.
+
+## vCluster Pro
 
 The Centralized HostPath Mapper feature supports the following use cases in the virtual cluster:
 
@@ -28,7 +49,7 @@ The Centralized HostPath Mapper feature supports the following use cases in the 
 - Velero restic backups.
 - KubeVirt workloads.
 
-Set `central: true` to configure vCluster to deploy one HostPath Mapper DaemonSet that is used by multiple virtual clusters.
+For details on configuring the vCluster and installing the Central HostPath Mapper, refer to the [central-hostpath-mapper](../../../../../../platform/administer/monitoring/central-hostpath-mapper) page under the platform documentation.
 
 ## Config reference
 

--- a/vcluster_versioned_docs/version-0.21.0/introduction/architecture.mdx
+++ b/vcluster_versioned_docs/version-0.21.0/introduction/architecture.mdx
@@ -17,7 +17,7 @@ Virtual clusters are fully functional Kubernetes clusters nested inside a physic
   <figcaption>vCluster - Pod Scheduling</figcaption>
 </figure>
 
-## Virtual cluster compoments
+## Virtual cluster components
 
 ### Virtual control plane
 

--- a/vcluster_versioned_docs/version-0.22.0/configure/vcluster-yaml/control-plane/components/host-path-mapper.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/configure/vcluster-yaml/control-plane/components/host-path-mapper.mdx
@@ -15,11 +15,32 @@ Virtual cluster internal logging relies on a separate component called the [Host
 
 If you don't map host paths, logs for vCluster pods are incorrectly resolved by log collectors such as Loki, ELK, and Fluentd.
 
-## vCluster open source
+## vCluster Open Source
 
-Set `enabled: true` to configure vCluster to deploy a HostPath Mapper DaemonSet per Node per vCluster instance.
+### Enabling the HostPath Mapper
+Set `enabled: true` in the vCluster config to allow it to use the HostPath Mapper daemonset, which would be created in the next step.
+```yaml title="vcluster.yaml"
+controlPlane:
+  hostPathMapper:
+    enabled: true
+```
 
-## vCluster pro
+### Deploy the HostPath Mapper daemonset
+Now that the vCluster itself is ready, the HostPath Mapper component can be deployed. The following 2 pieces of information are needed for this:
+* The HostPath Mapper has to be deployed in the same namespace as the target vCluster
+* The `.Values.VclusterReleaseName` value when deploying this Helm Chart needs to be equal to the name of the target vCluster
+
+For example if your vCluster is named `my-vcluster` and is deployed in namespace `my-namespace` then you should run
+```bash title="Installing the HostPath Mapper daemonset"
+helm install vcluster-hpm vcluster-hpm \
+    --repo https://charts.loft.sh \
+    -n my-namespace \
+    --set VclusterReleaseName=my-vcluster
+```
+
+Once deployed successfully a new Daemonset component of the HostPath Mapper would start running on every node used by the vCluster workloads.
+
+## vCluster Pro
 
 The Centralized HostPath Mapper feature supports the following use cases in the virtual cluster:
 
@@ -28,7 +49,7 @@ The Centralized HostPath Mapper feature supports the following use cases in the 
 - Velero restic backups.
 - KubeVirt workloads.
 
-Set `central: true` to configure vCluster to deploy one HostPath Mapper DaemonSet that is used by multiple virtual clusters.
+For details on configuring the vCluster and installing the Central HostPath Mapper, refer to the [central-hostpath-mapper](../../../../../platform/administer/monitoring/central-hostpath-mapper) page under the platform documentation.
 
 ## Config reference
 

--- a/vcluster_versioned_docs/version-0.22.0/introduction/architecture.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/introduction/architecture.mdx
@@ -17,7 +17,7 @@ Virtual clusters are fully functional Kubernetes clusters nested inside a physic
   <figcaption>vCluster - Pod Scheduling</figcaption>
 </figure>
 
-## Virtual cluster compoments
+## Virtual cluster components
 
 ### Virtual control plane
 


### PR DESCRIPTION
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Updated the docs for current and previous version (v0.21 & v0.22) to include detailed installation instructions for hpm. 

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
- [Architecture](https://deploy-preview-431--vcluster-docs-site.netlify.app/docs/vcluster/next/introduction/architecture)
- [HostPath Mapper](https://deploy-preview-431--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/control-plane/components/host-path-mapper)

## Internal Reference
<!--Add the Github or Linear ticket reference-->
Closes DOC-393

