### PR TITLE
adds warning not to double configure sleep mode

### DIFF
--- a/vcluster/configure/vcluster-yaml/experimental/native-sleep-mode.mdx
+++ b/vcluster/configure/vcluster-yaml/experimental/native-sleep-mode.mdx
@@ -7,9 +7,9 @@ description: Learn how to configure and manage sleep mode functionality in virtu
 ---
 import ProAdmonition from '../../../_partials/admonitions/pro-admonition.mdx'
 import ExperimentalSleepMode from '../../../_partials/config/experimental/sleepMode.mdx'
-import SleepModeDeploymentExample from '@site/vcluster/_fragments/sleepmode-deployment-example.mdx'
-import SleepModeIngressExample from '@site/vcluster/_fragments/sleepmode-ingress-example.mdx'
-import BasePrerequisites from '@site/docs/_partials/base-prerequisites.mdx';
+import SleepModeDeploymentExample from '../../../_fragments/sleepmode-deployment-example.mdx'
+import SleepModeIngressExample from '../../../_fragments/sleepmode-ingress-example.mdx'
+import BasePrerequisites from '../../../../docs/_partials/base-prerequisites.mdx';
 import InstallCli from '../../../_partials/deploy/install-cli.mdx';
 
 <ProAdmonition />
@@ -18,7 +18,8 @@ import InstallCli from '../../../_partials/deploy/install-cli.mdx';
 
 :::warning
 Native sleep mode is intended for pre-production use cases only, and comes with some limitations and
-caveats.
+caveats and should not be enabled on virtual clusters that are using the current sleep mode configuration found in
+[external.platform](../external/platform).
 :::
 
 

--- a/vcluster_versioned_docs/version-0.22.0/configure/vcluster-yaml/experimental/native-sleep-mode.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/configure/vcluster-yaml/experimental/native-sleep-mode.mdx
@@ -7,9 +7,9 @@ description: Learn how to configure and manage sleep mode functionality in virtu
 ---
 import ProAdmonition from '../../../_partials/admonitions/pro-admonition.mdx'
 import ExperimentalSleepMode from '../../../_partials/config/experimental/sleepMode.mdx'
-import SleepModeDeploymentExample from '@site/vcluster/_fragments/sleepmode-deployment-example.mdx'
-import SleepModeIngressExample from '@site/vcluster/_fragments/sleepmode-ingress-example.mdx'
-import BasePrerequisites from '@site/docs/_partials/base-prerequisites.mdx';
+import SleepModeDeploymentExample from '../../../../../vcluster/_fragments/sleepmode-deployment-example.mdx'
+import SleepModeIngressExample from '../../../../../vcluster/_fragments/sleepmode-ingress-example.mdx'
+import BasePrerequisites from '../../../../../docs/_partials/base-prerequisites.mdx';
 import InstallCli from '../../../_partials/deploy/install-cli.mdx';
 
 <ProAdmonition />
@@ -18,7 +18,8 @@ import InstallCli from '../../../_partials/deploy/install-cli.mdx';
 
 :::warning
 Native sleep mode is intended for pre-production use cases only, and comes with some limitations and
-caveats.
+caveats and should not be enabled on virtual clusters that are using the current sleep mode configuration found in
+[external.platform](../external/platform).
 :::
 
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[v0.22](https://deploy-preview-446--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml/experimental/native-sleep-mode)
[main](https://deploy-preview-446--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/experimental/native-sleep-mode)


## Internal Reference
Closes DOC-412

