### PR TITLE
chore(vale): add autogenerated docs to vale ignore list

### DIFF
--- a/.github/workflows/reviewdog.yaml
+++ b/.github/workflows/reviewdog.yaml
@@ -54,6 +54,12 @@ jobs:
           base_sha: ${{ github.event.pull_request.base.sha }}
           sha: ${{ github.event.pull_request.head.sha }}
           separator: ","
+          files_ignore: |
+            vcluster_versioned_docs/**/cli/*.md
+            vcluster_versioned_docs/**/cli/*.mdx
+            vcluster/**/cli/*.md
+            vcluster/**/cli/*.mdx
+            "*.md"
           files: |
             platform/**/*.mdx
             platform/**/*.md


### PR DESCRIPTION
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Currently vale checks content of all docs, but some of them are autogenerated and here vale checks create false positives. We should configure vale to ignore folders with the autogenerated documentation.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
N/A

## Internal Reference
<!--Add the Github or Linear ticket reference-->
Closes DOC-402

