### PR TITLE
refactor: update text on patches

### DIFF
--- a/vcluster/_fragments/patches.mdx
+++ b/vcluster/_fragments/patches.mdx
@@ -25,7 +25,7 @@ When using the asterisk (`*`) notation, vCluster applies changes individually to
 A JavaScript expression patch allows you to use JavaScript ES6 expressions to change specific fields when syncing between virtual and host clusters. 
 This is useful when modifying resource configurations to align with differing environments or naming conventions between clusters. If your clusters use different container name prefixes, a JavaScript expression patch can automatically update them.
 
-You can define a path for `spec.containers[*].name` in `vcluster.yaml` using the following configuration:
+You can define a path for <span>${props.path}</span> field in `vcluster.yaml` using the following configuration:
 
 <CodeBlock language="yaml">
 {`sync:
@@ -41,8 +41,8 @@ You can define a path for `spec.containers[*].name` in `vcluster.yaml` using the
 
 In the example:
 
-  - The path targets the `${props.resource}` field to override when syncing to the host cluster. The `*` wildcard applies the patch to each container individually.
-  - `"'my-prefix-' + value"` defines a JavaScript expression that prepends `"my-prefix-"` to the `${props.resource}` field in the host cluster.
+  - The path targets the <span>${props.path}</span> field to override when syncing to the host cluster. The `*` wildcard applies the patch to each container individually.
+  - `"'my-prefix-' + value"` defines a JavaScript expression that prepends `"my-prefix-"` to the <span>${props.path}</span> field in the host cluster.
 
 :::note Reverse sync
 You can use the `reverseExpression` field to define how to revert changes when syncing from the host cluster back to the virtual cluster.
@@ -87,7 +87,7 @@ You can sync between the virtual cluster and the host cluster by mapping `spec.s
 In the example:
 
 - The code uses a patch to add `metadata.annotations["my-secret-ref"]` 
-- It references a `Secret` in the host cluster using the patch and ensures `${props.resource}` in the host cluster links to the correct `Secret`.
+- It references a `Secret` in the host cluster using the patch and ensures <span>${props.resource}</span> in the host cluster links to the correct `Secret`.
 
 :::info Multi namespace mode
 With multi-namespace mode you only need to rewrite references that include a namespace. You can use the `namespacePath` option to specify the path of the namespace of the reference.

--- a/vcluster/_fragments/patches.mdx
+++ b/vcluster/_fragments/patches.mdx
@@ -7,7 +7,7 @@ Patches override the default resource syncing rules in your vCluster YAML config
 
 By default, vCluster [syncs specific resources](https://www.vcluster.com/docs/vcluster/next/configure/vcluster-yaml/sync/) between virtual and host clusters. To modify the sync behavior, you can use patches to specify which fields to edit, exclude, or override during syncing.
 
-Patches can provide greater control over syncing by preventing unintended changes, preserving critical settings, and ensuring only necessary updates are applied.
+By default, vCluster mirrors resources from the virtual cluster to the host cluster when syncing—any changes made in the virtual cluster are automatically applied to the host cluster. You can use patches to modify, exclude, or override specific fields to create a custom syncing pattern. This gives you more control by preventing unintended changes and ensuring only necessary updates are applied.
 
 vCluster supports two patch types:
 

--- a/vcluster/_fragments/patches.mdx
+++ b/vcluster/_fragments/patches.mdx
@@ -66,23 +66,31 @@ The context variable is an object supported in JavaScript expression patches, th
 A reference patch allows you to link a field in one resource to another resource. During syncing, vCluster rewrites the reference and imports the linked resource from a host cluster into its corresponding virtual cluster, if the resource exists.
 You can use reference patches to share resources, such as `Secrets` or `ConfigMaps`, between clusters without manually recreating or duplicating them.
 
-For example, if you have a custom resource in your virtual cluster that references a `Secret` named `my-secret-ref`, you can define a reference patch in your `vcluster.yaml` using the following configuration:
+For example, if the host cluster contains a secret named "my-example-secret" vCluster automatically imports it into the virtual cluster. 
+Workloads in the virtual cluster can then use the secret without manual syncing.
+
+You can sync between the virtual cluster and the host cluster by mapping `spec.secretName` to a secret in the host cluster:
 
 <CodeBlock language="yaml">
-{`sync:
+{`
+sync:
   toHost:
-    ${props.resource}:
-      enabled: true
-      patches:
-      - path: metadata.annotations["my-secret-ref"]
-        reference:
-          apiVersion: v1
-          kind: Secret`}
+    customResources:
+      certificates.cert-manager.io:
+        enabled: true
+        patches:
+        - path: spec.secretName
+          reference:
+            apiVersion: v1
+            kind: Secret
+`}
 </CodeBlock>
 
 In the example:
 
-  - `metadata.annotations["my-secret-ref"]` points to a `Secret`. The `Secret` is created in the host cluster and vCluster automatically imports it into the virtual cluster.
+- `customResources` enables synchronization of Cert-Manager certificates from the virtual cluster to the host cluster.
+- `patches` ensures `spec.secretName` references a `Secret` in the host cluster.
+- When a certificate is created in the virtual cluster, vCluster maps its `secretName` to a `Secret` in the host cluster.
 
 :::info Multi namespace mode
 With multi-namespace mode you only need to rewrite references that include a namespace. You can use the `namespacePath` option to specify the path of the namespace of the reference.

--- a/vcluster/_fragments/patches.mdx
+++ b/vcluster/_fragments/patches.mdx
@@ -23,27 +23,26 @@ When using the asterisk (`*`) notation, vCluster applies changes individually to
 ### JavaScript expression patch
 
 A JavaScript expression patch allows you to use JavaScript ES6 expressions to change specific fields when syncing between virtual and host clusters. 
-This is useful when modifying resource configurations to align with differing environments or naming conventions between clusters.
-
-For example, if your virtual cluster follows a specific naming convention for container names, but the host cluster requires a different prefix, you can use a JavaScript expression patch to automatically update the relevant field for each container.
+This is useful when modifying resource configurations to align with differing environments or naming conventions between clusters. If your clusters use different container name prefixes, a JavaScript expression patch can automatically update them.
 
 You can define a path for `spec.containers[*].name` in `vcluster.yaml` using the following configuration:
 
 <CodeBlock language="yaml">
-{`
-sync:
+{`sync:
   toHost:
-    enabled: true
-    patches:
-    - path: spec.containers[*].name
-      expression: "'my-prefix-' + value"
-`}
+    ${props.resource}:
+      enabled: true
+      patches:
+      - path: ${props.path}
+        expression: '"my-prefix-"+value'
+        # optional reverseExpression to reverse the change from the host cluster
+        # reverseExpression: 'value.slice("my-prefix".length)'`}
 </CodeBlock>
 
 In the example:
 
-  - `spec.containers[*].name` targets the `name` field of all containers within a Pod. The `*` wildcard applies the patch to each container individually.
-  - `"'my-prefix-' + value"` defines a JavaScript expression that prepends `"my-prefix-"` to each container name during syncing.
+  - The path targets the `${props.resource}` field to override when syncing to the host cluster. The `*` wildcard applies the patch to each container individually.
+  - `"'my-prefix-' + value"` defines a JavaScript expression that prepends `"my-prefix-"` to the `${props.resource}` field in the host cluster.
 
 :::note Reverse sync
 You can use the `reverseExpression` field to define how to revert changes when syncing from the host cluster back to the virtual cluster.
@@ -72,25 +71,21 @@ Workloads in the virtual cluster can then use the secret without manual syncing.
 You can sync between the virtual cluster and the host cluster by mapping `spec.secretName` to a secret in the host cluster:
 
 <CodeBlock language="yaml">
-{`
-sync:
+{`sync:
   toHost:
-    customResources:
-      certificates.cert-manager.io:
-        enabled: true
-        patches:
-        - path: spec.secretName
-          reference:
-            apiVersion: v1
-            kind: Secret
-`}
+    ${props.resource}:
+      enabled: true
+      patches:
+      - path: metadata.annotations["my-secret-ref"]
+        reference:
+          apiVersion: v1
+          kind: Secret`}
 </CodeBlock>
 
 In the example:
 
-- `customResources` enables synchronization of Cert-Manager certificates from the virtual cluster to the host cluster.
-- `patches` ensures `spec.secretName` references a `Secret` in the host cluster.
-- When a certificate is created in the virtual cluster, vCluster maps its `secretName` to a `Secret` in the host cluster.
+- The code uses a patch to add `metadata.annotations["my-secret-ref"]` 
+- It references a `Secret` in the host cluster using the patch and ensures `${props.resource}` in the host cluster links to the correct `Secret`.
 
 :::info Multi namespace mode
 With multi-namespace mode you only need to rewrite references that include a namespace. You can use the `namespacePath` option to specify the path of the namespace of the reference.

--- a/vcluster/_fragments/patches.mdx
+++ b/vcluster/_fragments/patches.mdx
@@ -7,12 +7,12 @@ Patches override the default resource syncing rules in your vCluster YAML config
 
 By default, vCluster [syncs specific resources](https://www.vcluster.com/docs/vcluster/next/configure/vcluster-yaml/sync/) between virtual and host clusters. To modify the sync behavior, you can use patches to specify which fields to edit, exclude, or override during syncing.
 
-By default, vCluster mirrors resources from the virtual cluster to the host cluster when syncing—any changes made in the virtual cluster are automatically applied to the host cluster. You can use patches to modify, exclude, or override specific fields to create a custom syncing pattern. This gives you more control by preventing unintended changes and ensuring only necessary updates are applied.
+For example, vCluster can mirror resources from the virtual cluster to the host cluster—any changes made in the virtual cluster are automatically applied to the host cluster. The same applies in the other direction if syncing is set up from host to virtual cluster.
 
 vCluster supports two patch types:
 
 - [JavaScript expression patch](#javascript-expression-patch): Uses JavaScript ES6 expressions to dynamically modify fields during syncing. You can define how a field changes when syncing from a virtual cluster to a host cluster, or from a host cluster to a virtual cluster.
-- [Reference patch](#reference-patch): Modifies specific fields within a resource to point to different resources. If the specified resource exists in a host cluster, vCluster automatically imports it into the corresponding virtual cluster.
+- [Reference patch](#reference-patch): Modifies specific fields within a resource to point to different resources. If the referenced resource exists in the host cluster, vCluster automatically imports it into the virtual cluster. If the referenced resource exists in the virtual cluster and syncing is configured, vCluster can import it into the host cluster.
 
 :::info Using wildcards in patches
 You can apply a wildcard, using an asterisk (`*`) in a specified path, to modify all elements of an array or object.
@@ -62,10 +62,12 @@ The context variable is an object supported in JavaScript expression patches, th
 
 ### Reference patch
 
-A reference patch allows you to link a field in one resource to another resource. During syncing, vCluster rewrites the reference and imports the linked resource from a host cluster into its corresponding virtual cluster, if the resource exists.
+A reference patch links a field in one resource to another resource. During syncing, vCluster updates the reference and imports the linked resource from the virtual cluster to the host cluster or from the host cluster to the virtual cluster, depending on the sync direction and whether the resource exists.
+
 You can use reference patches to share resources, such as `Secrets` or `ConfigMaps`, between clusters without manually recreating or duplicating them.
 
-For example, if the host cluster contains a secret named "my-example-secret" vCluster automatically imports it into the virtual cluster. 
+For example, if the host cluster contains a secret named `"my-example-secret"`, vCluster automatically imports it into the virtual cluster. 
+
 Workloads in the virtual cluster can then use the secret without manual syncing.
 
 You can sync between the virtual cluster and the host cluster by mapping `spec.secretName` to a secret in the host cluster:

--- a/vcluster/_fragments/patches.mdx
+++ b/vcluster/_fragments/patches.mdx
@@ -3,38 +3,71 @@ import CodeBlock from '@theme/CodeBlock';
 
 <ProAdmonition/>
 
-You can modify the sync behaviour with patches that target specific paths. Currently there is 2 different kinds of patches supported.
+Patches override the default resource syncing rules in your vCluster YAML configurations.
 
-:::info Wildcard patches
-You can use `*` in paths to select all entries of an array or object, e.g. `spec.containers[*].name` or `spec.containers[*].volumeMounts[*]`. vCluster calls the patch multiple times when using the wildcard reference.
+By default, vCluster [syncs specific resources](https://www.vcluster.com/docs/vcluster/next/configure/vcluster-yaml/sync/) between virtual and host clusters. To modify the sync behavior, you can use patches to specify which fields to edit, exclude, or override during syncing.
+
+Patches can provide greater control over syncing by preventing unintended changes, preserving critical settings, and ensuring only necessary updates are applied.
+
+vCluster supports two patch types:
+
+- [JavaScript expression patch](#javascript-expression-patch): Uses JavaScript ES6 expressions to dynamically modify fields during syncing. You can define how a field changes when syncing from a virtual cluster to a host cluster, or from a host cluster to a virtual cluster.
+- [Reference patch](#reference-patch): Modifies specific fields within a resource to point to different resources. If the specified resource exists in a host cluster, vCluster automatically imports it into the corresponding virtual cluster.
+
+:::info Using wildcards in patches
+You can apply a wildcard, using an asterisk (`*`) in a specified path, to modify all elements of an array or object.
+For instance, `spec.containers[*].name` selects the `name` field of every container in the `spec.containers` array, and `spec.containers[*].volumeMounts[*]` selects all `volumeMounts` for each container. 
+When using the asterisk (`*`) notation, vCluster applies changes individually to every element that matches the path.
 :::
 
-### JavaScript Expression Patches
+### JavaScript expression patch
 
-These are powerful JavaScript ES6 compatible expression patches that can be used to change a field while syncing. You define how it changes when syncing from the virtual cluster into the host cluster or when syncing from the host cluster into the virtual cluster. To change the path <span>{props.path}</span> you can do:
+A JavaScript expression patch allows you to use JavaScript ES6 expressions to change specific fields when syncing between virtual and host clusters. 
+This is useful when modifying resource configurations to align with differing environments or naming conventions between clusters.
+
+For example, if your virtual cluster follows a specific naming convention for container names, but the host cluster requires a different prefix, you can use a JavaScript expression patch to automatically update the relevant field for each container.
+
+You can define a path for `spec.containers[*].name` in `vcluster.yaml` using the following configuration:
+
 <CodeBlock language="yaml">
-{`sync:
+{`
+sync:
   toHost:
-    ${props.resource}:
-      enabled: true
-      patches:
-      - path: ${props.path}
-        expression: '"my-prefix-"+value'
-        # optional reverseExpression to reverse the change from the host cluster
-        # reverseExpression: 'value.slice("my-prefix".length)'`}
+    enabled: true
+    patches:
+    - path: spec.containers[*].name
+      expression: "'my-prefix-' + value"
+`}
 </CodeBlock>
 
-There is also a variable called `context` besides `value` that can be used to access specific data of the virtual cluster:
-* `context.vcluster.name`: Name of the virtual cluster
-* `context.vcluster.namespace`: Namespace of the virtual cluster
-* `context.vcluster.config`: Config of the virtual cluster, basically `vcluster.yaml` merged with the defaults
-* `context.hostObject`: Host object (can be null if not available)
-* `context.virtualObject`: Virtual object (can be null if not available)
-* `context.path`: The matched path on the object, useful when using wildcard path selectors (*)
+In the example:
 
-### Reference patches
+  - `spec.containers[*].name` targets the `name` field of all containers within a Pod. The `*` wildcard applies the patch to each container individually.
+  - `"'my-prefix-' + value"` defines a JavaScript expression that prepends `"my-prefix-"` to each container name during syncing.
 
-A reference patch can be used to have a specific field of one resource point to a different resource that should get rewritten. vCluster automatically imports the referenced resource to the virtual cluster if it can find it in the host cluster. For example:
+:::note Reverse sync
+You can use the `reverseExpression` field to define how to revert changes when syncing from the host cluster back to the virtual cluster.
+For example, add `reverseExpression: {"value.slice('my-prefix'.length)"}` to `vcluster.yaml` to remove the `"my-prefix-"` prefix when syncing back from the host cluster to the virtual cluster in the previous example.
+:::
+
+#### Context variable
+
+The context variable is an object supported in JavaScript expression patches, that provides access to virtual cluster data during syncing. The context object includes the following properties:
+
+* `context.vcluster.name`: Name of the virtual cluster.
+* `context.vcluster.namespace`: Namespace of the virtual cluster.
+* `context.vcluster.config`: Configuration of the virtual cluster, basically `vcluster.yaml` merged with the defaults.
+* `context.hostObject`: Host object (`null` if not available).
+* `context.virtualObject`: Virtual object (`null` if not available).
+* `context.path`: Matched path on the object, useful when using wildcard path selectors (`*`).
+
+### Reference patch
+
+A reference patch allows you to link a field in one resource to another resource. During syncing, vCluster rewrites the reference and imports the linked resource from a host cluster into its corresponding virtual cluster, if the resource exists.
+You can use reference patches to share resources, such as `Secrets` or `ConfigMaps`, between clusters without manually recreating or duplicating them.
+
+For example, if you have a custom resource in your virtual cluster that references a `Secret` named `my-secret-ref`, you can define a reference patch in your `vcluster.yaml` using the following configuration:
+
 <CodeBlock language="yaml">
 {`sync:
   toHost:
@@ -47,8 +80,10 @@ A reference patch can be used to have a specific field of one resource point to 
           kind: Secret`}
 </CodeBlock>
 
-With this yaml, vCluster translates the path `metadata.annotations["my-secret-ref"]` as it points to a secret. If the secret is created in the host cluster, vCluster automatically imports it into the virtual cluster.
+In the example:
 
-:::info Multi-Namespace-Mode
-With multi-namespace-mode you only need to rewrite references that include a namespace. You can use the `namespacePath` option to specify the path of the namespace of the reference.
+  - `metadata.annotations["my-secret-ref"]` points to a `Secret`. The `Secret` is created in the host cluster and vCluster automatically imports it into the virtual cluster.
+
+:::info Multi namespace mode
+With multi-namespace mode you only need to rewrite references that include a namespace. You can use the `namespacePath` option to specify the path of the namespace of the reference.
 :::

--- a/vcluster/_fragments/patches.mdx
+++ b/vcluster/_fragments/patches.mdx
@@ -25,7 +25,7 @@ When using the asterisk (`*`) notation, vCluster applies changes individually to
 A JavaScript expression patch allows you to use JavaScript ES6 expressions to change specific fields when syncing between virtual and host clusters. 
 This is useful when modifying resource configurations to align with differing environments or naming conventions between clusters. If your clusters use different container name prefixes, a JavaScript expression patch can automatically update them.
 
-You can define a path for <span>${props.path}</span> field in `vcluster.yaml` using the following configuration:
+You can define a path for <code>{`<span>${props.path}</span>`}</code> field in `vcluster.yaml` using the following configuration:
 
 <CodeBlock language="yaml">
 {`sync:
@@ -41,8 +41,8 @@ You can define a path for <span>${props.path}</span> field in `vcluster.yaml` us
 
 In the example:
 
-  - The path targets the <span>${props.path}</span> field to override when syncing to the host cluster. The `*` wildcard applies the patch to each container individually.
-  - `"'my-prefix-' + value"` defines a JavaScript expression that prepends `"my-prefix-"` to the <span>${props.path}</span> field in the host cluster.
+  - The path targets the <code>{`<span>${props.path}</span>`}</code> field to override when syncing to the host cluster. The `*` wildcard applies the patch to each container individually.
+  - `"'my-prefix-' + value"` defines a JavaScript expression that prepends `"my-prefix-"` to the <code>{`<span>${props.path}</span>`}</code> field in the host cluster.
 
 :::note Reverse sync
 You can use the `reverseExpression` field to define how to revert changes when syncing from the host cluster back to the virtual cluster.
@@ -87,7 +87,7 @@ You can sync between the virtual cluster and the host cluster by mapping `spec.s
 In the example:
 
 - The code uses a patch to add `metadata.annotations["my-secret-ref"]` 
-- It references a `Secret` in the host cluster using the patch and ensures <span>${props.resource}</span> in the host cluster links to the correct `Secret`.
+- It references a `Secret` in the host cluster using the patch and ensures <code>{`<span>${props.resource}</span>`}</code> in the host cluster links to the correct `Secret`.
 
 :::info Multi namespace mode
 With multi-namespace mode you only need to rewrite references that include a namespace. You can use the `namespacePath` option to specify the path of the namespace of the reference.

--- a/vcluster/_fragments/patches.mdx
+++ b/vcluster/_fragments/patches.mdx
@@ -25,7 +25,7 @@ When using the asterisk (`*`) notation, vCluster applies changes individually to
 A JavaScript expression patch allows you to use JavaScript ES6 expressions to change specific fields when syncing between virtual and host clusters. 
 This is useful when modifying resource configurations to align with differing environments or naming conventions between clusters. If your clusters use different container name prefixes, a JavaScript expression patch can automatically update them.
 
-You can define a path for <code>{`<span>${props.path}</span>`}</code> field in `vcluster.yaml` using the following configuration:
+You can define a path for <code>{props.path}</code> field in `vcluster.yaml` using the following configuration:
 
 <CodeBlock language="yaml">
 {`sync:
@@ -41,8 +41,8 @@ You can define a path for <code>{`<span>${props.path}</span>`}</code> field in `
 
 In the example:
 
-  - The path targets the <code>{`<span>${props.path}</span>`}</code> field to override when syncing to the host cluster. The `*` wildcard applies the patch to each container individually.
-  - `"'my-prefix-' + value"` defines a JavaScript expression that prepends `"my-prefix-"` to the <code>{`<span>${props.path}</span>`}</code> field in the host cluster.
+  - The path targets the <code>{props.path}</code> field to override when syncing to the host cluster. The `*` wildcard applies the patch to each container individually.
+  - `"'my-prefix-' + value"` defines a JavaScript expression that prepends `"my-prefix-"` to the <code>{props.path}</code> field in the host cluster.
 
 :::note Reverse sync
 You can use the `reverseExpression` field to define how to revert changes when syncing from the host cluster back to the virtual cluster.
@@ -87,7 +87,7 @@ You can sync between the virtual cluster and the host cluster by mapping `spec.s
 In the example:
 
 - The code uses a patch to add `metadata.annotations["my-secret-ref"]` 
-- It references a `Secret` in the host cluster using the patch and ensures <code>{`<span>${props.resource}</span>`}</code> in the host cluster links to the correct `Secret`.
+- It references a `Secret` in the host cluster using the patch and ensures <code>{props.resource}</code> in the host cluster links to the correct `Secret`.
 
 :::info Multi namespace mode
 With multi-namespace mode you only need to rewrite references that include a namespace. You can use the `namespacePath` option to specify the path of the namespace of the reference.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
- Update the text related to patches
- Restructure doc for a bit more clarity
- Add further explanation for wildcards in patches and `context` variable
- Refine examples for clarity


## Preview Link 

- [Link to preview](https://deploy-preview-445--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/sync/to-host/core/pods#patch)


## Internal Reference
<!--Add the Github or Linear ticket reference-->
N/A

