### PR TITLE
Adds basic example at top of native sleep mode docs

### DIFF
--- a/vcluster/configure/vcluster-yaml/experimental/native-sleep-mode.mdx
+++ b/vcluster/configure/vcluster-yaml/experimental/native-sleep-mode.mdx
@@ -22,6 +22,19 @@ caveats and should not be enabled on virtual clusters that are using the current
 [external.platform](../external/platform).
 :::
 
+Not all workloads need to run all the time, and scaling them down saves time and money. With vCluster-native sleep mode you can scale down workloads based on a set schedule, or activity from users and ingress. 
+
+## Enable native sleep mode
+
+To enable vCluster-native sleep mode, use the following configuration inside your `vcluster.yaml`:
+
+```yaml title="native sleep mode configuration"
+experimental:
+  sleepMode:
+    enabled: true
+    autoSleep:
+      afterInactivity: 1h
+```
 
 ## How it works
 

--- a/vcluster_versioned_docs/version-0.22.0/configure/vcluster-yaml/experimental/native-sleep-mode.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/configure/vcluster-yaml/experimental/native-sleep-mode.mdx
@@ -22,6 +22,19 @@ caveats and should not be enabled on virtual clusters that are using the current
 [external.platform](../external/platform).
 :::
 
+Not all workloads need to run all the time, and scaling them down saves time and money. With vCluster-native sleep mode you can scale down workloads based on a set schedule, or activity from users and ingress.
+
+## Enable native sleep mode
+
+To enable vCluster-native sleep mode, use the following configuration inside your `vcluster.yaml`:
+
+```yaml title="native sleep mode configuration"
+experimental:
+  sleepMode:
+    enabled: true
+    autoSleep:
+      afterInactivity: 1h
+```
 
 ## How it works
 


### PR DESCRIPTION
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Adds example so native sleep mode docs look more like the Kube Virt integration page

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
None