### PR TITLE
feature: adjust netlify redirects to latest

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,52 +10,36 @@ command = """
   """
 
 [[redirects]]
-  from = "/docs/advanced-topics/*"
-  to = "https://www.vcluster.com/docs/v0.19/advanced-topics/:splat"
-
-[[redirects]]
   from = "/docs/architecture/*"
-  to = "/docs/vcluster/architecture/"
+  to = "/docs/vcluster/introduction/architecture/"
 
 [[redirects]]
   from = "/docs/cli/*"
-  to = "https://www.vcluster.com/docs/v0.19/cli/:splat"
+  to = "https://www.vcluster.com/docs/vcluster/cli/:splat"
 
 [[redirects]]
   from = "/docs/deploying-vclusters/*"
-  to = "https://www.vcluster.com/docs/v0.19/deploying-vclusters/:splat"
+  to = "https://www.vcluster.com/docs/vcluster/deploy/:splat"
 
 [[redirects]]
   from = "/docs/getting-started/*"
-  to = "/docs/get-started/"
-
-[[redirects]]
-  from = "/docs/licenses/vcluster"
-  to = "https://www.vcluster.com/docs/v0.19/licenses/vcluster"
+  to = "/docs/vcluster/"
 
 [[redirects]]
   from = "/docs/networking/*"
-  to = "https://www.vcluster.com/docs/v0.19/networking/:splat"
-
-[[redirects]]
-  from = "/docs/o11y/*"
-  to = "https://www.vcluster.com/docs/v0.19/o11y/:splat"
+  to = "https://www.vcluster.com/docs/vcluster/configure/vcluster-yaml/networking/:splat"
 
 [[redirects]]
   from = "/docs/security/*"
-  to = "https://www.vcluster.com/docs/v0.19/security/:splat"
+  to = "https://www.vcluster.com/docs/platform/understand/what-are-virtual-clusters#robust-security-and-isolation"
 
 [[redirects]]
   from = "/docs/syncer/*"
-  to = "https://www.vcluster.com/docs/v0.19/syncer/:splat"
-
-[[redirects]]
-  from = "/docs/use-cases/*"
-  to = "https://www.vcluster.com/docs/v0.19/use-cases/o11y/:splat"
+  to = "https://www.vcluster.com/docs/vcluster/0.20.0/introduction/architecture#syncer"
 
 [[redirects]]
   from = "/docs/using-vclusters/*"
-  to = "https://www.vcluster.com/docs/v0.19/using-vclusters/:splat"
+  to = "https://www.vcluster.com/docs/vcluster/introduction/what-are-virtual-clusters#common-use-cases"
 
 [[redirects]]
   from = "/docs/config-reference/"
@@ -63,12 +47,12 @@ command = """
 
 [[redirects]]
   from = "/docs/storage/"
-  to = "https://www.vcluster.com/docs/v0.19/storage/"
+  to = "https://www.vcluster.com/docs/vcluster/category/storage"
 
 [[redirects]]
   from = "/docs/what-are-virtual-clusters/"
-  to = "/docs/"
+  to = "https://www.vcluster.com/docs/vcluster/introduction/what-are-virtual-clusters"
 
 [[redirects]]
   from = "/docs/help&tutorials/*"
-  to = "https://www.vcluster.com/docs/v0.19/help&tutorials/:splat"
+  to = "https://www.vcluster.com/docs/vcluster/"


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
When users type part of url in the url search bar, the old settings would redirect them to the `v0.19` docs. Changing the redirects to use only recent version of the docs and removing redirects that are no longer there.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[What are virtual clusters?](https://deploy-preview-453--vcluster-docs-site.netlify.app/docs/)

### Note on testing
Try to type in the url search bar one of the redirects and see if it resolves to url correctly


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-415
References DOC-419

