### PR TITLE
fix context window for action metadata.name

### DIFF
--- a/vcluster/_partials/integrations/github-actions-pull-request-devspace.mdx
+++ b/vcluster/_partials/integrations/github-actions-pull-request-devspace.mdx
@@ -22,7 +22,7 @@ jobs:
         run: vcluster login $LOFT_URL --access-key $ACCESS_KEY
       - name: Create PR Virtual Cluster
         env:
-          NAME: pr-${{ github.event.pull_request.number }}
+          NAME: repo-${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}
         run: vcluster create $NAME --project default
       - name: Run Tests
         run: devspace run e2e

--- a/vcluster/_partials/integrations/github-actions-vclusters-pull-request-automatic.mdx
+++ b/vcluster/_partials/integrations/github-actions-vclusters-pull-request-automatic.mdx
@@ -19,7 +19,7 @@ jobs:
       - name: Create Virtual Cluster for PR
         uses: loft-sh/create-vcluster@main
         with:
-          name: pr-${{ github.event.pull_request.number }}
+          name: repo-${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}
           auto-cleanup: true
       - name: Deploy Application
         run: kubectl apply -Rf ./kubernetes

--- a/vcluster/_partials/integrations/github-actions-vclusters-pull-request-manual.mdx
+++ b/vcluster/_partials/integrations/github-actions-vclusters-pull-request-manual.mdx
@@ -20,7 +20,7 @@ jobs:
         run: vcluster login $LOFT_URL --access-key $ACCESS_KEY
       - name: Create PR Virtual Cluster
         env:
-          NAME: pr-${{ github.event.pull_request.number }}
+          NAME: repo-${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}
         run: vcluster create $NAME --project default
       - name: Deploy Application
         run: kubectl apply -Rf ./kubernetes
@@ -30,7 +30,7 @@ jobs:
         run: make e2e
       - name: Delete PR Virtual Cluster
         env:
-          NAME: pr-${{ github.event.pull_request.number }}
+          NAME: repo-${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}
         run: vcluster delete $NAME --project default
 ```
 

--- a/vcluster/_partials/integrations/github-actions-vclusters-pull-request-use.mdx
+++ b/vcluster/_partials/integrations/github-actions-vclusters-pull-request-use.mdx
@@ -20,7 +20,7 @@ jobs:
         run: vcluster login $LOFT_URL --access-key $ACCESS_KEY
       - name: Create PR Virtual Cluster
         env:
-          NAME: pr-${{ github.event.pull_request.number }}
+          NAME: repo-${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}
         run: vcluster create $NAME --project default --upgrade
       - name: Deploy Application
         run: kubectl apply -Rf ./kubernetes


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Currently the context is too long and it creates something that breaks the action. Having just the pr is good enough for demo and to work smoothly so this PR fixes that by removing the not required context. Eg: https://github.com/hrittikhere/vcluster-ghaction/actions/runs/13263668222/job/37025746913

![image](https://github.com/user-attachments/assets/b0ce449b-c448-40fe-886c-99c72d7dafd5)


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

