### PR TITLE
Improved PRO label drawing, and fixed a display bug

### DIFF
--- a/src/css/sidebar.scss
+++ b/src/css/sidebar.scss
@@ -10,36 +10,48 @@
   }
 
   /* PRO label */
-  &.pro > .menu__list-item-collapsible > .menu__link, // With subitems
-  &.pro > .menu__link // Without subitems
-  {
+  &.pro {
     position: relative;
 
     &::after {
       content: "PRO";
+
+      // Technical settings:
+      display: block;
+      box-sizing: content-box;
       position: absolute;
+
+      // Sizing and placement:
+      line-height: 100%;
       right: 0.5rem;
-      top: 50%;
-      transform: translateY(-50%);
-      padding: 0.25em 0.45em 0.25em 0.45em;
-      font-size: 0.7em;
+      height: 1em;
+      // The calculation below is derived from:
+      // 0.5rem -> top padding for items
+      // 2px -> manual adjustment
+      // This is done this way instead of placing it halfway down the element
+      // and adjusting with `transform` because this item may not always be one
+      // line tall.
+      top: calc(0.5rem + 2px);
+      padding: 0.25em 0.35em;
+
+      // Typography:
+      // This is set for a consistent look across sections (vcluster.yaml
+      // values are monospaced)
+      font-family: var(--ifm-font-family-base);
+      font-size: 0.6rem;
       font-weight: 700;
-      letter-spacing: 0.3px;
+      letter-spacing: 0.2px;
+
+      // Colors:
       color: #fff;
       background: #f27506;
       border-radius: 3px;
-      // This is here on purpose. Sometimes text-indent is applied on the parent
-      // element and gets inherited by the PRO label, which it is not supposed
-      // to do:
-      text-indent: 0;
     }
-  }
 
-  // In the case of sidebar items that are collapsible, the PRO label should be
-  // positioned inwards to prevent overlap with the expand/collapse caret
-  &.pro > .menu__list-item-collapsible > .menu__link {
-    &::after {
-      right: 2.5rem;
+    &:has(a.menu__link--sublist-caret[role="button"]) {
+      &::after {
+        right: 2.5rem;
+      }
     }
   }
 

--- a/vcluster/integrations/certManager.mdx
+++ b/vcluster/integrations/certManager.mdx
@@ -5,6 +5,6 @@ sidebar_class_name: pro
 sidebar_position: 2
 ---
 
-import CertManager from '../../_fragments/integrations/cert-manager.mdx'
+import CertManager from '../_fragments/integrations/cert-manager.mdx'
 
 <CertManager />

--- a/vcluster/integrations/kubevirt.mdx
+++ b/vcluster/integrations/kubevirt.mdx
@@ -5,7 +5,7 @@ sidebar_class_name: pro
 sidebar_position: 2
 ---
 
-import KubeVirt from '../../_fragments/integrations/kube-virt.mdx'
+import KubeVirt from '../_fragments/integrations/kube-virt.mdx'
 
 <KubeVirt />
 


### PR DESCRIPTION
The PRO label is now applied to the `::after` pseudo-selector of the actual `.pro` element. This is to prevent a collision with Docusaurus' own `::after`, which draws the submenus generally.

This affects the way that the PRO label is positioned (added comments for future generations).

Additionally, I have implemented some changes for a more consistent look for the PRO tags across different sections (though, some small and mysterious quirks of style do remain)

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the Github or Linear ticket reference-->
Closes DOC-397

## Screenshots

Support for collapsible pro items (**none currently exist, this is a test**):
![Screenshot 2025-01-31 at 12 39 09](https://github.com/user-attachments/assets/0e9e8dbf-274b-47d9-ba85-17cdab9ca844)

Other pro tags:
![image](https://github.com/user-attachments/assets/b00ef26d-03e3-4979-a8fc-36b0a1e293c4)
![image](https://github.com/user-attachments/assets/38ff675e-b11a-43d6-922c-977a915b610e)

