### PR TITLE
chore: add contribution doc to vcluster and platform

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,3 @@
-# Contribute to the vCluster docs
 <!-- vale off -->
 ## Docs website
 
@@ -190,7 +189,9 @@ EOF
 
 #### Highlight lines of code
 
-Use inline comments in the code to highlight lines. See <https://docusaurus.io/docs/markdown-features/code-blocks#highlighting-with-comments>.
+Use [inline
+comments](https://docusaurus.io/docs/markdown-features/code-blocks#highlighting-with-comments)
+in the code to highlight lines. See .
 
 ### vCluster terms
 
@@ -223,7 +224,7 @@ Abbreviations for Kubernetes distros:
 
 - [Lightweight Kubernetes](https://k3s.io/): K3s
 - [Kubernetes](https://kubernetes.io/): K8s
-- [Zero Friction Kubernetes](https://k0sproject.io/ ): k0s  Note that k0s is the
+- [Zero Friction Kubernetes](https://k0sproject.io/): k0s  Note that k0s is the
   only Kubernetes distro to use a lower case 'k'
 - [AWS Elastic Kubernetes Service](https://aws.amazon.com/eks/): EKS
 

--- a/vcluster/contribute/_category_.json
+++ b/vcluster/contribute/_category_.json
@@ -1,0 +1,5 @@
+{
+    "label": "Contribute",
+    "position": "9",
+    "collapsible": true
+  }

--- a/vcluster/contribute/contribute.mdx
+++ b/vcluster/contribute/contribute.mdx
@@ -1,8 +1,9 @@
 ---
-title: Contribute to Platform Docs
+title: Contribute to vCluster Docs
 sidebar_label: Contribute
 sidebar_position: 1
 ---
 import Contribute from '../../CONTRIBUTING.md'
 
 <Contribute />
+

--- a/vcluster_versioned_docs/version-0.20.0/contribute/_category_.json
+++ b/vcluster_versioned_docs/version-0.20.0/contribute/_category_.json
@@ -1,0 +1,5 @@
+{
+    "label": "Contribute",
+    "position": "9",
+    "collapsible": true
+  }

--- a/vcluster_versioned_docs/version-0.20.0/contribute/contribute.mdx
+++ b/vcluster_versioned_docs/version-0.20.0/contribute/contribute.mdx
@@ -1,0 +1,9 @@
+---
+title: Contribute to vCluster Docs
+sidebar_label: Contribute
+sidebar_position: 1
+---
+import Contribute from '../../../CONTRIBUTING.md'
+
+<Contribute />
+

--- a/vcluster_versioned_docs/version-0.21.0/contribute/_category_.json
+++ b/vcluster_versioned_docs/version-0.21.0/contribute/_category_.json
@@ -1,0 +1,5 @@
+{
+    "label": "Contribute",
+    "position": "9",
+    "collapsible": true
+  }

--- a/vcluster_versioned_docs/version-0.21.0/contribute/contribute.mdx
+++ b/vcluster_versioned_docs/version-0.21.0/contribute/contribute.mdx
@@ -1,0 +1,9 @@
+---
+title: Contribute to vCluster Docs
+sidebar_label: Contribute
+sidebar_position: 1
+---
+import Contribute from '../../../CONTRIBUTING.md'
+
+<Contribute />
+

--- a/vcluster_versioned_docs/version-0.22.0/contribute/_category_.json
+++ b/vcluster_versioned_docs/version-0.22.0/contribute/_category_.json
@@ -1,0 +1,5 @@
+{
+    "label": "Contribute",
+    "position": "9",
+    "collapsible": true
+  }

--- a/vcluster_versioned_docs/version-0.22.0/contribute/contribute.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/contribute/contribute.mdx
@@ -1,0 +1,9 @@
+---
+title: Contribute to vCluster Docs
+sidebar_label: Contribute
+sidebar_position: 1
+---
+import Contribute from '../../../CONTRIBUTING.md'
+
+<Contribute />
+


### PR DESCRIPTION
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Previously, only `the platform` docs had `Contribute` section. Since now, we have improved the contribution guidelines, we are referencing it in `vCluster` docs as well, all versions.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
- [Contribute to Platform Docs](https://deploy-preview-438--vcluster-docs-site.netlify.app/docs/platform/contribute/)
- [Contribute to vCluster Docs](https://deploy-preview-438--vcluster-docs-site.netlify.app/docs/vcluster/contribute/)

> [!NOTE]
> make sure to select all vCluster versions


## Internal Reference
<!--Add the Github or Linear ticket reference-->
Closes DOC-406

