### PR TITLE
fix: database config reference

### DIFF
--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/external.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/external.mdx
@@ -6,7 +6,7 @@ sidebar_class_name: pro
 description: Configure an external database as the virtual cluster's backing store for enhanced performance and scalability.
 ---
 
-import ConfigReference from "../../../../../../_partials/config/controlPlane/backingStore/database/embedded.mdx";
+import ConfigReference from "../../../../../../_partials/config/controlPlane/backingStore/database/external.mdx";
 import ProAdmonition from "../../../../../../_partials/admonitions/pro-admonition.mdx";
 
 <ProAdmonition />

--- a/vcluster_versioned_docs/version-0.21.0/configure/vcluster-yaml/control-plane/components/backing-store/database/external.mdx
+++ b/vcluster_versioned_docs/version-0.21.0/configure/vcluster-yaml/control-plane/components/backing-store/database/external.mdx
@@ -6,7 +6,7 @@ sidebar_class_name: pro
 description: Configure an external database as the virtual cluster's backing store for enhanced performance and scalability.
 ---
 
-import ConfigReference from "../../../../../../_partials/config/controlPlane/backingStore/database/embedded.mdx";
+import ConfigReference from "../../../../../../_partials/config/controlPlane/backingStore/database/external.mdx";
 import ProAdmonition from "../../../../../../_partials/admonitions/pro-admonition.mdx";
 
 <ProAdmonition />

--- a/vcluster_versioned_docs/version-0.22.0/configure/vcluster-yaml/control-plane/components/backing-store/database/external.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/configure/vcluster-yaml/control-plane/components/backing-store/database/external.mdx
@@ -6,7 +6,7 @@ sidebar_class_name: pro
 description: Configure an external database as the virtual cluster's backing store for enhanced performance and scalability.
 ---
 
-import ConfigReference from "../../../../../../_partials/config/controlPlane/backingStore/database/embedded.mdx";
+import ConfigReference from "../../../../../../_partials/config/controlPlane/backingStore/database/external.mdx";
 import ProAdmonition from "../../../../../../_partials/admonitions/pro-admonition.mdx";
 
 <ProAdmonition />


### PR DESCRIPTION
# Content Description
fix import for database config reference 

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/vcluster/next/configure/vcluster-yaml/control-plane/components/backing-store/database/external) . -->
[Next version Preview](https://deploy-preview-440--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/control-plane/components/backing-store/database/external/)
[v0.21 Preview](https://deploy-preview-440--vcluster-docs-site.netlify.app/docs/vcluster/0.21.0/configure/vcluster-yaml/control-plane/components/backing-store/database/external/)
[v0.22 Preview](https://deploy-preview-440--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/database/external/)

## Internal Reference
<!--Add the Github or Linear ticket reference-->


