### PR TITLE
chore(cli): fixing vcluster commands references

### DIFF
--- a/vcluster/cli/vcluster_connect.md
+++ b/vcluster/cli/vcluster_connect.md
@@ -49,7 +49,7 @@ vcluster connect test -n test -- kubectl get ns
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_convert.md
+++ b/vcluster/cli/vcluster_convert.md
@@ -25,7 +25,7 @@ Convert virtual cluster config values
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_convert_config.md
+++ b/vcluster/cli/vcluster_convert_config.md
@@ -40,7 +40,7 @@ cat /my/k0s/values.yaml | vcluster convert config --distro k0s
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_create.md
+++ b/vcluster/cli/vcluster_create.md
@@ -35,7 +35,6 @@ vcluster create test --namespace test
       --chart-version string              The virtual cluster chart version to use (e.g. v0.9.1)
       --cluster string                    [PLATFORM] The vCluster platform connected cluster to use
       --connect                           If true will run vcluster connect directly after the vcluster was created (default true)
-      --create-context                    If the CLI should create a kube context for the space (default true)
       --create-namespace                  If true the namespace will be created if it does not exist (default true)
       --description string                [PLATFORM] The description to show in the platform UI for this virtual cluster
       --display-name string               [PLATFORM] The display name to show in the platform UI for this virtual cluster
@@ -55,11 +54,9 @@ vcluster create test --namespace test
       --set-param stringArray             [PLATFORM] If a template is used, this can be used to set a specific parameter. E.g. --set-param 'my-param=my-value'
       --set-parameter stringArray         [PLATFORM] If a template is used, this can be used to set a specific parameter. E.g. --set-parameter 'my-param=my-value'
       --skip-wait                         [PLATFORM] If true, will not wait until the virtual cluster is running
-      --switch-context                    If the CLI should switch the current context to the new context (default true)
       --team string                       [PLATFORM] The team to create the space for
       --template string                   [PLATFORM] The vCluster platform template to use
       --template-version string           [PLATFORM] The vCluster platform template version to use
-      --update-current                    If true updates the current kube config (default true)
       --upgrade                           If true will try to upgrade the vcluster instead of failing if it already exists
       --use                               [PLATFORM] If the platform should use the virtual cluster if its already there
       --user string                       [PLATFORM] The user to create the space for
@@ -70,7 +67,7 @@ vcluster create test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_credits.md
+++ b/vcluster/cli/vcluster_credits.md
@@ -27,7 +27,7 @@ Saves licenses, copyright notices and source code, as required by a Go package's
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_debug.md
+++ b/vcluster/cli/vcluster_debug.md
@@ -1,0 +1,35 @@
+---
+title: "vcluster debug --help"
+sidebar_label: vcluster debug
+---
+
+
+Debug retrieves information from vCluster
+
+## Synopsis
+
+```
+#######################################################
+################### vcluster debug ####################
+#######################################################
+```
+
+
+## Flags
+
+```
+  -h, --help   help for debug
+```
+
+
+## Global & Inherited Flags
+
+```
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
+      --context string      The kubernetes config context to use
+      --debug               Prints the stack trace if an error occurs
+      --log-output string   The log format to use. Can be either plain, raw or json (default "plain")
+  -n, --namespace string    The kubernetes namespace to use
+  -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals
+```
+

--- a/vcluster/cli/vcluster_debug_collect.md
+++ b/vcluster/cli/vcluster_debug_collect.md
@@ -1,0 +1,52 @@
+---
+title: "vcluster debug collect --help"
+sidebar_label: vcluster debug collect
+---
+
+
+Collects debugging information from the vCluster
+
+## Synopsis
+
+```
+vcluster debug collect [flags]
+```
+
+```
+##############################################################
+################### vcluster debug collect ###################
+##############################################################
+Collects debugging information from the vCluster
+
+Examples:
+vcluster debug collect
+##############################################################
+```
+
+
+## Flags
+
+```
+      --count-virtual-cluster-objects   Collect how many objects are in the vCluster (default true)
+  -h, --help                            help for collect
+      --host-info                       Collect host cluster info (default true)
+      --host-resources strings          Collect host resources in vCluster namespace
+      --logs                            Collect vCluster logs (default true)
+      --output-filename string          If specified, will write to the given filename
+      --release                         Collect vCluster release info (default true)
+      --virtual-info                    Collect virtual cluster info (default true)
+      --virtual-resources strings       Collect virtual cluster resources
+```
+
+
+## Global & Inherited Flags
+
+```
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
+      --context string      The kubernetes config context to use
+      --debug               Prints the stack trace if an error occurs
+      --log-output string   The log format to use. Can be either plain, raw or json (default "plain")
+  -n, --namespace string    The kubernetes namespace to use
+  -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals
+```
+

--- a/vcluster/cli/vcluster_delete.md
+++ b/vcluster/cli/vcluster_delete.md
@@ -43,7 +43,7 @@ vcluster delete test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_describe.md
+++ b/vcluster/cli/vcluster_describe.md
@@ -38,7 +38,7 @@ vcluster describe -o json test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_disconnect.md
+++ b/vcluster/cli/vcluster_disconnect.md
@@ -37,7 +37,7 @@ vcluster disconnect
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_list.md
+++ b/vcluster/cli/vcluster_list.md
@@ -38,7 +38,7 @@ vcluster list --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_login.md
+++ b/vcluster/cli/vcluster_login.md
@@ -39,7 +39,7 @@ vcluster login https://my-vcluster-platform.com --access-key myaccesskey
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_logout.md
+++ b/vcluster/cli/vcluster_logout.md
@@ -34,7 +34,7 @@ vcluster logout
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_pause.md
+++ b/vcluster/cli/vcluster_pause.md
@@ -43,7 +43,7 @@ vcluster pause test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform.md
+++ b/vcluster/cli/vcluster_platform.md
@@ -25,7 +25,7 @@ vCluster platform subcommands
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_access-key.md
+++ b/vcluster/cli/vcluster_platform_access-key.md
@@ -39,7 +39,7 @@ vcluster platform token
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_add.md
+++ b/vcluster/cli/vcluster_platform_add.md
@@ -25,7 +25,7 @@ Adds a cluster to vCluster platform
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_add_cluster.md
+++ b/vcluster/cli/vcluster_platform_add_cluster.md
@@ -35,7 +35,7 @@ vcluster platform add cluster my-cluster
       --helm-values stringArray     Extra helm values for the agent chart
   -h, --help                        help for cluster
       --insecure                    If true, deploys the agent in insecure mode
-      --namespace string            The namespace to generate the service account in. The namespace will be created if it does not exist (default "loft")
+      --namespace string            The namespace to generate the service account in. The namespace will be created if it does not exist (default "vcluster-platform")
       --service-account string      The service account name to create (default "loft-admin")
       --wait                        If true, will wait until the cluster is initialized
 ```
@@ -44,7 +44,7 @@ vcluster platform add cluster my-cluster
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")
   -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals

--- a/vcluster/cli/vcluster_platform_add_vcluster.md
+++ b/vcluster/cli/vcluster_platform_add_vcluster.md
@@ -20,6 +20,10 @@ Adds a vCluster to the vCluster platform.
 
 Example:
 vcluster platform add vcluster my-vcluster --namespace vcluster-my-vcluster --project my-project --import-name my-vcluster
+
+Add all vCluster instances in the host cluster:
+vcluster platform add vcluster --project my-project --all
+
 ###############################################
 ```
 
@@ -27,20 +31,22 @@ vcluster platform add vcluster my-vcluster --namespace vcluster-my-vcluster --pr
 ## Flags
 
 ```
-      --access-key string    The access key for the vCluster to connect to the platform. If empty, the CLI will generate one
-  -h, --help                 help for vcluster
-      --host string          The host where to reach the platform
-      --import-name string   The name of the vCluster under projects. If unspecified, will use the vcluster name
-      --insecure             If the platform host is insecure
-      --project string       The project to import the vCluster into
-      --restart              Restart the vCluster control-plane after creating the platform secret (default true)
+      --access-key string     The access key for the vCluster to connect to the platform. If empty, the CLI will generate one
+      --all                   all will try to add Virtual Cluster found in all namespaces in the host cluster. If this flag is set, any provided vCluster name argument is ignored
+      --ca-data bytesBase64   additional, base64 encoded certificate authority data that will be passed to the platform secret
+  -h, --help                  help for vcluster
+      --host string           The host where to reach the platform
+      --import-name string    The name of the vCluster under projects. If unspecified, will use the vcluster name
+      --insecure              If the platform host is insecure
+      --project string        The project to import the vCluster into
+      --restart               Restart the vCluster control-plane after creating the platform secret (default true)
 ```
 
 
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_backup.md
+++ b/vcluster/cli/vcluster_platform_backup.md
@@ -25,7 +25,7 @@ Backup subcommands
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_backup_management.md
+++ b/vcluster/cli/vcluster_platform_backup_management.md
@@ -30,7 +30,7 @@ vcluster platform backup management
 ```
       --filename string    The filename to write the backup to (default "backup.yaml")
   -h, --help               help for management
-      --namespace string   The namespace vCluster platform was installed into (default "vcluster-platform")
+      --namespace string   The namespace vCluster platform was installed into
       --skip strings       What resources the backup should skip. Valid options are: users, teams, accesskeys, sharedsecrets, clusters and clusteraccounttemplates
 ```
 
@@ -38,7 +38,7 @@ vcluster platform backup management
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_connect.md
+++ b/vcluster/cli/vcluster_platform_connect.md
@@ -28,7 +28,7 @@ Activates a kube context for the given cluster / management / namespace / vclust
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_connect_cluster.md
+++ b/vcluster/cli/vcluster_platform_connect_cluster.md
@@ -37,7 +37,7 @@ vcluster platform connect cluster mycluster
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_connect_management.md
+++ b/vcluster/cli/vcluster_platform_connect_management.md
@@ -36,7 +36,7 @@ vcluster platform connect management
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_connect_namespace.md
+++ b/vcluster/cli/vcluster_platform_connect_namespace.md
@@ -42,7 +42,7 @@ vcluster platform connect namespace myspace --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_connect_vcluster.md
+++ b/vcluster/cli/vcluster_platform_connect_vcluster.md
@@ -48,7 +48,7 @@ vcluster platform connect vcluster test -n test -- kubectl get ns
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_create.md
+++ b/vcluster/cli/vcluster_platform_create.md
@@ -25,7 +25,7 @@ Creates vCluster platform resources
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_create_namespace.md
+++ b/vcluster/cli/vcluster_platform_create_namespace.md
@@ -59,7 +59,7 @@ vcluster platform create namespace myspace --project myproject --team myteam
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_create_vcluster.md
+++ b/vcluster/cli/vcluster_platform_create_vcluster.md
@@ -33,7 +33,6 @@ vcluster platform create vcluster test --namespace test
       --chart-version string              The virtual cluster chart version to use (e.g. v0.9.1)
       --cluster string                    The vCluster platform connected cluster to use
       --connect                           If true will run vcluster connect directly after the vcluster was created (default true)
-      --create-context                    If the CLI should create a kube context for the space (default true)
       --description string                The description to show in the platform UI for this virtual cluster
       --display-name string               The display name to show in the platform UI for this virtual cluster
       --expose                            If true will create a load balancer service to expose the vcluster endpoint
@@ -51,11 +50,9 @@ vcluster platform create vcluster test --namespace test
       --set-param stringArray             If a template is used, this can be used to set a specific parameter. E.g. --set-param 'my-param=my-value'
       --set-parameter stringArray         If a template is used, this can be used to set a specific parameter. E.g. --set-parameter 'my-param=my-value'
       --skip-wait                         If true, will not wait until the virtual cluster is running
-      --switch-context                    If the CLI should switch the current context to the new context (default true)
       --team string                       The team to create the space for
       --template string                   The vCluster platform template to use
       --template-version string           The vCluster platform template version to use
-      --update-current                    If true updates the current kube config (default true)
       --upgrade                           If true will try to upgrade the vcluster instead of failing if it already exists
       --use                               If the platform should use the virtual cluster if its already there
       --user string                       The user to create the space for
@@ -66,7 +63,7 @@ vcluster platform create vcluster test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_delete.md
+++ b/vcluster/cli/vcluster_platform_delete.md
@@ -25,7 +25,7 @@ Deletes vCluster platform resources
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_delete_namespace.md
+++ b/vcluster/cli/vcluster_platform_delete_namespace.md
@@ -40,7 +40,7 @@ vcluster platform delete namespace myspace --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_delete_vcluster.md
+++ b/vcluster/cli/vcluster_platform_delete_vcluster.md
@@ -37,7 +37,7 @@ vcluster platform delete vcluster --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_destroy.md
+++ b/vcluster/cli/vcluster_platform_destroy.md
@@ -1,0 +1,61 @@
+---
+title: "vcluster platform destroy --help"
+sidebar_label: vcluster platform destroy
+---
+
+
+Destroy a vCluster Platform instance
+
+## Synopsis
+
+```
+vcluster platform destroy [flags]
+```
+
+```
+########################################################
+############# vcluster platform destroy ##################
+########################################################
+
+Destroys a vCluster Platform instance in your Kubernetes cluster.
+
+IMPORTANT: This action is done against the cluster the the kube-context is pointing to, and not the vCluster Platform instance that is logged in.
+It does not require logging in to vCluster Platform.
+
+Please make sure you meet the following requirements
+before running this command:
+
+1. Current kube-context has admin access to the cluster
+2. Helm v3 must be installed
+
+
+VirtualClusterInstances managed with driver helm will be deleted, but the underlying virtual cluster will not be uninstalled.
+
+########################################################
+```
+
+
+## Flags
+
+```
+      --context string            The kube context to use for installation
+      --delete-namespace          Whether to delete the namespace or not (default true)
+      --force                     Try uninstalling even if the platform is not installed. '--namespace' is required if true
+      --force-remove-finalizers   IMPORTANT! Removing finalizers may cause unintended behaviours like leaving resources behind, but will ensure the platform is uninstalled.
+  -h, --help                      help for destroy
+      --ignore-not-found          Exit successfully if platform installation is not found
+      --namespace string          The namespace vCluster Platform is installed in
+      --non-interactive           Will not prompt for confirmation
+      --timeout-minutes int       How long to try deleting the platform before giving up. May increase when removing finalizers if --remove-finalizers is used (default 5)
+```
+
+
+## Global & Inherited Flags
+
+```
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
+      --debug               Prints the stack trace if an error occurs
+      --log-output string   The log format to use. Can be either plain, raw or json (default "plain")
+  -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals
+```
+

--- a/vcluster/cli/vcluster_platform_get.md
+++ b/vcluster/cli/vcluster_platform_get.md
@@ -25,7 +25,7 @@ Retrieves and display informations
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_get_cluster-access-key.md
+++ b/vcluster/cli/vcluster_platform_get_cluster-access-key.md
@@ -36,7 +36,7 @@ vcluster platform get cluster-access-key [CLUSTER_NAME]
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_get_cluster.md
+++ b/vcluster/cli/vcluster_platform_get_cluster.md
@@ -20,7 +20,7 @@ vcluster platform get cluster [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_get_current-user.md
+++ b/vcluster/cli/vcluster_platform_get_current-user.md
@@ -36,7 +36,7 @@ vcluster platform get current-user
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_get_secret.md
+++ b/vcluster/cli/vcluster_platform_get_secret.md
@@ -40,7 +40,7 @@ vcluster platform get secret test-secret.key --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_list.md
+++ b/vcluster/cli/vcluster_platform_list.md
@@ -25,7 +25,7 @@ Lists configuration
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_list_clusters.md
+++ b/vcluster/cli/vcluster_platform_list_clusters.md
@@ -35,7 +35,7 @@ vcluster platform list clusters
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_list_namespaces.md
+++ b/vcluster/cli/vcluster_platform_list_namespaces.md
@@ -34,7 +34,7 @@ vcluster platform list namespaces
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_list_projects.md
+++ b/vcluster/cli/vcluster_platform_list_projects.md
@@ -35,7 +35,7 @@ vcluster platform list projects
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_list_secrets.md
+++ b/vcluster/cli/vcluster_platform_list_secrets.md
@@ -39,7 +39,7 @@ vcluster platform list secrets
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_list_teams.md
+++ b/vcluster/cli/vcluster_platform_list_teams.md
@@ -35,7 +35,7 @@ vcluster platform list teams
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_list_vclusters.md
+++ b/vcluster/cli/vcluster_platform_list_vclusters.md
@@ -36,7 +36,7 @@ vcluster platform list vclusters
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_login.md
+++ b/vcluster/cli/vcluster_platform_login.md
@@ -39,7 +39,7 @@ vcluster platform login https://my-vcluster-platform.com --access-key myaccesske
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_logout.md
+++ b/vcluster/cli/vcluster_platform_logout.md
@@ -34,7 +34,7 @@ vcluster platform logout
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_reset.md
+++ b/vcluster/cli/vcluster_platform_reset.md
@@ -25,7 +25,7 @@ Reset configuration
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_reset_password.md
+++ b/vcluster/cli/vcluster_platform_reset_password.md
@@ -28,22 +28,22 @@ vcluster platform reset password --user admin
 ## Flags
 
 ```
-      --create            Creates the user if it does not exist
-      --force             If user had no password will create one
-  -h, --help              help for password
-      --password string   The new password to use
-      --user string       The name of the user to reset the password (default "admin")
+      --create             Creates the user if it does not exist
+      --force              If user had no password will create one
+  -h, --help               help for password
+      --namespace string   The namespace to use (default "vcluster-platform")
+      --password string    The new password to use
+      --user string        The name of the user to reset the password (default "admin")
 ```
 
 
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")
-  -n, --namespace string    The kubernetes namespace to use
   -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals
 ```
 

--- a/vcluster/cli/vcluster_platform_set.md
+++ b/vcluster/cli/vcluster_platform_set.md
@@ -25,7 +25,7 @@ Set configuration
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_set_secret.md
+++ b/vcluster/cli/vcluster_platform_set_secret.md
@@ -39,7 +39,7 @@ vcluster platform set secret test-secret.key value --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_share.md
+++ b/vcluster/cli/vcluster_platform_share.md
@@ -25,7 +25,7 @@ Shares a virtual cluster / namespace with another vCluster platform user or team
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_share_namespace.md
+++ b/vcluster/cli/vcluster_platform_share_namespace.md
@@ -42,7 +42,7 @@ vcluster platform share namespace myspace --project myproject --user admin
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_share_vcluster.md
+++ b/vcluster/cli/vcluster_platform_share_vcluster.md
@@ -41,7 +41,7 @@ vcluster platform share vcluster myvcluster --project myproject --user admin
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_sleep.md
+++ b/vcluster/cli/vcluster_platform_sleep.md
@@ -28,7 +28,7 @@ Put a virtual cluster / namespace to sleep.
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_sleep_namespace.md
+++ b/vcluster/cli/vcluster_platform_sleep_namespace.md
@@ -38,7 +38,7 @@ vcluster platform sleep namespace myspace --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_sleep_vcluster.md
+++ b/vcluster/cli/vcluster_platform_sleep_vcluster.md
@@ -42,7 +42,7 @@ vcluster platform sleep vcluster test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_start.md
+++ b/vcluster/cli/vcluster_platform_start.md
@@ -48,7 +48,7 @@ before running this command:
       --no-tunnel            If true, vCluster platform will not create a loft.host tunnel for this installation
       --no-wait              If true, vCluster platform will not wait after installing it
       --password string      The password to use for the admin account. (If empty this will be the namespace UID)
-      --reset                If true, an existing vCluster platform instance will be deleted before installing vCluster platform
+      --reset                If true, existing vCluster Platform resources, including the deployment, will be deleted before installing vCluster platform
       --reuse-values         Reuse previous vCluster platform helm values on upgrade (default true)
       --upgrade              If true, vCluster platform will try to upgrade the release
       --values string        Path to a file for extra vCluster platform helm chart values
@@ -59,7 +59,7 @@ before running this command:
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")
   -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals

--- a/vcluster/cli/vcluster_platform_wakeup.md
+++ b/vcluster/cli/vcluster_platform_wakeup.md
@@ -28,7 +28,7 @@ Wake up a virtual cluster / namespace.
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_wakeup_namespace.md
+++ b/vcluster/cli/vcluster_platform_wakeup_namespace.md
@@ -37,7 +37,7 @@ vcluster platform wakeup namespace myspace --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_platform_wakeup_vcluster.md
+++ b/vcluster/cli/vcluster_platform_wakeup_vcluster.md
@@ -37,7 +37,7 @@ vcluster platform wakeup vcluster test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_resume.md
+++ b/vcluster/cli/vcluster_resume.md
@@ -38,7 +38,7 @@ vcluster resume test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_set.md
+++ b/vcluster/cli/vcluster_set.md
@@ -25,7 +25,7 @@ Set configuration
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_set_secret.md
+++ b/vcluster/cli/vcluster_set_secret.md
@@ -39,7 +39,7 @@ vcluster platform set secret test-secret.key value --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_telemetry.md
+++ b/vcluster/cli/vcluster_telemetry.md
@@ -30,7 +30,7 @@ docs: https://www.vcluster.com/docs/advanced-topics/telemetry
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_telemetry_disable.md
+++ b/vcluster/cli/vcluster_telemetry_disable.md
@@ -35,7 +35,7 @@ docs: https://www.vcluster.com/docs/advanced-topics/telemetry
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_telemetry_enable.md
+++ b/vcluster/cli/vcluster_telemetry_enable.md
@@ -35,7 +35,7 @@ docs: https://www.vcluster.com/docs/advanced-topics/telemetry
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_ui.md
+++ b/vcluster/cli/vcluster_ui.md
@@ -34,7 +34,7 @@ vcluster ui
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_upgrade.md
+++ b/vcluster/cli/vcluster_upgrade.md
@@ -32,7 +32,7 @@ Upgrades the vcluster CLI to the newest version
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_use.md
+++ b/vcluster/cli/vcluster_use.md
@@ -25,7 +25,7 @@ vCluster use subcommand
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_use_driver.md
+++ b/vcluster/cli/vcluster_use_driver.md
@@ -31,7 +31,7 @@ Either use "helm" or "platform" as the deployment method for managing virtual cl
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster/cli/vcluster_version.md
+++ b/vcluster/cli/vcluster_version.md
@@ -27,7 +27,7 @@ All software has versions. This is Vcluster's.
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_connect.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_connect.md
@@ -49,7 +49,7 @@ vcluster connect test -n test -- kubectl get ns
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_convert.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_convert.md
@@ -25,7 +25,7 @@ Convert virtual cluster config values
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_convert_config.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_convert_config.md
@@ -40,7 +40,7 @@ cat /my/k0s/values.yaml | vcluster convert config --distro k0s
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_create.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_create.md
@@ -35,7 +35,6 @@ vcluster create test --namespace test
       --chart-version string              The virtual cluster chart version to use (e.g. v0.9.1)
       --cluster string                    [PLATFORM] The vCluster platform connected cluster to use
       --connect                           If true will run vcluster connect directly after the vcluster was created (default true)
-      --create-context                    If the CLI should create a kube context for the space (default true)
       --create-namespace                  If true the namespace will be created if it does not exist (default true)
       --description string                [PLATFORM] The description to show in the platform UI for this virtual cluster
       --display-name string               [PLATFORM] The display name to show in the platform UI for this virtual cluster
@@ -55,11 +54,9 @@ vcluster create test --namespace test
       --set-param stringArray             [PLATFORM] If a template is used, this can be used to set a specific parameter. E.g. --set-param 'my-param=my-value'
       --set-parameter stringArray         [PLATFORM] If a template is used, this can be used to set a specific parameter. E.g. --set-parameter 'my-param=my-value'
       --skip-wait                         [PLATFORM] If true, will not wait until the virtual cluster is running
-      --switch-context                    If the CLI should switch the current context to the new context (default true)
       --team string                       [PLATFORM] The team to create the space for
       --template string                   [PLATFORM] The vCluster platform template to use
       --template-version string           [PLATFORM] The vCluster platform template version to use
-      --update-current                    If true updates the current kube config (default true)
       --upgrade                           If true will try to upgrade the vcluster instead of failing if it already exists
       --use                               [PLATFORM] If the platform should use the virtual cluster if its already there
       --user string                       [PLATFORM] The user to create the space for
@@ -70,7 +67,7 @@ vcluster create test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_credits.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_credits.md
@@ -27,7 +27,7 @@ Saves licenses, copyright notices and source code, as required by a Go package's
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_delete.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_delete.md
@@ -43,7 +43,7 @@ vcluster delete test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_describe.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_describe.md
@@ -38,7 +38,7 @@ vcluster describe -o json test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_disconnect.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_disconnect.md
@@ -37,7 +37,7 @@ vcluster disconnect
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_list.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_list.md
@@ -38,7 +38,7 @@ vcluster list --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_login.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_login.md
@@ -39,7 +39,7 @@ vcluster login https://my-vcluster-platform.com --access-key myaccesskey
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_logout.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_logout.md
@@ -34,7 +34,7 @@ vcluster logout
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_pause.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_pause.md
@@ -43,7 +43,7 @@ vcluster pause test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform.md
@@ -25,7 +25,7 @@ vCluster platform subcommands
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_access-key.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_access-key.md
@@ -39,7 +39,7 @@ vcluster platform token
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_add.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_add.md
@@ -25,7 +25,7 @@ Adds a cluster to vCluster platform
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_add_cluster.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_add_cluster.md
@@ -35,7 +35,7 @@ vcluster platform add cluster my-cluster
       --helm-values stringArray     Extra helm values for the agent chart
   -h, --help                        help for cluster
       --insecure                    If true, deploys the agent in insecure mode
-      --namespace string            The namespace to generate the service account in. The namespace will be created if it does not exist (default "loft")
+      --namespace string            The namespace to generate the service account in. The namespace will be created if it does not exist (default "vcluster-platform")
       --service-account string      The service account name to create (default "loft-admin")
       --wait                        If true, will wait until the cluster is initialized
 ```
@@ -44,7 +44,7 @@ vcluster platform add cluster my-cluster
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")
   -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_add_vcluster.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_add_vcluster.md
@@ -27,20 +27,21 @@ vcluster platform add vcluster my-vcluster --namespace vcluster-my-vcluster --pr
 ## Flags
 
 ```
-      --access-key string    The access key for the vCluster to connect to the platform. If empty, the CLI will generate one
-  -h, --help                 help for vcluster
-      --host string          The host where to reach the platform
-      --import-name string   The name of the vCluster under projects. If unspecified, will use the vcluster name
-      --insecure             If the platform host is insecure
-      --project string       The project to import the vCluster into
-      --restart              Restart the vCluster control-plane after creating the platform secret (default true)
+      --access-key string     The access key for the vCluster to connect to the platform. If empty, the CLI will generate one
+      --ca-data bytesBase64   additional, base64 encoded certificate authority data that will be passed to the platform secret
+  -h, --help                  help for vcluster
+      --host string           The host where to reach the platform
+      --import-name string    The name of the vCluster under projects. If unspecified, will use the vcluster name
+      --insecure              If the platform host is insecure
+      --project string        The project to import the vCluster into
+      --restart               Restart the vCluster control-plane after creating the platform secret (default true)
 ```
 
 
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_backup.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_backup.md
@@ -25,7 +25,7 @@ Backup subcommands
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_backup_management.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_backup_management.md
@@ -30,7 +30,7 @@ vcluster platform backup management
 ```
       --filename string    The filename to write the backup to (default "backup.yaml")
   -h, --help               help for management
-      --namespace string   The namespace vCluster platform was installed into (default "vcluster-platform")
+      --namespace string   The namespace vCluster platform was installed into
       --skip strings       What resources the backup should skip. Valid options are: users, teams, accesskeys, sharedsecrets, clusters and clusteraccounttemplates
 ```
 
@@ -38,7 +38,7 @@ vcluster platform backup management
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_connect.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_connect.md
@@ -28,7 +28,7 @@ Activates a kube context for the given cluster / management / namespace / vclust
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_connect_cluster.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_connect_cluster.md
@@ -37,7 +37,7 @@ vcluster platform connect cluster mycluster
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_connect_management.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_connect_management.md
@@ -36,7 +36,7 @@ vcluster platform connect management
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_connect_namespace.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_connect_namespace.md
@@ -42,7 +42,7 @@ vcluster platform connect namespace myspace --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_connect_vcluster.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_connect_vcluster.md
@@ -48,7 +48,7 @@ vcluster platform connect vcluster test -n test -- kubectl get ns
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_create.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_create.md
@@ -25,7 +25,7 @@ Creates vCluster platform resources
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_create_namespace.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_create_namespace.md
@@ -59,7 +59,7 @@ vcluster platform create namespace myspace --project myproject --team myteam
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_create_vcluster.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_create_vcluster.md
@@ -33,7 +33,6 @@ vcluster platform create vcluster test --namespace test
       --chart-version string              The virtual cluster chart version to use (e.g. v0.9.1)
       --cluster string                    The vCluster platform connected cluster to use
       --connect                           If true will run vcluster connect directly after the vcluster was created (default true)
-      --create-context                    If the CLI should create a kube context for the space (default true)
       --description string                The description to show in the platform UI for this virtual cluster
       --display-name string               The display name to show in the platform UI for this virtual cluster
       --expose                            If true will create a load balancer service to expose the vcluster endpoint
@@ -51,11 +50,9 @@ vcluster platform create vcluster test --namespace test
       --set-param stringArray             If a template is used, this can be used to set a specific parameter. E.g. --set-param 'my-param=my-value'
       --set-parameter stringArray         If a template is used, this can be used to set a specific parameter. E.g. --set-parameter 'my-param=my-value'
       --skip-wait                         If true, will not wait until the virtual cluster is running
-      --switch-context                    If the CLI should switch the current context to the new context (default true)
       --team string                       The team to create the space for
       --template string                   The vCluster platform template to use
       --template-version string           The vCluster platform template version to use
-      --update-current                    If true updates the current kube config (default true)
       --upgrade                           If true will try to upgrade the vcluster instead of failing if it already exists
       --use                               If the platform should use the virtual cluster if its already there
       --user string                       The user to create the space for
@@ -66,7 +63,7 @@ vcluster platform create vcluster test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_delete.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_delete.md
@@ -25,7 +25,7 @@ Deletes vCluster platform resources
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_delete_namespace.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_delete_namespace.md
@@ -40,7 +40,7 @@ vcluster platform delete namespace myspace --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_delete_vcluster.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_delete_vcluster.md
@@ -37,7 +37,7 @@ vcluster platform delete vcluster --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_get.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_get.md
@@ -25,7 +25,7 @@ Retrieves and display informations
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_get_cluster-access-key.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_get_cluster-access-key.md
@@ -36,7 +36,7 @@ vcluster platform get cluster-access-key [CLUSTER_NAME]
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_get_cluster.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_get_cluster.md
@@ -20,7 +20,7 @@ vcluster platform get cluster [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_get_current-user.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_get_current-user.md
@@ -36,7 +36,7 @@ vcluster platform get current-user
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_get_secret.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_get_secret.md
@@ -40,7 +40,7 @@ vcluster platform get secret test-secret.key --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_list.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_list.md
@@ -25,7 +25,7 @@ Lists configuration
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_list_clusters.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_list_clusters.md
@@ -35,7 +35,7 @@ vcluster platform list clusters
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_list_namespaces.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_list_namespaces.md
@@ -34,7 +34,7 @@ vcluster platform list namespaces
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_list_projects.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_list_projects.md
@@ -35,7 +35,7 @@ vcluster platform list projects
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_list_secrets.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_list_secrets.md
@@ -39,7 +39,7 @@ vcluster platform list secrets
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_list_teams.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_list_teams.md
@@ -35,7 +35,7 @@ vcluster platform list teams
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_list_vclusters.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_list_vclusters.md
@@ -36,7 +36,7 @@ vcluster platform list vclusters
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_login.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_login.md
@@ -39,7 +39,7 @@ vcluster platform login https://my-vcluster-platform.com --access-key myaccesske
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_logout.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_logout.md
@@ -34,7 +34,7 @@ vcluster platform logout
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_reset.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_reset.md
@@ -25,7 +25,7 @@ Reset configuration
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_reset_password.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_reset_password.md
@@ -28,22 +28,22 @@ vcluster platform reset password --user admin
 ## Flags
 
 ```
-      --create            Creates the user if it does not exist
-      --force             If user had no password will create one
-  -h, --help              help for password
-      --password string   The new password to use
-      --user string       The name of the user to reset the password (default "admin")
+      --create             Creates the user if it does not exist
+      --force              If user had no password will create one
+  -h, --help               help for password
+      --namespace string   The namespace to use (default "vcluster-platform")
+      --password string    The new password to use
+      --user string        The name of the user to reset the password (default "admin")
 ```
 
 
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")
-  -n, --namespace string    The kubernetes namespace to use
   -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals
 ```
 

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_set.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_set.md
@@ -25,7 +25,7 @@ Set configuration
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_set_secret.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_set_secret.md
@@ -39,7 +39,7 @@ vcluster platform set secret test-secret.key value --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_share.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_share.md
@@ -25,7 +25,7 @@ Shares a virtual cluster / namespace with another vCluster platform user or team
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_share_namespace.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_share_namespace.md
@@ -42,7 +42,7 @@ vcluster platform share namespace myspace --project myproject --user admin
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_share_vcluster.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_share_vcluster.md
@@ -41,7 +41,7 @@ vcluster platform share vcluster myvcluster --project myproject --user admin
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_sleep.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_sleep.md
@@ -28,7 +28,7 @@ Put a virtual cluster / namespace to sleep.
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_sleep_namespace.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_sleep_namespace.md
@@ -38,7 +38,7 @@ vcluster platform sleep namespace myspace --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_sleep_vcluster.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_sleep_vcluster.md
@@ -42,7 +42,7 @@ vcluster platform sleep vcluster test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_start.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_start.md
@@ -48,7 +48,7 @@ before running this command:
       --no-tunnel            If true, vCluster platform will not create a loft.host tunnel for this installation
       --no-wait              If true, vCluster platform will not wait after installing it
       --password string      The password to use for the admin account. (If empty this will be the namespace UID)
-      --reset                If true, an existing vCluster platform instance will be deleted before installing vCluster platform
+      --reset                If true, existing vCluster Platform resources, including the deployment, will be deleted before installing vCluster platform
       --reuse-values         Reuse previous vCluster platform helm values on upgrade (default true)
       --upgrade              If true, vCluster platform will try to upgrade the release
       --values string        Path to a file for extra vCluster platform helm chart values
@@ -59,7 +59,7 @@ before running this command:
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")
   -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_wakeup.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_wakeup.md
@@ -28,7 +28,7 @@ Wake up a virtual cluster / namespace.
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_wakeup_namespace.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_wakeup_namespace.md
@@ -37,7 +37,7 @@ vcluster platform wakeup namespace myspace --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_wakeup_vcluster.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_platform_wakeup_vcluster.md
@@ -37,7 +37,7 @@ vcluster platform wakeup vcluster test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_resume.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_resume.md
@@ -38,7 +38,7 @@ vcluster resume test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_set.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_set.md
@@ -25,7 +25,7 @@ Set configuration
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_set_secret.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_set_secret.md
@@ -39,7 +39,7 @@ vcluster platform set secret test-secret.key value --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_telemetry.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_telemetry.md
@@ -30,7 +30,7 @@ docs: https://www.vcluster.com/docs/advanced-topics/telemetry
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_telemetry_disable.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_telemetry_disable.md
@@ -35,7 +35,7 @@ docs: https://www.vcluster.com/docs/advanced-topics/telemetry
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_telemetry_enable.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_telemetry_enable.md
@@ -35,7 +35,7 @@ docs: https://www.vcluster.com/docs/advanced-topics/telemetry
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_ui.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_ui.md
@@ -34,7 +34,7 @@ vcluster ui
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_upgrade.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_upgrade.md
@@ -32,7 +32,7 @@ Upgrades the vcluster CLI to the newest version
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_use.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_use.md
@@ -25,7 +25,7 @@ vCluster use subcommand
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_use_driver.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_use_driver.md
@@ -31,7 +31,7 @@ Either use "helm" or "platform" as the deployment method for managing virtual cl
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_version.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_version.md
@@ -27,7 +27,7 @@ All software has versions. This is Vcluster's.
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_connect.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_connect.md
@@ -49,7 +49,7 @@ vcluster connect test -n test -- kubectl get ns
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_convert.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_convert.md
@@ -25,7 +25,7 @@ Convert virtual cluster config values
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_convert_config.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_convert_config.md
@@ -40,7 +40,7 @@ cat /my/k0s/values.yaml | vcluster convert config --distro k0s
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_create.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_create.md
@@ -35,7 +35,6 @@ vcluster create test --namespace test
       --chart-version string              The virtual cluster chart version to use (e.g. v0.9.1)
       --cluster string                    [PLATFORM] The vCluster platform connected cluster to use
       --connect                           If true will run vcluster connect directly after the vcluster was created (default true)
-      --create-context                    If the CLI should create a kube context for the space (default true)
       --create-namespace                  If true the namespace will be created if it does not exist (default true)
       --description string                [PLATFORM] The description to show in the platform UI for this virtual cluster
       --display-name string               [PLATFORM] The display name to show in the platform UI for this virtual cluster
@@ -55,11 +54,9 @@ vcluster create test --namespace test
       --set-param stringArray             [PLATFORM] If a template is used, this can be used to set a specific parameter. E.g. --set-param 'my-param=my-value'
       --set-parameter stringArray         [PLATFORM] If a template is used, this can be used to set a specific parameter. E.g. --set-parameter 'my-param=my-value'
       --skip-wait                         [PLATFORM] If true, will not wait until the virtual cluster is running
-      --switch-context                    If the CLI should switch the current context to the new context (default true)
       --team string                       [PLATFORM] The team to create the space for
       --template string                   [PLATFORM] The vCluster platform template to use
       --template-version string           [PLATFORM] The vCluster platform template version to use
-      --update-current                    If true updates the current kube config (default true)
       --upgrade                           If true will try to upgrade the vcluster instead of failing if it already exists
       --use                               [PLATFORM] If the platform should use the virtual cluster if its already there
       --user string                       [PLATFORM] The user to create the space for
@@ -70,7 +67,7 @@ vcluster create test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_credits.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_credits.md
@@ -27,7 +27,7 @@ Saves licenses, copyright notices and source code, as required by a Go package's
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_delete.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_delete.md
@@ -43,7 +43,7 @@ vcluster delete test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_describe.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_describe.md
@@ -38,7 +38,7 @@ vcluster describe -o json test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_disconnect.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_disconnect.md
@@ -37,7 +37,7 @@ vcluster disconnect
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_list.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_list.md
@@ -38,7 +38,7 @@ vcluster list --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_login.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_login.md
@@ -39,7 +39,7 @@ vcluster login https://my-vcluster-platform.com --access-key myaccesskey
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_logout.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_logout.md
@@ -34,7 +34,7 @@ vcluster logout
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_pause.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_pause.md
@@ -43,7 +43,7 @@ vcluster pause test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform.md
@@ -25,7 +25,7 @@ vCluster platform subcommands
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_access-key.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_access-key.md
@@ -39,7 +39,7 @@ vcluster platform token
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_add.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_add.md
@@ -25,7 +25,7 @@ Adds a cluster to vCluster platform
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_add_cluster.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_add_cluster.md
@@ -35,7 +35,7 @@ vcluster platform add cluster my-cluster
       --helm-values stringArray     Extra helm values for the agent chart
   -h, --help                        help for cluster
       --insecure                    If true, deploys the agent in insecure mode
-      --namespace string            The namespace to generate the service account in. The namespace will be created if it does not exist (default "loft")
+      --namespace string            The namespace to generate the service account in. The namespace will be created if it does not exist (default "vcluster-platform")
       --service-account string      The service account name to create (default "loft-admin")
       --wait                        If true, will wait until the cluster is initialized
 ```
@@ -44,7 +44,7 @@ vcluster platform add cluster my-cluster
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")
   -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_add_vcluster.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_add_vcluster.md
@@ -20,6 +20,10 @@ Adds a vCluster to the vCluster platform.
 
 Example:
 vcluster platform add vcluster my-vcluster --namespace vcluster-my-vcluster --project my-project --import-name my-vcluster
+
+Add all vCluster instances in the host cluster:
+vcluster platform add vcluster --project my-project --all
+
 ###############################################
 ```
 
@@ -27,20 +31,22 @@ vcluster platform add vcluster my-vcluster --namespace vcluster-my-vcluster --pr
 ## Flags
 
 ```
-      --access-key string    The access key for the vCluster to connect to the platform. If empty, the CLI will generate one
-  -h, --help                 help for vcluster
-      --host string          The host where to reach the platform
-      --import-name string   The name of the vCluster under projects. If unspecified, will use the vcluster name
-      --insecure             If the platform host is insecure
-      --project string       The project to import the vCluster into
-      --restart              Restart the vCluster control-plane after creating the platform secret (default true)
+      --access-key string     The access key for the vCluster to connect to the platform. If empty, the CLI will generate one
+      --all                   all will try to add Virtual Cluster found in all namespaces in the host cluster. If this flag is set, any provided vCluster name argument is ignored
+      --ca-data bytesBase64   additional, base64 encoded certificate authority data that will be passed to the platform secret
+  -h, --help                  help for vcluster
+      --host string           The host where to reach the platform
+      --import-name string    The name of the vCluster under projects. If unspecified, will use the vcluster name
+      --insecure              If the platform host is insecure
+      --project string        The project to import the vCluster into
+      --restart               Restart the vCluster control-plane after creating the platform secret (default true)
 ```
 
 
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_backup.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_backup.md
@@ -25,7 +25,7 @@ Backup subcommands
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_backup_management.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_backup_management.md
@@ -30,7 +30,7 @@ vcluster platform backup management
 ```
       --filename string    The filename to write the backup to (default "backup.yaml")
   -h, --help               help for management
-      --namespace string   The namespace vCluster platform was installed into (default "vcluster-platform")
+      --namespace string   The namespace vCluster platform was installed into
       --skip strings       What resources the backup should skip. Valid options are: users, teams, accesskeys, sharedsecrets, clusters and clusteraccounttemplates
 ```
 
@@ -38,7 +38,7 @@ vcluster platform backup management
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_connect.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_connect.md
@@ -28,7 +28,7 @@ Activates a kube context for the given cluster / management / namespace / vclust
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_connect_cluster.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_connect_cluster.md
@@ -37,7 +37,7 @@ vcluster platform connect cluster mycluster
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_connect_management.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_connect_management.md
@@ -36,7 +36,7 @@ vcluster platform connect management
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_connect_namespace.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_connect_namespace.md
@@ -42,7 +42,7 @@ vcluster platform connect namespace myspace --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_connect_vcluster.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_connect_vcluster.md
@@ -48,7 +48,7 @@ vcluster platform connect vcluster test -n test -- kubectl get ns
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_create.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_create.md
@@ -25,7 +25,7 @@ Creates vCluster platform resources
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_create_namespace.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_create_namespace.md
@@ -59,7 +59,7 @@ vcluster platform create namespace myspace --project myproject --team myteam
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_create_vcluster.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_create_vcluster.md
@@ -33,7 +33,6 @@ vcluster platform create vcluster test --namespace test
       --chart-version string              The virtual cluster chart version to use (e.g. v0.9.1)
       --cluster string                    The vCluster platform connected cluster to use
       --connect                           If true will run vcluster connect directly after the vcluster was created (default true)
-      --create-context                    If the CLI should create a kube context for the space (default true)
       --description string                The description to show in the platform UI for this virtual cluster
       --display-name string               The display name to show in the platform UI for this virtual cluster
       --expose                            If true will create a load balancer service to expose the vcluster endpoint
@@ -51,11 +50,9 @@ vcluster platform create vcluster test --namespace test
       --set-param stringArray             If a template is used, this can be used to set a specific parameter. E.g. --set-param 'my-param=my-value'
       --set-parameter stringArray         If a template is used, this can be used to set a specific parameter. E.g. --set-parameter 'my-param=my-value'
       --skip-wait                         If true, will not wait until the virtual cluster is running
-      --switch-context                    If the CLI should switch the current context to the new context (default true)
       --team string                       The team to create the space for
       --template string                   The vCluster platform template to use
       --template-version string           The vCluster platform template version to use
-      --update-current                    If true updates the current kube config (default true)
       --upgrade                           If true will try to upgrade the vcluster instead of failing if it already exists
       --use                               If the platform should use the virtual cluster if its already there
       --user string                       The user to create the space for
@@ -66,7 +63,7 @@ vcluster platform create vcluster test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_delete.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_delete.md
@@ -25,7 +25,7 @@ Deletes vCluster platform resources
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_delete_namespace.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_delete_namespace.md
@@ -40,7 +40,7 @@ vcluster platform delete namespace myspace --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_delete_vcluster.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_delete_vcluster.md
@@ -37,7 +37,7 @@ vcluster platform delete vcluster --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_get.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_get.md
@@ -25,7 +25,7 @@ Retrieves and display informations
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_get_cluster-access-key.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_get_cluster-access-key.md
@@ -36,7 +36,7 @@ vcluster platform get cluster-access-key [CLUSTER_NAME]
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_get_cluster.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_get_cluster.md
@@ -20,7 +20,7 @@ vcluster platform get cluster [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_get_current-user.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_get_current-user.md
@@ -36,7 +36,7 @@ vcluster platform get current-user
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_get_secret.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_get_secret.md
@@ -40,7 +40,7 @@ vcluster platform get secret test-secret.key --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_list.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_list.md
@@ -25,7 +25,7 @@ Lists configuration
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_list_clusters.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_list_clusters.md
@@ -35,7 +35,7 @@ vcluster platform list clusters
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_list_namespaces.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_list_namespaces.md
@@ -34,7 +34,7 @@ vcluster platform list namespaces
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_list_projects.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_list_projects.md
@@ -35,7 +35,7 @@ vcluster platform list projects
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_list_secrets.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_list_secrets.md
@@ -39,7 +39,7 @@ vcluster platform list secrets
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_list_teams.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_list_teams.md
@@ -35,7 +35,7 @@ vcluster platform list teams
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_list_vclusters.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_list_vclusters.md
@@ -36,7 +36,7 @@ vcluster platform list vclusters
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_login.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_login.md
@@ -39,7 +39,7 @@ vcluster platform login https://my-vcluster-platform.com --access-key myaccesske
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_logout.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_logout.md
@@ -34,7 +34,7 @@ vcluster platform logout
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_reset.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_reset.md
@@ -25,7 +25,7 @@ Reset configuration
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_reset_password.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_reset_password.md
@@ -28,22 +28,22 @@ vcluster platform reset password --user admin
 ## Flags
 
 ```
-      --create            Creates the user if it does not exist
-      --force             If user had no password will create one
-  -h, --help              help for password
-      --password string   The new password to use
-      --user string       The name of the user to reset the password (default "admin")
+      --create             Creates the user if it does not exist
+      --force              If user had no password will create one
+  -h, --help               help for password
+      --namespace string   The namespace to use (default "vcluster-platform")
+      --password string    The new password to use
+      --user string        The name of the user to reset the password (default "admin")
 ```
 
 
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")
-  -n, --namespace string    The kubernetes namespace to use
   -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals
 ```
 

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_set.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_set.md
@@ -25,7 +25,7 @@ Set configuration
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_set_secret.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_set_secret.md
@@ -39,7 +39,7 @@ vcluster platform set secret test-secret.key value --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_share.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_share.md
@@ -25,7 +25,7 @@ Shares a virtual cluster / namespace with another vCluster platform user or team
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_share_namespace.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_share_namespace.md
@@ -42,7 +42,7 @@ vcluster platform share namespace myspace --project myproject --user admin
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_share_vcluster.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_share_vcluster.md
@@ -41,7 +41,7 @@ vcluster platform share vcluster myvcluster --project myproject --user admin
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_sleep.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_sleep.md
@@ -28,7 +28,7 @@ Put a virtual cluster / namespace to sleep.
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_sleep_namespace.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_sleep_namespace.md
@@ -38,7 +38,7 @@ vcluster platform sleep namespace myspace --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_sleep_vcluster.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_sleep_vcluster.md
@@ -42,7 +42,7 @@ vcluster platform sleep vcluster test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_start.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_start.md
@@ -48,7 +48,7 @@ before running this command:
       --no-tunnel            If true, vCluster platform will not create a loft.host tunnel for this installation
       --no-wait              If true, vCluster platform will not wait after installing it
       --password string      The password to use for the admin account. (If empty this will be the namespace UID)
-      --reset                If true, an existing vCluster platform instance will be deleted before installing vCluster platform
+      --reset                If true, existing vCluster Platform resources, including the deployment, will be deleted before installing vCluster platform
       --reuse-values         Reuse previous vCluster platform helm values on upgrade (default true)
       --upgrade              If true, vCluster platform will try to upgrade the release
       --values string        Path to a file for extra vCluster platform helm chart values
@@ -59,7 +59,7 @@ before running this command:
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")
   -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_wakeup.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_wakeup.md
@@ -28,7 +28,7 @@ Wake up a virtual cluster / namespace.
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_wakeup_namespace.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_wakeup_namespace.md
@@ -37,7 +37,7 @@ vcluster platform wakeup namespace myspace --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_wakeup_vcluster.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_platform_wakeup_vcluster.md
@@ -37,7 +37,7 @@ vcluster platform wakeup vcluster test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_resume.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_resume.md
@@ -38,7 +38,7 @@ vcluster resume test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_set.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_set.md
@@ -25,7 +25,7 @@ Set configuration
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_set_secret.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_set_secret.md
@@ -39,7 +39,7 @@ vcluster platform set secret test-secret.key value --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_telemetry.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_telemetry.md
@@ -30,7 +30,7 @@ docs: https://www.vcluster.com/docs/advanced-topics/telemetry
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_telemetry_disable.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_telemetry_disable.md
@@ -35,7 +35,7 @@ docs: https://www.vcluster.com/docs/advanced-topics/telemetry
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_telemetry_enable.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_telemetry_enable.md
@@ -35,7 +35,7 @@ docs: https://www.vcluster.com/docs/advanced-topics/telemetry
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_ui.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_ui.md
@@ -34,7 +34,7 @@ vcluster ui
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_upgrade.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_upgrade.md
@@ -32,7 +32,7 @@ Upgrades the vcluster CLI to the newest version
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_use.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_use.md
@@ -25,7 +25,7 @@ vCluster use subcommand
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_use_driver.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_use_driver.md
@@ -31,7 +31,7 @@ Either use "helm" or "platform" as the deployment method for managing virtual cl
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_version.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_version.md
@@ -27,7 +27,7 @@ All software has versions. This is Vcluster's.
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_connect.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_connect.md
@@ -49,7 +49,7 @@ vcluster connect test -n test -- kubectl get ns
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_convert.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_convert.md
@@ -25,7 +25,7 @@ Convert virtual cluster config values
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_convert_config.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_convert_config.md
@@ -40,7 +40,7 @@ cat /my/k0s/values.yaml | vcluster convert config --distro k0s
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_create.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_create.md
@@ -35,7 +35,6 @@ vcluster create test --namespace test
       --chart-version string              The virtual cluster chart version to use (e.g. v0.9.1)
       --cluster string                    [PLATFORM] The vCluster platform connected cluster to use
       --connect                           If true will run vcluster connect directly after the vcluster was created (default true)
-      --create-context                    If the CLI should create a kube context for the space (default true)
       --create-namespace                  If true the namespace will be created if it does not exist (default true)
       --description string                [PLATFORM] The description to show in the platform UI for this virtual cluster
       --display-name string               [PLATFORM] The display name to show in the platform UI for this virtual cluster
@@ -55,11 +54,9 @@ vcluster create test --namespace test
       --set-param stringArray             [PLATFORM] If a template is used, this can be used to set a specific parameter. E.g. --set-param 'my-param=my-value'
       --set-parameter stringArray         [PLATFORM] If a template is used, this can be used to set a specific parameter. E.g. --set-parameter 'my-param=my-value'
       --skip-wait                         [PLATFORM] If true, will not wait until the virtual cluster is running
-      --switch-context                    If the CLI should switch the current context to the new context (default true)
       --team string                       [PLATFORM] The team to create the space for
       --template string                   [PLATFORM] The vCluster platform template to use
       --template-version string           [PLATFORM] The vCluster platform template version to use
-      --update-current                    If true updates the current kube config (default true)
       --upgrade                           If true will try to upgrade the vcluster instead of failing if it already exists
       --use                               [PLATFORM] If the platform should use the virtual cluster if its already there
       --user string                       [PLATFORM] The user to create the space for
@@ -70,7 +67,7 @@ vcluster create test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_credits.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_credits.md
@@ -27,7 +27,7 @@ Saves licenses, copyright notices and source code, as required by a Go package's
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_debug.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_debug.md
@@ -1,0 +1,35 @@
+---
+title: "vcluster debug --help"
+sidebar_label: vcluster debug
+---
+
+
+Debug retrieves information from vCluster
+
+## Synopsis
+
+```
+#######################################################
+################### vcluster debug ####################
+#######################################################
+```
+
+
+## Flags
+
+```
+  -h, --help   help for debug
+```
+
+
+## Global & Inherited Flags
+
+```
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
+      --context string      The kubernetes config context to use
+      --debug               Prints the stack trace if an error occurs
+      --log-output string   The log format to use. Can be either plain, raw or json (default "plain")
+  -n, --namespace string    The kubernetes namespace to use
+  -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals
+```
+

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_debug_collect.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_debug_collect.md
@@ -1,0 +1,52 @@
+---
+title: "vcluster debug collect --help"
+sidebar_label: vcluster debug collect
+---
+
+
+Collects debugging information from the vCluster
+
+## Synopsis
+
+```
+vcluster debug collect [flags]
+```
+
+```
+##############################################################
+################### vcluster debug collect ###################
+##############################################################
+Collects debugging information from the vCluster
+
+Examples:
+vcluster debug collect
+##############################################################
+```
+
+
+## Flags
+
+```
+      --count-virtual-cluster-objects   Collect how many objects are in the vCluster (default true)
+  -h, --help                            help for collect
+      --host-info                       Collect host cluster info (default true)
+      --host-resources strings          Collect host resources in vCluster namespace
+      --logs                            Collect vCluster logs (default true)
+      --output-filename string          If specified, will write to the given filename
+      --release                         Collect vCluster release info (default true)
+      --virtual-info                    Collect virtual cluster info (default true)
+      --virtual-resources strings       Collect virtual cluster resources
+```
+
+
+## Global & Inherited Flags
+
+```
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
+      --context string      The kubernetes config context to use
+      --debug               Prints the stack trace if an error occurs
+      --log-output string   The log format to use. Can be either plain, raw or json (default "plain")
+  -n, --namespace string    The kubernetes namespace to use
+  -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals
+```
+

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_delete.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_delete.md
@@ -43,7 +43,7 @@ vcluster delete test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_describe.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_describe.md
@@ -38,7 +38,7 @@ vcluster describe -o json test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_disconnect.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_disconnect.md
@@ -37,7 +37,7 @@ vcluster disconnect
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_list.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_list.md
@@ -38,7 +38,7 @@ vcluster list --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_login.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_login.md
@@ -39,7 +39,7 @@ vcluster login https://my-vcluster-platform.com --access-key myaccesskey
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_logout.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_logout.md
@@ -34,7 +34,7 @@ vcluster logout
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_pause.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_pause.md
@@ -43,7 +43,7 @@ vcluster pause test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform.md
@@ -25,7 +25,7 @@ vCluster platform subcommands
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_access-key.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_access-key.md
@@ -39,7 +39,7 @@ vcluster platform token
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_add.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_add.md
@@ -25,7 +25,7 @@ Adds a cluster to vCluster platform
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_add_cluster.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_add_cluster.md
@@ -35,7 +35,7 @@ vcluster platform add cluster my-cluster
       --helm-values stringArray     Extra helm values for the agent chart
   -h, --help                        help for cluster
       --insecure                    If true, deploys the agent in insecure mode
-      --namespace string            The namespace to generate the service account in. The namespace will be created if it does not exist (default "loft")
+      --namespace string            The namespace to generate the service account in. The namespace will be created if it does not exist (default "vcluster-platform")
       --service-account string      The service account name to create (default "loft-admin")
       --wait                        If true, will wait until the cluster is initialized
 ```
@@ -44,7 +44,7 @@ vcluster platform add cluster my-cluster
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")
   -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_add_vcluster.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_add_vcluster.md
@@ -20,6 +20,10 @@ Adds a vCluster to the vCluster platform.
 
 Example:
 vcluster platform add vcluster my-vcluster --namespace vcluster-my-vcluster --project my-project --import-name my-vcluster
+
+Add all vCluster instances in the host cluster:
+vcluster platform add vcluster --project my-project --all
+
 ###############################################
 ```
 
@@ -27,20 +31,22 @@ vcluster platform add vcluster my-vcluster --namespace vcluster-my-vcluster --pr
 ## Flags
 
 ```
-      --access-key string    The access key for the vCluster to connect to the platform. If empty, the CLI will generate one
-  -h, --help                 help for vcluster
-      --host string          The host where to reach the platform
-      --import-name string   The name of the vCluster under projects. If unspecified, will use the vcluster name
-      --insecure             If the platform host is insecure
-      --project string       The project to import the vCluster into
-      --restart              Restart the vCluster control-plane after creating the platform secret (default true)
+      --access-key string     The access key for the vCluster to connect to the platform. If empty, the CLI will generate one
+      --all                   all will try to add Virtual Cluster found in all namespaces in the host cluster. If this flag is set, any provided vCluster name argument is ignored
+      --ca-data bytesBase64   additional, base64 encoded certificate authority data that will be passed to the platform secret
+  -h, --help                  help for vcluster
+      --host string           The host where to reach the platform
+      --import-name string    The name of the vCluster under projects. If unspecified, will use the vcluster name
+      --insecure              If the platform host is insecure
+      --project string        The project to import the vCluster into
+      --restart               Restart the vCluster control-plane after creating the platform secret (default true)
 ```
 
 
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_backup.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_backup.md
@@ -25,7 +25,7 @@ Backup subcommands
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_backup_management.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_backup_management.md
@@ -30,7 +30,7 @@ vcluster platform backup management
 ```
       --filename string    The filename to write the backup to (default "backup.yaml")
   -h, --help               help for management
-      --namespace string   The namespace vCluster platform was installed into (default "vcluster-platform")
+      --namespace string   The namespace vCluster platform was installed into
       --skip strings       What resources the backup should skip. Valid options are: users, teams, accesskeys, sharedsecrets, clusters and clusteraccounttemplates
 ```
 
@@ -38,7 +38,7 @@ vcluster platform backup management
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_connect.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_connect.md
@@ -28,7 +28,7 @@ Activates a kube context for the given cluster / management / namespace / vclust
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_connect_cluster.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_connect_cluster.md
@@ -37,7 +37,7 @@ vcluster platform connect cluster mycluster
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_connect_management.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_connect_management.md
@@ -36,7 +36,7 @@ vcluster platform connect management
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_connect_namespace.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_connect_namespace.md
@@ -42,7 +42,7 @@ vcluster platform connect namespace myspace --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_connect_vcluster.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_connect_vcluster.md
@@ -48,7 +48,7 @@ vcluster platform connect vcluster test -n test -- kubectl get ns
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_create.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_create.md
@@ -25,7 +25,7 @@ Creates vCluster platform resources
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_create_namespace.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_create_namespace.md
@@ -59,7 +59,7 @@ vcluster platform create namespace myspace --project myproject --team myteam
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_create_vcluster.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_create_vcluster.md
@@ -33,7 +33,6 @@ vcluster platform create vcluster test --namespace test
       --chart-version string              The virtual cluster chart version to use (e.g. v0.9.1)
       --cluster string                    The vCluster platform connected cluster to use
       --connect                           If true will run vcluster connect directly after the vcluster was created (default true)
-      --create-context                    If the CLI should create a kube context for the space (default true)
       --description string                The description to show in the platform UI for this virtual cluster
       --display-name string               The display name to show in the platform UI for this virtual cluster
       --expose                            If true will create a load balancer service to expose the vcluster endpoint
@@ -51,11 +50,9 @@ vcluster platform create vcluster test --namespace test
       --set-param stringArray             If a template is used, this can be used to set a specific parameter. E.g. --set-param 'my-param=my-value'
       --set-parameter stringArray         If a template is used, this can be used to set a specific parameter. E.g. --set-parameter 'my-param=my-value'
       --skip-wait                         If true, will not wait until the virtual cluster is running
-      --switch-context                    If the CLI should switch the current context to the new context (default true)
       --team string                       The team to create the space for
       --template string                   The vCluster platform template to use
       --template-version string           The vCluster platform template version to use
-      --update-current                    If true updates the current kube config (default true)
       --upgrade                           If true will try to upgrade the vcluster instead of failing if it already exists
       --use                               If the platform should use the virtual cluster if its already there
       --user string                       The user to create the space for
@@ -66,7 +63,7 @@ vcluster platform create vcluster test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_delete.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_delete.md
@@ -25,7 +25,7 @@ Deletes vCluster platform resources
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_delete_namespace.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_delete_namespace.md
@@ -40,7 +40,7 @@ vcluster platform delete namespace myspace --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_delete_vcluster.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_delete_vcluster.md
@@ -37,7 +37,7 @@ vcluster platform delete vcluster --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_destroy.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_destroy.md
@@ -1,0 +1,61 @@
+---
+title: "vcluster platform destroy --help"
+sidebar_label: vcluster platform destroy
+---
+
+
+Destroy a vCluster Platform instance
+
+## Synopsis
+
+```
+vcluster platform destroy [flags]
+```
+
+```
+########################################################
+############# vcluster platform destroy ##################
+########################################################
+
+Destroys a vCluster Platform instance in your Kubernetes cluster.
+
+IMPORTANT: This action is done against the cluster the the kube-context is pointing to, and not the vCluster Platform instance that is logged in.
+It does not require logging in to vCluster Platform.
+
+Please make sure you meet the following requirements
+before running this command:
+
+1. Current kube-context has admin access to the cluster
+2. Helm v3 must be installed
+
+
+VirtualClusterInstances managed with driver helm will be deleted, but the underlying virtual cluster will not be uninstalled.
+
+########################################################
+```
+
+
+## Flags
+
+```
+      --context string            The kube context to use for installation
+      --delete-namespace          Whether to delete the namespace or not (default true)
+      --force                     Try uninstalling even if the platform is not installed. '--namespace' is required if true
+      --force-remove-finalizers   IMPORTANT! Removing finalizers may cause unintended behaviours like leaving resources behind, but will ensure the platform is uninstalled.
+  -h, --help                      help for destroy
+      --ignore-not-found          Exit successfully if platform installation is not found
+      --namespace string          The namespace vCluster Platform is installed in
+      --non-interactive           Will not prompt for confirmation
+      --timeout-minutes int       How long to try deleting the platform before giving up. May increase when removing finalizers if --remove-finalizers is used (default 5)
+```
+
+
+## Global & Inherited Flags
+
+```
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
+      --debug               Prints the stack trace if an error occurs
+      --log-output string   The log format to use. Can be either plain, raw or json (default "plain")
+  -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals
+```
+

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_get.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_get.md
@@ -25,7 +25,7 @@ Retrieves and display informations
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_get_cluster-access-key.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_get_cluster-access-key.md
@@ -36,7 +36,7 @@ vcluster platform get cluster-access-key [CLUSTER_NAME]
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_get_cluster.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_get_cluster.md
@@ -20,7 +20,7 @@ vcluster platform get cluster [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_get_current-user.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_get_current-user.md
@@ -36,7 +36,7 @@ vcluster platform get current-user
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_get_secret.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_get_secret.md
@@ -40,7 +40,7 @@ vcluster platform get secret test-secret.key --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_list.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_list.md
@@ -25,7 +25,7 @@ Lists configuration
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_list_clusters.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_list_clusters.md
@@ -35,7 +35,7 @@ vcluster platform list clusters
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_list_namespaces.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_list_namespaces.md
@@ -34,7 +34,7 @@ vcluster platform list namespaces
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_list_projects.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_list_projects.md
@@ -35,7 +35,7 @@ vcluster platform list projects
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_list_secrets.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_list_secrets.md
@@ -39,7 +39,7 @@ vcluster platform list secrets
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_list_teams.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_list_teams.md
@@ -35,7 +35,7 @@ vcluster platform list teams
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_list_vclusters.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_list_vclusters.md
@@ -36,7 +36,7 @@ vcluster platform list vclusters
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_login.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_login.md
@@ -39,7 +39,7 @@ vcluster platform login https://my-vcluster-platform.com --access-key myaccesske
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_logout.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_logout.md
@@ -34,7 +34,7 @@ vcluster platform logout
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_reset.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_reset.md
@@ -25,7 +25,7 @@ Reset configuration
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_reset_password.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_reset_password.md
@@ -28,22 +28,22 @@ vcluster platform reset password --user admin
 ## Flags
 
 ```
-      --create            Creates the user if it does not exist
-      --force             If user had no password will create one
-  -h, --help              help for password
-      --password string   The new password to use
-      --user string       The name of the user to reset the password (default "admin")
+      --create             Creates the user if it does not exist
+      --force              If user had no password will create one
+  -h, --help               help for password
+      --namespace string   The namespace to use (default "vcluster-platform")
+      --password string    The new password to use
+      --user string        The name of the user to reset the password (default "admin")
 ```
 
 
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")
-  -n, --namespace string    The kubernetes namespace to use
   -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals
 ```
 

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_set.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_set.md
@@ -25,7 +25,7 @@ Set configuration
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_set_secret.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_set_secret.md
@@ -39,7 +39,7 @@ vcluster platform set secret test-secret.key value --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_share.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_share.md
@@ -25,7 +25,7 @@ Shares a virtual cluster / namespace with another vCluster platform user or team
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_share_namespace.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_share_namespace.md
@@ -42,7 +42,7 @@ vcluster platform share namespace myspace --project myproject --user admin
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_share_vcluster.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_share_vcluster.md
@@ -41,7 +41,7 @@ vcluster platform share vcluster myvcluster --project myproject --user admin
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_sleep.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_sleep.md
@@ -28,7 +28,7 @@ Put a virtual cluster / namespace to sleep.
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_sleep_namespace.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_sleep_namespace.md
@@ -38,7 +38,7 @@ vcluster platform sleep namespace myspace --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_sleep_vcluster.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_sleep_vcluster.md
@@ -42,7 +42,7 @@ vcluster platform sleep vcluster test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_start.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_start.md
@@ -48,7 +48,7 @@ before running this command:
       --no-tunnel            If true, vCluster platform will not create a loft.host tunnel for this installation
       --no-wait              If true, vCluster platform will not wait after installing it
       --password string      The password to use for the admin account. (If empty this will be the namespace UID)
-      --reset                If true, an existing vCluster platform instance will be deleted before installing vCluster platform
+      --reset                If true, existing vCluster Platform resources, including the deployment, will be deleted before installing vCluster platform
       --reuse-values         Reuse previous vCluster platform helm values on upgrade (default true)
       --upgrade              If true, vCluster platform will try to upgrade the release
       --values string        Path to a file for extra vCluster platform helm chart values
@@ -59,7 +59,7 @@ before running this command:
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")
   -s, --silent              Run in silent mode and prevents any vcluster log output except panics & fatals

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_wakeup.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_wakeup.md
@@ -28,7 +28,7 @@ Wake up a virtual cluster / namespace.
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_wakeup_namespace.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_wakeup_namespace.md
@@ -37,7 +37,7 @@ vcluster platform wakeup namespace myspace --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_wakeup_vcluster.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_platform_wakeup_vcluster.md
@@ -37,7 +37,7 @@ vcluster platform wakeup vcluster test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_resume.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_resume.md
@@ -38,7 +38,7 @@ vcluster resume test --namespace test
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_set.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_set.md
@@ -25,7 +25,7 @@ Set configuration
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_set_secret.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_set_secret.md
@@ -39,7 +39,7 @@ vcluster platform set secret test-secret.key value --project myproject
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_telemetry.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_telemetry.md
@@ -30,7 +30,7 @@ docs: https://www.vcluster.com/docs/advanced-topics/telemetry
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_telemetry_disable.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_telemetry_disable.md
@@ -35,7 +35,7 @@ docs: https://www.vcluster.com/docs/advanced-topics/telemetry
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_telemetry_enable.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_telemetry_enable.md
@@ -35,7 +35,7 @@ docs: https://www.vcluster.com/docs/advanced-topics/telemetry
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_ui.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_ui.md
@@ -34,7 +34,7 @@ vcluster ui
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_upgrade.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_upgrade.md
@@ -32,7 +32,7 @@ Upgrades the vcluster CLI to the newest version
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_use.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_use.md
@@ -25,7 +25,7 @@ vCluster use subcommand
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_use_driver.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_use_driver.md
@@ -31,7 +31,7 @@ Either use "helm" or "platform" as the deployment method for managing virtual cl
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_version.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_version.md
@@ -27,7 +27,7 @@ All software has versions. This is Vcluster's.
 ## Global & Inherited Flags
 
 ```
-      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "/Users/ryanswanson/.vcluster/config.json")
+      --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")
       --context string      The kubernetes config context to use
       --debug               Prints the stack trace if an error occurs
       --log-output string   The log format to use. Can be either plain, raw or json (default "plain")


### PR DESCRIPTION
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Command references were outdated, updating for
- main folder
- 0.22
- 0.21
- 0.21

## Testing

This is a large PR due to automated docs generation. Best way to test is to do some exploratory tests, spot-check of various commands directly from the preview links below.

When reviewing, please disregard the linter issues, I'll follow up with a separate PR.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
- [main](https://deploy-preview-432--vcluster-docs-site.netlify.app/docs/vcluster/next/)
- [0.22](https://deploy-preview-432--vcluster-docs-site.netlify.app/docs/vcluster/)
- [0.21](https://deploy-preview-432--vcluster-docs-site.netlify.app/docs/vcluster/0.21.0/)
- [0.21](https://deploy-preview-432--vcluster-docs-site.netlify.app/docs/vcluster/0.20.0/)

## Internal Reference
<!--Add the Github or Linear ticket reference-->
Closes DOC-398

