### PR TITLE
fix(cli): fixing vcluster sleep and wakeup commands

### DIFF
--- a/vcluster/manage/sleep-wakeup.mdx
+++ b/vcluster/manage/sleep-wakeup.mdx
@@ -3,47 +3,68 @@ title: Sleep & Wakeup vCluster
 sidebar_label: Sleep & Wakeup
 sidebar_position: 4
 ---
+import BasePrerequisites from '../../docs/_partials/base-prerequisites.mdx';
+import InstallCli from '../_partials/deploy/install-cli.mdx';
 
-Sleeping a vCluster means to temporarily scale down the vCluster and delete all its created workloads on the host cluster. This can be useful to save computing resources used by vCluster workloads in the host cluster.
+The sleep mode **temporarily scales down** a virtual cluster and deletes all its created workloads on the host cluster. This approach helps **save computing resources** used by virtual cluster workloads in the host cluster. For example, sleeping development clusters during non-working hours can significantly reduce infrastructure costs.
+
+## Prerequisites
+
+<BasePrerequisites />
+- `vCluster` CLI
+  <InstallCli />
+
 
 ## Sleeping a vCluster
 
-Put a vCluster to sleep with the vCluster CLI: 
+Put a virtual cluster to sleep with the `vCluster` CLI:
 
+```bash title="Sleep a virtual cluster"
+vcluster platform sleep my-vcluster -n my-vcluster-namespace
 ```
-vcluster sleep my-vcluster -n my-vcluster-namespace
-```
 
-This command will do the following things:
-1. Scale down any statefulset(s) or deployment(s) in the vCluster.  
-2. Delete all workloads created by the vCluster on the host cluster.
+:::tip CLI reference
+<!-- vale off -->
+Read about using the [vcluster platform sleep](/vcluster/cli/vcluster_platform_sleep) command.
+<!-- vale on -->
+:::
 
-The command leaves the objects within the vCluster untouched, which means that even single pods that were deployed within the vCluster without a controlling replica set or statefulset will be restarted.
+This command performs the following actions:
+- Scales down any StatefulSets or Deployments in the virtual cluster
+- Deletes all workloads created by the virtual cluster on the host cluster
+
+While the command preserves object definitions within the virtual cluster, any standalone pods (those without a controlling replica set or StatefulSet) needs to be restarted when the cluster wakes up.
 
 :::warning Restarting pods
-Since all the pods will be restarted, the temporary filesystem is erased and the pod IP will change.
+When pods are restarted:
+- The temporary filesystem is erased
+- Pod IP addresses change
 :::
 
 ## Waking up a vCluster
 
-You can wake up a vCluster with two different vCluster CLI commands. 
+You can wake up a virtual cluster with two different `vCluster` CLI commands.
 
-As soon as the vCluster is woken up, vCluster will scale up any paused statefulset(s) or deployment(s) and the vCluster syncer will recreate the vCluster pods onto the host cluster.
+As soon as the virtual cluster is woken up, `vCluster` scales up any paused StatefulSets or Deployments and the `vCluster` syncer recreates the `vCluster` pods onto the host cluster.
 
-### Wake Up the vCluster Directly
+### Direct wake up
 
-Wake up the vCluster with a vCluster CLI command:
+Wake up the virtual cluster with a `vCluster` CLI command:
 
+```bash title="Wake up a virtual cluster"
+vcluster platform wakeup my-vcluster -n my-vcluster-namespace
 ```
-vcluster wakeup my-vcluster -n my-vcluster-namespace
-```
 
-### Connect to the vCluster to Wake Up
+:::tip CLI reference
+<!-- vale off -->
+Read about using the [vcluster platform wakeup](/vcluster/cli/vcluster_platform_wakeup) command.
+<!-- vale on -->
+:::
 
-Connect to the vCluster with a vCluster CLI command, which will automatically wake up the vCluster:
+### Connect to wake up
 
-```
+Connect to the virtual cluster with a `vCluster` CLI command, which automatically wakes up the virtual cluster:
+
+```bash title="Connect to wake up a virtual cluster"
 vcluster connect my-vcluster -n my-vcluster-namespace
 ```
-
-

--- a/vcluster_versioned_docs/version-0.20.0/manage/sleep-wakeup.mdx
+++ b/vcluster_versioned_docs/version-0.20.0/manage/sleep-wakeup.mdx
@@ -3,47 +3,68 @@ title: Sleep & Wakeup vCluster
 sidebar_label: Sleep & Wakeup
 sidebar_position: 4
 ---
+import BasePrerequisites from '../../../docs/_partials/base-prerequisites.mdx';
+import InstallCli from '../_partials/deploy/install-cli.mdx';
 
-Sleeping a vCluster means to temporarily scale down the vCluster and delete all its created workloads on the host cluster. This can be useful to save computing resources used by vCluster workloads in the host cluster.
+The sleep mode **temporarily scales down** a virtual cluster and deletes all its created workloads on the host cluster. This approach helps **save computing resources** used by virtual cluster workloads in the host cluster. For example, sleeping development clusters during non-working hours can significantly reduce infrastructure costs.
+
+## Prerequisites
+
+<BasePrerequisites />
+- `vCluster` CLI
+  <InstallCli />
+
 
 ## Sleeping a vCluster
 
-Put a vCluster to sleep with the vCluster CLI: 
+Put a virtual cluster to sleep with the `vCluster` CLI:
 
+```bash title="Sleep a virtual cluster"
+vcluster platform sleep my-vcluster -n my-vcluster-namespace
 ```
-vcluster sleep my-vcluster -n my-vcluster-namespace
-```
 
-This command will do the following things:
-1. Scale down any statefulset(s) or deployment(s) in the vCluster.  
-2. Delete all workloads created by the vCluster on the host cluster.
+:::tip CLI reference
+<!-- vale off -->
+Read about using the [vcluster platform sleep](/vcluster/cli/vcluster_platform_sleep) command.
+<!-- vale on -->
+:::
 
-The command leaves the objects within the vCluster untouched, which means that even single pods that were deployed within the vCluster without a controlling replica set or statefulset will be restarted.
+This command performs the following actions:
+- Scales down any StatefulSets or Deployments in the virtual cluster
+- Deletes all workloads created by the virtual cluster on the host cluster
+
+While the command preserves object definitions within the virtual cluster, any standalone pods (those without a controlling replica set or StatefulSet) needs to be restarted when the cluster wakes up.
 
 :::warning Restarting pods
-Since all the pods will be restarted, the temporary filesystem is erased and the pod IP will change.
+When pods are restarted:
+- The temporary filesystem is erased
+- Pod IP addresses change
 :::
 
 ## Waking up a vCluster
 
-You can wake up a vCluster with two different vCluster CLI commands. 
+You can wake up a virtual cluster with two different `vCluster` CLI commands.
 
-As soon as the vCluster is woken up, vCluster will scale up any paused statefulset(s) or deployment(s) and the vCluster syncer will recreate the vCluster pods onto the host cluster.
+As soon as the virtual cluster is woken up, `vCluster` scales up any paused StatefulSets or Deployments and the `vCluster` syncer recreates the `vCluster` pods onto the host cluster.
 
-### Wake Up the vCluster Directly
+### Direct wake up
 
-Wake up the vCluster with a vCluster CLI command:
+Wake up the virtual cluster with a `vCluster` CLI command:
 
+```bash title="Wake up a virtual cluster"
+vcluster platform wakeup my-vcluster -n my-vcluster-namespace
 ```
-vcluster wakeup my-vcluster -n my-vcluster-namespace
-```
 
-### Connect to the vCluster to Wake Up
+:::tip CLI reference
+<!-- vale off -->
+Read about using the [vcluster platform wakeup](/vcluster/cli/vcluster_platform_wakeup) command.
+<!-- vale on -->
+:::
 
-Connect to the vCluster with a vCluster CLI command, which will automatically wake up the vCluster:
+### Connect to wake up
 
-```
+Connect to the virtual cluster with a `vCluster` CLI command, which automatically wakes up the virtual cluster:
+
+```bash title="Connect to wake up a virtual cluster"
 vcluster connect my-vcluster -n my-vcluster-namespace
 ```
-
-

--- a/vcluster_versioned_docs/version-0.21.0/manage/sleep-wakeup.mdx
+++ b/vcluster_versioned_docs/version-0.21.0/manage/sleep-wakeup.mdx
@@ -3,47 +3,68 @@ title: Sleep & Wakeup vCluster
 sidebar_label: Sleep & Wakeup
 sidebar_position: 4
 ---
+import BasePrerequisites from '../../../docs/_partials/base-prerequisites.mdx';
+import InstallCli from '../_partials/deploy/install-cli.mdx';
 
-Sleeping a vCluster means to temporarily scale down the vCluster and delete all its created workloads on the host cluster. This can be useful to save computing resources used by vCluster workloads in the host cluster.
+The sleep mode **temporarily scales down** a virtual cluster and deletes all its created workloads on the host cluster. This approach helps **save computing resources** used by virtual cluster workloads in the host cluster. For example, sleeping development clusters during non-working hours can significantly reduce infrastructure costs.
+
+## Prerequisites
+
+<BasePrerequisites />
+- `vCluster` CLI
+  <InstallCli />
+
 
 ## Sleeping a vCluster
 
-Put a vCluster to sleep with the vCluster CLI: 
+Put a virtual cluster to sleep with the `vCluster` CLI:
 
+```bash title="Sleep a virtual cluster"
+vcluster platform sleep my-vcluster -n my-vcluster-namespace
 ```
-vcluster sleep my-vcluster -n my-vcluster-namespace
-```
 
-This command will do the following things:
-1. Scale down any statefulset(s) or deployment(s) in the vCluster.  
-2. Delete all workloads created by the vCluster on the host cluster.
+:::tip CLI reference
+<!-- vale off -->
+Read about using the [vcluster platform sleep](/vcluster/cli/vcluster_platform_sleep) command.
+<!-- vale on -->
+:::
 
-The command leaves the objects within the vCluster untouched, which means that even single pods that were deployed within the vCluster without a controlling replica set or statefulset will be restarted.
+This command performs the following actions:
+- Scales down any StatefulSets or Deployments in the virtual cluster
+- Deletes all workloads created by the virtual cluster on the host cluster
+
+While the command preserves object definitions within the virtual cluster, any standalone pods (those without a controlling replica set or StatefulSet) needs to be restarted when the cluster wakes up.
 
 :::warning Restarting pods
-Since all the pods will be restarted, the temporary filesystem is erased and the pod IP will change.
+When pods are restarted:
+- The temporary filesystem is erased
+- Pod IP addresses change
 :::
 
 ## Waking up a vCluster
 
-You can wake up a vCluster with two different vCluster CLI commands. 
+You can wake up a virtual cluster with two different `vCluster` CLI commands.
 
-As soon as the vCluster is woken up, vCluster will scale up any paused statefulset(s) or deployment(s) and the vCluster syncer will recreate the vCluster pods onto the host cluster.
+As soon as the virtual cluster is woken up, `vCluster` scales up any paused StatefulSets or Deployments and the `vCluster` syncer recreates the `vCluster` pods onto the host cluster.
 
-### Wake Up the vCluster Directly
+### Direct wake up
 
-Wake up the vCluster with a vCluster CLI command:
+Wake up the virtual cluster with a `vCluster` CLI command:
 
+```bash title="Wake up a virtual cluster"
+vcluster platform wakeup my-vcluster -n my-vcluster-namespace
 ```
-vcluster wakeup my-vcluster -n my-vcluster-namespace
-```
 
-### Connect to the vCluster to Wake Up
+:::tip CLI reference
+<!-- vale off -->
+Read about using the [vcluster platform wakeup](/vcluster/cli/vcluster_platform_wakeup) command.
+<!-- vale on -->
+:::
 
-Connect to the vCluster with a vCluster CLI command, which will automatically wake up the vCluster:
+### Connect to wake up
 
-```
+Connect to the virtual cluster with a `vCluster` CLI command, which automatically wakes up the virtual cluster:
+
+```bash title="Connect to wake up a virtual cluster"
 vcluster connect my-vcluster -n my-vcluster-namespace
 ```
-
-

--- a/vcluster_versioned_docs/version-0.22.0/manage/sleep-wakeup.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/manage/sleep-wakeup.mdx
@@ -3,47 +3,68 @@ title: Sleep & Wakeup vCluster
 sidebar_label: Sleep & Wakeup
 sidebar_position: 4
 ---
+import BasePrerequisites from '../../../docs/_partials/base-prerequisites.mdx';
+import InstallCli from '../_partials/deploy/install-cli.mdx';
 
-Sleeping a vCluster means to temporarily scale down the vCluster and delete all its created workloads on the host cluster. This can be useful to save computing resources used by vCluster workloads in the host cluster.
+The sleep mode **temporarily scales down** a virtual cluster and deletes all its created workloads on the host cluster. This approach helps **save computing resources** used by virtual cluster workloads in the host cluster. For example, sleeping development clusters during non-working hours can significantly reduce infrastructure costs.
+
+## Prerequisites
+
+<BasePrerequisites />
+- `vCluster` CLI
+  <InstallCli />
+
 
 ## Sleeping a vCluster
 
-Put a vCluster to sleep with the vCluster CLI: 
+Put a virtual cluster to sleep with the `vCluster` CLI:
 
+```bash title="Sleep a virtual cluster"
+vcluster platform sleep my-vcluster -n my-vcluster-namespace
 ```
-vcluster sleep my-vcluster -n my-vcluster-namespace
-```
 
-This command will do the following things:
-1. Scale down any statefulset(s) or deployment(s) in the vCluster.  
-2. Delete all workloads created by the vCluster on the host cluster.
+:::tip CLI reference
+<!-- vale off -->
+Read about using the [vcluster platform sleep](/vcluster/cli/vcluster_platform_sleep) command.
+<!-- vale on -->
+:::
 
-The command leaves the objects within the vCluster untouched, which means that even single pods that were deployed within the vCluster without a controlling replica set or statefulset will be restarted.
+This command performs the following actions:
+- Scales down any StatefulSets or Deployments in the virtual cluster
+- Deletes all workloads created by the virtual cluster on the host cluster
+
+While the command preserves object definitions within the virtual cluster, any standalone pods (those without a controlling replica set or StatefulSet) needs to be restarted when the cluster wakes up.
 
 :::warning Restarting pods
-Since all the pods will be restarted, the temporary filesystem is erased and the pod IP will change.
+When pods are restarted:
+- The temporary filesystem is erased
+- Pod IP addresses change
 :::
 
 ## Waking up a vCluster
 
-You can wake up a vCluster with two different vCluster CLI commands. 
+You can wake up a virtual cluster with two different `vCluster` CLI commands.
 
-As soon as the vCluster is woken up, vCluster will scale up any paused statefulset(s) or deployment(s) and the vCluster syncer will recreate the vCluster pods onto the host cluster.
+As soon as the virtual cluster is woken up, `vCluster` scales up any paused StatefulSets or Deployments and the `vCluster` syncer recreates the `vCluster` pods onto the host cluster.
 
-### Wake Up the vCluster Directly
+### Direct wake up
 
-Wake up the vCluster with a vCluster CLI command:
+Wake up the virtual cluster with a `vCluster` CLI command:
 
+```bash title="Wake up a virtual cluster"
+vcluster platform wakeup my-vcluster -n my-vcluster-namespace
 ```
-vcluster wakeup my-vcluster -n my-vcluster-namespace
-```
 
-### Connect to the vCluster to Wake Up
+:::tip CLI reference
+<!-- vale off -->
+Read about using the [vcluster platform wakeup](/vcluster/cli/vcluster_platform_wakeup) command.
+<!-- vale on -->
+:::
 
-Connect to the vCluster with a vCluster CLI command, which will automatically wake up the vCluster:
+### Connect to wake up
 
-```
+Connect to the virtual cluster with a `vCluster` CLI command, which automatically wakes up the virtual cluster:
+
+```bash title="Connect to wake up a virtual cluster"
 vcluster connect my-vcluster -n my-vcluster-namespace
 ```
-
-


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Fixing sleep and wake-up commands and doc.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Sleep & Wakeup vCluster](https://deploy-preview-451--vcluster-docs-site.netlify.app/docs/vcluster/next/manage/sleep-wakeup)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-417

