### PR TITLE
fix(platform): clarify hostcluster add

### DIFF
--- a/platform/administer/clusters/connect-cluster.mdx
+++ b/platform/administer/clusters/connect-cluster.mdx
@@ -14,8 +14,10 @@ import PartialClusterConnectHelm from '../../_partials/cluster/connect-helm.mdx'
 import BeforeSvg from '@site/static/media/agent/egress-only-before.excalidraw.svg';
 import AfterSvg from '@site/static/media/agent/egress-only-after.excalidraw.svg';
 import EnrollmentSvg from '@site/static/media/agent/egress-only-enrollment.excalidraw.svg';
+import ConnectPlatform from '../../_fragments/cli-steps/connect-platform.mdx';
 
-A new cluster can be connected to vCluster Platform through the UI or CLI:
+
+A new cluster can be connected to the platform through the UI or CLI:
 
 <Tabs
   defaultValue="ui"
@@ -26,9 +28,30 @@ A new cluster can be connected to vCluster Platform through the UI or CLI:
   ]}>
   <TabItem value="ui">
     <PartialClusterConnectUI />
+        :::tip Connect a cluster
+UI will generate a CLI command that can be used to connect the cluster. Make
+sure to check the `CLI` tab for working with the command.
+:::
+
+
   </TabItem>
   <TabItem value="cli">
     <PartialClusterConnectCLI />
+
+
+  :::info platform login
+    <ConnectPlatform />
+
+  If your kubectl context is not set to the cluster with running platform, it's
+  possible to login to the platform using the CLI and access key.
+  If you haven't already, you need to [create access key](/platform/api/authentication#create-access-key) to be able to login to the platform.
+
+  ```bash title="Login to the platform using access key"
+  vcluster platform login [platform-url] --access-key [access-key]
+  ```
+
+  :::
+
   </TabItem>
   <TabItem value="helm">
     <PartialClusterConnectHelm />
@@ -42,8 +65,8 @@ and establish a secure WireGuard-based, user-space tunnel.
 
 <EnrollmentSvg width="100%"/>
 
-If the agent cannot establish a direct WireGuard-based connection, the agents will
-fallback to utilising the control plane as a Designated Encrypted Relay for Packets.
+If the agent cannot establish a direct WireGuard-based connection, the agents
+falls back to utilising the control plane as a Designated Encrypted Relay for Packets.
 The control plane relay is comparable to the same role as TURN servers in the ICE
 standard, using HTTPS streams (or WebSockets) and WireGuards keys instead.
 

--- a/platform/use-platform/virtual-clusters/add-virtual-clusters.mdx
+++ b/platform/use-platform/virtual-clusters/add-virtual-clusters.mdx
@@ -16,7 +16,7 @@ import FragmentVirtualClustersSelect from '../../_fragments/ui-steps/virtual-clu
 import FragmentConnectPlatform from '../../_fragments/cli-steps/connect-platform.mdx'
 import FragmentPlatformAddCluster from '../../_fragments/cli-steps/platform-add-cluster.mdx'
 
-Any running virtual cluster can be added to the platform. When adding a virtual cluster to the platform, the virtual cluster must be added to a designated project and when the virtual 
+Any running virtual cluster can be added to the platform. When adding a virtual cluster to the platform, the virtual cluster must be added to a designated project and when the virtual
 cluster is added to the platform, a `VirtualClusterInstance` resource is created in the platform.
 
 
@@ -25,11 +25,11 @@ cluster is added to the platform, a `VirtualClusterInstance` resource is created
         <FragmentConnectPlatform />
       </Step>
       <Step>
-        **Add Host Cluster to the Platform (Optional)**: If you want to add the host cluster to the platform, then 
-        run this command. Before running this command, be sure that your kubecontext is set to the 
+        **Add Host Cluster to the Platform (Optional)**: If you want to add the host cluster to the platform, then
+        run this command. Before running this command, be sure that your kubecontext is set to the
         host cluster.
-        
-        
+
+
         ```bash title="Connect host cluster to platform."
         CLUSTER_ID=my-host-cluster
         UI_CLUSTER_NAME="My Host Cluster"
@@ -37,8 +37,8 @@ cluster is added to the platform, a `VirtualClusterInstance` resource is created
         ```
 
       </Step>
-      <Step> 
-      **Adding Virtual Cluster to the Platform**: Before running this command, be sure that your kubecontext is set to the 
+      <Step>
+      **Adding Virtual Cluster to the Platform**: Before running this command, be sure that your kubecontext is set to the
             host cluster running the vcluster that you want to add.
 
         ```bash title="Add vcluster to the platform in a project."


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Adds more context to adding host clusters to a platform instance.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Connect a Cluster](https://deploy-preview-454--vcluster-docs-site.netlify.app/docs/platform/administer/clusters/connect-cluster?x0=1)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-423

