### PR TITLE
Update prerequisites to reflect active voice

### DIFF
--- a/docs/_partials/base-prerequisites.mdx
+++ b/docs/_partials/base-prerequisites.mdx
@@ -1,7 +1,7 @@
 import Mark from "@site/src/components/Mark";
 
 - Administrator access to a Kubernetes cluster: See [Accessing Clusters with kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) for more information.
-Your current kube-context must have administrative privileges, which you can verify with `kubectl auth can-i create clusterrole -A`
+Run the command `kubectl auth can-i create clusterrole -A` to verify that your current kube-context has administrative privileges.
     :::info
     To obtain a kube-context with admin access, ensure you have the necessary credentials and permissions for your Kubernetes cluster. This typically involves using `kubectl config` commands or authenticating through your cloud provider's CLI tools.
     :::


### PR DESCRIPTION
# Content Description
- Added a line to [reflect active voice ](https://developers.google.com/style/voice)for prerequisites

## Preview Link 

[Link to docs ](https://deploy-preview-441--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml/experimental/native-sleep-mode/#prerequisites)

> **Note**: This PR is just for test purposes. Even though the text is changed in a partial doc, it actually just applies to one spot in the docs. I would have to update it in another partial within the `install` folder to apply it to the other prerequisite texts in published docs. 

## Internal Reference
n/a

