### PR TITLE
From host sync docs with examples

### DIFF
--- a/hack/vcluster/partials/main.go
+++ b/hack/vcluster/partials/main.go
@@ -41,6 +41,8 @@ var paths = []string{
 	"sync/fromHost/csiStorageCapacities",
 	"sync/fromHost/csiNodes",
 	"sync/fromHost/csiDrivers",
+	"sync/fromHost/configMaps",
+	"sync/fromHost/secrets",
 	"sync/fromHost",
 	"sync",
 	"rbac",

--- a/vcluster/_fragments/sync-from-host-configmap-example.mdx
+++ b/vcluster/_fragments/sync-from-host-configmap-example.mdx
@@ -4,7 +4,7 @@ import Flow, { Step } from "@site/src/components/Flow";
 
 
 
-## From Host ConfigMap Sync Example
+## From host config map sync example
 
 This guide shows how to sync k8s config map from host and use it in your workload inside the virtual cluster.
 
@@ -85,7 +85,7 @@ guide](/vcluster/#deploy-vcluster).
   #### Ensure that config map got synced to the vCluster
 
   Your config map should be now accessible in the virtual cluster.
-  Keep in mind, that any edit made in the virtual object is overwritten my the host object data.
+  Keep in mind, that any edit made in the virtual object is overwritten by the host object data.
 
   <Step>
     Check config map in the virtual cluster:

--- a/vcluster/_fragments/sync-from-host-configmap-example.mdx
+++ b/vcluster/_fragments/sync-from-host-configmap-example.mdx
@@ -6,7 +6,7 @@ import Flow, { Step } from "@site/src/components/Flow";
 
 ## From host config map sync example
 
-This guide shows how to sync k8s config map from host and use it in your workload inside the virtual cluster.
+This guide shows how to sync Kubernetes config maps from host clusters and how you can use them in your workload running inside virtual clusters.
 
 ### Prerequisites
 
@@ -181,9 +181,9 @@ guide](/vcluster/#deploy-vcluster).
   <Step>
     #### Summary
 
-    From host config map syncing allow you to make specific config map(s) from host accessible in your vCluster. You can make them accessible in the different namespaces and/or with different names in the virtual cluster.
+    From host config map syncing allow you to make specific config map(s) from host clusters accessible inside your virtual clusters. You can make them accessible from different namespaces and/or with different names in the virtual cluster.
     They are always synced from host to the virtual, so it is also possible to sync one host config map to the multiple virtual ones.
-    They can be used as a volume or env source in your workloads.
+    They can also be used as a volume or env source in your workloads.
 
   </Step>
 </Flow>

--- a/vcluster/_fragments/sync-from-host-configmap-example.mdx
+++ b/vcluster/_fragments/sync-from-host-configmap-example.mdx
@@ -8,23 +8,19 @@ import Flow, { Step } from "@site/src/components/Flow";
 
 This guide shows how to sync Kubernetes config maps from host clusters and how you can use them in your workload running inside virtual clusters.
 
-### Prerequisites
-
-- kubectl with access to the host cluster and virtual cluster.
-
 ### Set up cluster contexts
 
 Setting up the host and virtual cluster contexts makes it easier to switch
 between them.
 
-```bash
+```bash title="set up kubectl contexts"
 export HOST_CTX="your-host-context"
 export VCLUSTER_CTX="vcluster-ctx"
 ```
 
-then, create `foobar2` namespace in your host cluster:
+then, create a namespace in your host cluster, use `foobar2` as an example:
 
-```bash
+```bash title="create namespace"
 kubectl --context="${HOST_CTX}" create namespace foobar2
 ```
 
@@ -58,7 +54,7 @@ Create or update a `virtual Cluster` following the [vCluster quick start
 guide](/vcluster/#deploy-vcluster).
 :::
 
-### Sync ConfigMap to virtual and use it in pod
+### Sync ConfigMap to virtual cluster and use it in pod
 
 <Flow id="config-maps-from-host-example">
   <Step>
@@ -82,7 +78,7 @@ guide](/vcluster/#deploy-vcluster).
     ```
   </Step>
 
-  #### Ensure that ConfigMap got synced to the vCluster
+  #### Ensure that ConfigMap got synced to the virtual cluster
 
   Your ConfigMap should be now accessible in the virtual cluster.
   Keep in mind, that any edit made in the virtual object is overwritten by the host object data.

--- a/vcluster/_fragments/sync-from-host-configmap-example.mdx
+++ b/vcluster/_fragments/sync-from-host-configmap-example.mdx
@@ -33,11 +33,11 @@ You can find your contexts by running `kubectl config get-contexts`
 :::
 
 
-### Enable from host syncing for secret
+### Enable from host syncing for config map
 
-Enable the from host syncing for secrets in your virtual cluster configuration:
+Enable the from host syncing for config maps in your virtual cluster configuration:
 
-```yaml title="Enable from host syncing for a secret"
+```yaml title="Enable from host syncing for a config map"
 sync:
   fromHost:
     configMaps:
@@ -58,7 +58,7 @@ Create or update a `virtual Cluster` following the [vCluster quick start
 guide](/vcluster/#deploy-vcluster).
 :::
 
-### Sync secret to virtual and use it in pod
+### Sync config map to virtual and use it in pod
 
 <Flow id="config-maps-from-host-example">
   <Step>
@@ -166,7 +166,7 @@ guide](/vcluster/#deploy-vcluster).
     ```bash title="Check mounted file"
     kubectl --context="${VCLUSTER_CTX}" exec -it --namespace my-virtual-namespace my-pod -- cat /tmp/config.json
     ```
-    you should see environment successfully injected from the secret:
+    you should see environment successfully injected from the config map:
 
     ```json title="Config from ConfigMap"
     {

--- a/vcluster/_fragments/sync-from-host-configmap-example.mdx
+++ b/vcluster/_fragments/sync-from-host-configmap-example.mdx
@@ -33,11 +33,11 @@ You can find your contexts by running `kubectl config get-contexts`
 :::
 
 
-### Enable from host syncing for config map
+### Enable from host syncing for ConfigMap
 
-Enable the from host syncing for config maps in your virtual cluster configuration:
+Enable the from host syncing for ConfigMap in your virtual cluster configuration:
 
-```yaml title="Enable from host syncing for a config map"
+```yaml title="Enable from host syncing for a ConfigMap"
 sync:
   fromHost:
     configMaps:
@@ -49,20 +49,20 @@ sync:
 
 This configuration:
 
-- Enables from host syncing of the config map named `config` in the namespace `foobar2`.
-- Automatically configures RBAC permissions for vCluster, so it can access this config map (you need to re-deploy vCluster for it to take place)
-- Makes this config map accessible as `config` in the `my-namespace` in your vCluster.
+- Enables from host syncing of the ConfigMap named `config` in the namespace `foobar2`.
+- Automatically configures RBAC permissions for vCluster, so it can access this ConfigMap (you need to re-deploy vCluster for it to take place)
+- Makes this ConfigMap accessible as `config` in the `my-namespace` in your vCluster.
 
 :::tip create virtual cluster
 Create or update a `virtual Cluster` following the [vCluster quick start
 guide](/vcluster/#deploy-vcluster).
 :::
 
-### Sync config map to virtual and use it in pod
+### Sync ConfigMap to virtual and use it in pod
 
 <Flow id="config-maps-from-host-example">
   <Step>
-    First, you create a config map that you want to sync in the host cluster:
+    First, you create a ConfigMap that you want to sync in the host cluster:
 
     Copy this file and save it locally as `config.json`
 
@@ -73,30 +73,30 @@ guide](/vcluster/#deploy-vcluster).
     }
     ```
 
-    then, create a config map containing this file in the host cluster:
+    then, create a ConfigMap containing this file in the host cluster:
 
-    ```bash title="Create config map in the host"
+    ```bash title="Create ConfigMap in the host"
     kubectl --context="${HOST_CTX}" create configmap config \
     --namespace=foobar2 \
     --from-file=config.json=config.json
     ```
   </Step>
 
-  #### Ensure that config map got synced to the vCluster
+  #### Ensure that ConfigMap got synced to the vCluster
 
-  Your config map should be now accessible in the virtual cluster.
+  Your ConfigMap should be now accessible in the virtual cluster.
   Keep in mind, that any edit made in the virtual object is overwritten by the host object data.
 
   <Step>
-    Check config map in the virtual cluster:
+    Check ConfigMap in the virtual cluster:
 
-    ```bash title="Get synced config map"
+    ```bash title="Get synced ConfigMap"
     kubectl --context="${VCLUSTER_CTX}" get configmap --namespace my-namespace config -o yaml
     ```
 
     you should see similar output:
 
-    ```yaml title="config map contents"
+    ```yaml title="ConfigMap contents"
     apiVersion: v1
     data:
       config.json: |
@@ -120,7 +120,7 @@ guide](/vcluster/#deploy-vcluster).
 
   <Step>
 
-    Now, your can create a new pod in the `my-namespace` namespace and specify this config map as a volume and mount it in the container.
+    Now, your can create a new pod in the `my-namespace` namespace and specify this ConfigMap as a volume and mount it in the container.
 
     Save this pod locally to the file called `pod.yaml`:
     ```yaml title="pod.yaml"
@@ -166,7 +166,7 @@ guide](/vcluster/#deploy-vcluster).
     ```bash title="Check mounted file"
     kubectl --context="${VCLUSTER_CTX}" exec -it --namespace my-virtual-namespace my-pod -- cat /tmp/config.json
     ```
-    you should see environment successfully injected from the config map:
+    you should see environment successfully injected from the ConfigMap:
 
     ```json title="Config from ConfigMap"
     {
@@ -181,8 +181,8 @@ guide](/vcluster/#deploy-vcluster).
   <Step>
     #### Summary
 
-    From host config map syncing allow you to make specific config map(s) from host clusters accessible inside your virtual clusters. You can make them accessible from different namespaces and/or with different names in the virtual cluster.
-    They are always synced from host to the virtual, so it is also possible to sync one host config map to the multiple virtual ones.
+    From host ConfigMap syncing allow you to make specific ConfigMap(s) from host clusters accessible inside your virtual clusters. You can make them accessible from different namespaces and/or with different names in the virtual cluster.
+    They are always synced from host to the virtual, so it is also possible to sync one host ConfigMap to the multiple virtual ones.
     They can also be used as a volume or env source in your workloads.
 
   </Step>

--- a/vcluster/_fragments/sync-from-host-configmap-example.mdx
+++ b/vcluster/_fragments/sync-from-host-configmap-example.mdx
@@ -1,0 +1,189 @@
+import Highlight from "@site/src/components/Highlight/Highlight";
+
+import Flow, { Step } from "@site/src/components/Flow";
+
+
+
+## From Host ConfigMap Sync Example
+
+This guide shows how to sync k8s config map from host and use it in your workload inside the virtual cluster.
+
+### Prerequisites
+
+- kubectl with access to the host cluster and virtual cluster.
+
+### Set up cluster contexts
+
+Setting up the host and virtual cluster contexts makes it easier to switch
+between them.
+
+```bash
+export HOST_CTX="your-host-context"
+export VCLUSTER_CTX="vcluster-ctx"
+```
+
+then, create `foobar2` namespace in your host cluster:
+
+```bash
+kubectl --context="${HOST_CTX}" create namespace foobar2
+```
+
+:::tip
+You can find your contexts by running `kubectl config get-contexts`
+:::
+
+
+### Enable from host syncing for secret
+
+Enable the from host syncing for secrets in your virtual cluster configuration:
+
+```yaml title="Enable from host syncing for a secret"
+sync:
+  fromHost:
+    configMaps:
+      enabled: true
+      selector:
+        mappings:
+          "foobar2/config": "my-namespace/config"
+```
+
+This configuration:
+
+- Enables from host syncing of the config map named `config` in the namespace `foobar2`.
+- Automatically configures RBAC permissions for vCluster, so it can access this config map (you need to re-deploy vCluster for it to take place)
+- Makes this config map accessible as `config` in the `my-namespace` in your vCluster.
+
+:::tip create virtual cluster
+Create or update a `virtual Cluster` following the [vCluster quick start
+guide](/vcluster/#deploy-vcluster).
+:::
+
+### Sync secret to virtual and use it in pod
+
+<Flow id="config-maps-from-host-example">
+  <Step>
+    First, we will need to create a config map that we want to sync in the host cluster:
+
+    Copy this file and save it locally as `config.json`
+
+    ```json title=config.json
+    {
+      "name": "my-config",
+      "hosts": ["123.456.789", "987.654.321"]
+    }
+    ```
+
+    then, let's create a config map containing this file in the host cluster:
+
+    ```bash title="Create config map in the host"
+    kubectl --context="${HOST_CTX}" create configmap config \
+    --namespace=foobar2 \
+    --from-file=config.json=config.json
+    ```
+  </Step>
+
+  #### Ensure that config map got synced to the vCluster
+
+  Our config map should be now accessible in the virtual cluster.
+  Keep in mind, that any edit made in the virtual object will be overwritten my the host object data.
+
+  <Step>
+    Let's check config map in the virtual cluster:
+
+    ```bash title="Get synced config map"
+    kubectl --context="${VCLUSTER_CTX}" get configmap --namespace my-namespace config -o yaml
+    ```
+
+    you should see similar output:
+
+    ```yaml title="config map contents"
+    apiVersion: v1
+    data:
+      config.json: |
+        {
+          "name": "my-config",
+          "hosts": ["123.456.789", "987.654.321"]
+        }
+    kind: ConfigMap
+    metadata:
+      creationTimestamp: "2025-02-17T12:43:17Z"
+      name: config
+      namespace: my-namespace
+      resourceVersion: "18279"
+      uid: bb131bf9-8fed-4d34-904c-1f83ed05aa72
+    ```
+
+
+  </Step>
+
+  #### Use it in your workload
+
+  <Step>
+
+    Now, we can create a new pod in the `my-namespace` namespace and specify this config map as a volume and mount it in the container.
+
+    Save this pod locally to the file called `pod.yaml`:
+    ```yaml title="pod.yaml"
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: my-pod
+      namespace: my-virtual-namespace
+    spec:
+      containers:
+      - name: busybox
+        image: busybox
+        command:
+        - sleep
+        - "inf"
+        volumeMounts:
+        - name: my-config
+          mountPath: /tmp/
+      volumes:
+      - name: my-config
+        configMap:
+          name: config
+    ```
+
+    then, create it in the virtual cluster:
+
+    ```bash title="Create pod"
+    kubectl --context="${VCLUSTER_CTX}" create -f pod.yaml
+    ```
+
+  </Step>
+  <Step>
+    #### Verify that config is mounted
+
+    <Highlight color="green">Virtual Cluster</Highlight> Wait for pod running
+
+    ```bash title="Wait for pod running"
+    kubectl --context="${VCLUSTER_CTX}" wait --for=condition=ready pod my-pod --namespace my-virtual-namespace --timeout=300s
+    ```
+
+    once it is running, we can check if our file is accessible in the container under `/tmp/config.json` path.
+
+    ```bash title="Check mounted file"
+    kubectl --context="${VCLUSTER_CTX}" exec -it --namespace my-virtual-namespace my-pod -- cat /tmp/config.json
+    ```
+    you should see environment successfully injected from the secret:
+
+    ```json title="Config from ConfigMap"
+    {
+      "name": "my-config",
+      "hosts": ["123.456.789", "987.654.321"]
+    }
+
+    ```
+
+  </Step>
+
+  <Step>
+    #### Summary
+
+    From host config map syncing allow you to make specific config map(s) from host accessible in your vCluster. You can make them accessible in the different namespaces and/or with different names in the virtual cluster.
+    They are always synced from host to the virtual, so it is also possible to sync one host config map to the multiple virtual ones.
+    They can be used as a volume or env source in your workloads.
+
+  </Step>
+</Flow>

--- a/vcluster/_fragments/sync-from-host-configmap-example.mdx
+++ b/vcluster/_fragments/sync-from-host-configmap-example.mdx
@@ -148,9 +148,8 @@ guide](/vcluster/#deploy-vcluster).
     ```
 
   </Step>
+  #### Verify that config is mounted
   <Step>
-    #### Verify that config is mounted
-
     <Highlight color="green">Virtual Cluster</Highlight> Wait for pod running
 
     ```bash title="Wait for pod running"
@@ -174,8 +173,9 @@ guide](/vcluster/#deploy-vcluster).
 
   </Step>
 
+  #### Summary
   <Step>
-    #### Summary
+
 
     From host ConfigMap syncing allow you to make specific ConfigMap(s) from host clusters accessible inside your virtual clusters. You can make them accessible from different namespaces and/or with different names in the virtual cluster.
     They are always synced from host to the virtual, so it is also possible to sync one host ConfigMap to the multiple virtual ones.

--- a/vcluster/_fragments/sync-from-host-configmap-example.mdx
+++ b/vcluster/_fragments/sync-from-host-configmap-example.mdx
@@ -62,7 +62,7 @@ guide](/vcluster/#deploy-vcluster).
 
 <Flow id="config-maps-from-host-example">
   <Step>
-    First, we will need to create a config map that we want to sync in the host cluster:
+    First, you create a config map that you want to sync in the host cluster:
 
     Copy this file and save it locally as `config.json`
 
@@ -73,7 +73,7 @@ guide](/vcluster/#deploy-vcluster).
     }
     ```
 
-    then, let's create a config map containing this file in the host cluster:
+    then, create a config map containing this file in the host cluster:
 
     ```bash title="Create config map in the host"
     kubectl --context="${HOST_CTX}" create configmap config \
@@ -84,11 +84,11 @@ guide](/vcluster/#deploy-vcluster).
 
   #### Ensure that config map got synced to the vCluster
 
-  Our config map should be now accessible in the virtual cluster.
-  Keep in mind, that any edit made in the virtual object will be overwritten my the host object data.
+  Your config map should be now accessible in the virtual cluster.
+  Keep in mind, that any edit made in the virtual object is overwritten my the host object data.
 
   <Step>
-    Let's check config map in the virtual cluster:
+    Check config map in the virtual cluster:
 
     ```bash title="Get synced config map"
     kubectl --context="${VCLUSTER_CTX}" get configmap --namespace my-namespace config -o yaml
@@ -120,7 +120,7 @@ guide](/vcluster/#deploy-vcluster).
 
   <Step>
 
-    Now, we can create a new pod in the `my-namespace` namespace and specify this config map as a volume and mount it in the container.
+    Now, your can create a new pod in the `my-namespace` namespace and specify this config map as a volume and mount it in the container.
 
     Save this pod locally to the file called `pod.yaml`:
     ```yaml title="pod.yaml"
@@ -161,7 +161,7 @@ guide](/vcluster/#deploy-vcluster).
     kubectl --context="${VCLUSTER_CTX}" wait --for=condition=ready pod my-pod --namespace my-virtual-namespace --timeout=300s
     ```
 
-    once it is running, we can check if our file is accessible in the container under `/tmp/config.json` path.
+    once it is running, you can check if your file is accessible in the container under `/tmp/config.json` path.
 
     ```bash title="Check mounted file"
     kubectl --context="${VCLUSTER_CTX}" exec -it --namespace my-virtual-namespace my-pod -- cat /tmp/config.json

--- a/vcluster/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
+++ b/vcluster/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
@@ -9,23 +9,19 @@ import Flow, { Step } from "@site/src/components/Flow";
 This guide shows how to sync k8s namespaced CustomResources from host cluster.
 Example CRD is used in this guide.
 
-### Prerequisites
-
-- kubectl with access to the host cluster and virtual cluster.
-
 ### Set up cluster contexts
 
 Setting up the host and virtual cluster contexts makes it easier to switch
 between them.
 
-```bash
+```bash title="set up kubectl contexts"
 export HOST_CTX="your-host-context"
 export VCLUSTER_CTX="vcluster-ctx"
 ```
 
-then, create `foobar2` namespace in your host cluster:
+then, create a namespace in your host cluster, use `foobar2` as an example:
 
-```bash
+```bash title="create namespace"
 kubectl --context="${HOST_CTX}" create namespace foobar2
 ```
 
@@ -109,7 +105,7 @@ Create or update a `virtual Cluster` following the [vCluster quick start
 guide](/vcluster/#deploy-vcluster).
 :::
 
-### Sync namespaced CustomResource to vCluster
+### Sync namespaced CustomResource to virtual cluster
 
 <Flow id="namespaced-custom-resources-from-host-example">
   <Step>
@@ -135,7 +131,7 @@ guide](/vcluster/#deploy-vcluster).
     ```
   </Step>
 
-  #### Ensure that CustomResource got synced to vCluster
+  #### Ensure that CustomResource got synced to the virtual cluster
 
   Your CustomResource should be now accessible in the virtual cluster.
   Keep in mind, that any edit made in the virtual object is overwritten by the host object data.

--- a/vcluster/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
+++ b/vcluster/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
@@ -1,0 +1,189 @@
+import Highlight from "@site/src/components/Highlight/Highlight";
+
+import Flow, { Step } from "@site/src/components/Flow";
+
+
+
+## From Host Namespaced Custom Resources Example
+
+This guide shows how to sync k8s namespaced custom resources from host cluster.
+We will use Example CRD in our example.
+
+### Prerequisites
+
+- kubectl with access to the host cluster and virtual cluster.
+
+### Set up cluster contexts
+
+Setting up the host and virtual cluster contexts makes it easier to switch
+between them.
+
+```bash
+export HOST_CTX="your-host-context"
+export VCLUSTER_CTX="vcluster-ctx"
+```
+
+then, create `foobar2` namespace in your host cluster:
+
+```bash
+kubectl --context="${HOST_CTX}" create namespace foobar2
+```
+
+:::tip
+You can find your contexts by running `kubectl config get-contexts`
+:::
+
+
+### Create Custom Resource Definition in the host
+
+We will use following Custom Resource Definition in our example:
+
+```yaml title="example-crd.yaml"
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: examples.demo.loft.sh
+spec:
+  group: demo.loft.sh
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                image:
+                  type: string
+                replicas:
+                  type: integer
+      additionalPrinterColumns:
+      - name: Image
+        type: string
+        description: The image of an example
+        jsonPath: .spec.image
+      - name: Replicas
+        type: integer
+        description: The number of replicas in example
+        jsonPath: .spec.replicas
+  scope: Namespaced
+  names:
+    plural: examples
+    singular: example
+    kind: Example
+```
+
+save this file locally and then apply it in the host cluster:
+
+```bash title="Create Example CRD in the host"
+kubectl --context="${HOST_CTX}" create -f example-crd.yaml
+```
+
+### Enable from host syncing for Example CR
+
+Enable the from host syncing for examples custom resources in your virtual cluster configuration:
+
+```yaml title="Enable from host syncing for custom resource"
+sync:
+  fromHost:
+    customResources:
+      examples.demo.loft.sh:
+        enabled: true
+        scope: Namespaced
+        selector:
+          mappings:
+            "": "default"
+```
+
+This configuration:
+
+- Enables from host syncing of the examples.demo.loft.sh from the vCluster's host namespace
+- Automatically configures RBAC permissions for vCluster, so it can get, watch and list Examples in vCluster's host namespace.
+- Syncs all `Examples` from vCluster host namespace to the `default` namespace in your vCluster.
+
+:::tip create virtual cluster
+Create or update a `virtual Cluster` following the [vCluster quick start
+guide](/vcluster/#deploy-vcluster).
+:::
+
+### Sync namespaced custom resource to vCluster
+
+<Flow id="namespaced-custom-resources-from-host-example">
+  <Step>
+    First, we will need to create an example that we want to sync in the host cluster:
+
+    Copy this file and save it locally as `example-cr.yaml`
+
+    ```yaml title=example-cr.yaml
+    apiVersion: demo.loft.sh/v1
+    kind: Example
+    metadata:
+      name: my-example
+      namespace: vcluster
+    spec:
+      image: "my-image:latest"
+      replicas: 2
+    ```
+
+    then, let's create an example in the host cluster:
+
+    ```bash title="Create example in the host"
+    kubectl --context="${HOST_CTX}" create -f example-cr.yaml
+    ```
+  </Step>
+
+  #### Ensure that custom resource got synced to vCluster
+
+  Our custom resource should be now accessible in the virtual cluster.
+  Keep in mind, that any edit made in the virtual object will be overwritten my the host object data.
+
+  <Step>
+    Let's check custom resource in the virtual cluster:
+
+    ```bash title="Get synced custom resource"
+    kubectl --context="${VCLUSTER_CTX}" et examples.demo.loft.sh --namespace default
+    ```
+
+    you should see similar output:
+
+    ```bash title="examples in vCluster"
+    NAME         IMAGE             REPLICAS
+    my-example   my-image:latest   2
+    ```
+
+
+  </Step>
+
+  #### Edit custom resource in the host
+
+  <Step>
+
+    Now, we can edit our example in the host and see that the change is synced to the vCluster.
+    We will set replicas to 4:
+
+    ```bash title="Patch Example CR"
+    kubectl --context="${HOST_CTX}" patch examples.demo.loft.sh my-example --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value": 4}]'  --namespace vcluster
+    ```
+
+  </Step>
+  <Step>
+    #### Verify that Example is updated in vCluster
+
+    <Highlight color="green">Virtual Cluster</Highlight> Check number of replicas
+
+    ```bash title="Check example"
+    kubectl --context="${VCLUSTER_CTX}" get --namespace default examples.demo.loft.sh
+    ```
+    you should see number of replicas updated from host object:
+
+    ```bash title="Example updated in vCluster"
+    NAME         IMAGE             REPLICAS
+    my-example   my-image:latest   4
+    ```
+
+  </Step>
+
+</Flow>

--- a/vcluster/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
+++ b/vcluster/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
@@ -165,9 +165,9 @@ guide](/vcluster/#deploy-vcluster).
     ```
 
   </Step>
-  <Step>
-    #### Verify that Example is updated in vCluster
 
+  #### Verify that Example is updated in vCluster
+  <Step>
     <Highlight color="green">Virtual Cluster</Highlight> Check number of replicas
 
     ```bash title="Check example"

--- a/vcluster/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
+++ b/vcluster/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
@@ -7,7 +7,7 @@ import Flow, { Step } from "@site/src/components/Flow";
 ## From Host Namespaced Custom Resources Example
 
 This guide shows how to sync k8s namespaced custom resources from host cluster.
-We will use Example CRD in our example.
+Example CRD is used in this guide.
 
 ### Prerequisites
 
@@ -36,7 +36,7 @@ You can find your contexts by running `kubectl config get-contexts`
 
 ### Create Custom Resource Definition in the host
 
-We will use following Custom Resource Definition in our example:
+Saved following Custom Resource Definition:
 
 ```yaml title="example-crd.yaml"
 apiVersion: apiextensions.k8s.io/v1
@@ -113,7 +113,7 @@ guide](/vcluster/#deploy-vcluster).
 
 <Flow id="namespaced-custom-resources-from-host-example">
   <Step>
-    First, we will need to create an example that we want to sync in the host cluster:
+    First, you create an example that you want to sync in the host cluster:
 
     Copy this file and save it locally as `example-cr.yaml`
 
@@ -128,7 +128,7 @@ guide](/vcluster/#deploy-vcluster).
       replicas: 2
     ```
 
-    then, let's create an example in the host cluster:
+    then, create an example in the host cluster:
 
     ```bash title="Create example in the host"
     kubectl --context="${HOST_CTX}" create -f example-cr.yaml
@@ -137,11 +137,11 @@ guide](/vcluster/#deploy-vcluster).
 
   #### Ensure that custom resource got synced to vCluster
 
-  Our custom resource should be now accessible in the virtual cluster.
-  Keep in mind, that any edit made in the virtual object will be overwritten my the host object data.
+  Your custom resource should be now accessible in the virtual cluster.
+  Keep in mind, that any edit made in the virtual object is overwritten my the host object data.
 
   <Step>
-    Let's check custom resource in the virtual cluster:
+    Check custom resource in the virtual cluster:
 
     ```bash title="Get synced custom resource"
     kubectl --context="${VCLUSTER_CTX}" et examples.demo.loft.sh --namespace default
@@ -161,8 +161,8 @@ guide](/vcluster/#deploy-vcluster).
 
   <Step>
 
-    Now, we can edit our example in the host and see that the change is synced to the vCluster.
-    We will set replicas to 4:
+    Now, you can edit your example in the host and see that the change is synced to the vCluster.
+    To set replicas to 4, run:
 
     ```bash title="Patch Example CR"
     kubectl --context="${HOST_CTX}" patch examples.demo.loft.sh my-example --type='json' -p='[{"op": "replace", "path": "/spec/replicas", "value": 4}]'  --namespace vcluster

--- a/vcluster/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
+++ b/vcluster/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
@@ -4,9 +4,9 @@ import Flow, { Step } from "@site/src/components/Flow";
 
 
 
-## From host namespaced custom resource example
+## From host namespaced CustomResource example
 
-This guide shows how to sync k8s namespaced custom resources from host cluster.
+This guide shows how to sync k8s namespaced CustomResources from host cluster.
 Example CRD is used in this guide.
 
 ### Prerequisites
@@ -34,7 +34,7 @@ You can find your contexts by running `kubectl config get-contexts`
 :::
 
 
-### Create custom resource definition in the host
+### Create CustomResourceDefinition in the host
 
 Saved following Custom Resource Definition:
 
@@ -82,11 +82,11 @@ save this file locally and then apply it in the host cluster:
 kubectl --context="${HOST_CTX}" create -f example-crd.yaml
 ```
 
-### Enable from host syncing for your custom resource
+### Enable from host syncing for your CustomResource
 
-Enable the from host syncing for examples custom resources in your virtual cluster configuration:
+Enable the from host syncing for Example CustomResources in your virtual cluster configuration:
 
-```yaml title="Enable from host syncing for custom resource"
+```yaml title="Enable from host syncing for CustomResource"
 sync:
   fromHost:
     customResources:
@@ -109,7 +109,7 @@ Create or update a `virtual Cluster` following the [vCluster quick start
 guide](/vcluster/#deploy-vcluster).
 :::
 
-### Sync namespaced custom resource to vCluster
+### Sync namespaced CustomResource to vCluster
 
 <Flow id="namespaced-custom-resources-from-host-example">
   <Step>
@@ -135,15 +135,15 @@ guide](/vcluster/#deploy-vcluster).
     ```
   </Step>
 
-  #### Ensure that custom resource got synced to vCluster
+  #### Ensure that CustomResource got synced to vCluster
 
-  Your custom resource should be now accessible in the virtual cluster.
+  Your CustomResource should be now accessible in the virtual cluster.
   Keep in mind, that any edit made in the virtual object is overwritten by the host object data.
 
   <Step>
-    Check custom resource in the virtual cluster:
+    Check CustomResource in the virtual cluster:
 
-    ```bash title="Get synced custom resource"
+    ```bash title="Get synced CustomResource"
     kubectl --context="${VCLUSTER_CTX}" et examples.demo.loft.sh --namespace default
     ```
 
@@ -157,7 +157,7 @@ guide](/vcluster/#deploy-vcluster).
 
   </Step>
 
-  #### Edit custom resource in the host
+  #### Edit CustomResource in the host
 
   <Step>
 

--- a/vcluster/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
+++ b/vcluster/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
@@ -4,7 +4,7 @@ import Flow, { Step } from "@site/src/components/Flow";
 
 
 
-## From Host Namespaced Custom Resources Example
+## From host namespaced custom resource example
 
 This guide shows how to sync k8s namespaced custom resources from host cluster.
 Example CRD is used in this guide.
@@ -34,7 +34,7 @@ You can find your contexts by running `kubectl config get-contexts`
 :::
 
 
-### Create Custom Resource Definition in the host
+### Create custom resource definition in the host
 
 Saved following Custom Resource Definition:
 
@@ -82,7 +82,7 @@ save this file locally and then apply it in the host cluster:
 kubectl --context="${HOST_CTX}" create -f example-crd.yaml
 ```
 
-### Enable from host syncing for Example CR
+### Enable from host syncing for your custom resource
 
 Enable the from host syncing for examples custom resources in your virtual cluster configuration:
 
@@ -138,7 +138,7 @@ guide](/vcluster/#deploy-vcluster).
   #### Ensure that custom resource got synced to vCluster
 
   Your custom resource should be now accessible in the virtual cluster.
-  Keep in mind, that any edit made in the virtual object is overwritten my the host object data.
+  Keep in mind, that any edit made in the virtual object is overwritten by the host object data.
 
   <Step>
     Check custom resource in the virtual cluster:

--- a/vcluster/_fragments/sync-from-host-resources.mdx
+++ b/vcluster/_fragments/sync-from-host-resources.mdx
@@ -1,13 +1,13 @@
-vCluster can sync certain resources from the host cluster to make them available inside the virtual cluster, but when these resources are 
-synced, they are only synced in read-only mode. No changes to the resource in the virtual cluster syncs back to the host cluster as the 
+vCluster can sync certain resources from the host cluster to make them available inside the virtual cluster, but when these resources are
+synced, they are only synced in read-only mode. No changes to the resource in the virtual cluster syncs back to the host cluster as the
 resources are shared across the host cluster.
 
-A good example would be nodes, which are nice to view inside the virtual cluster and can be also used to enabled certain features such as [scheduling inside the vCluster](/vcluster/configure/vcluster-yaml/control-plane/other/advanced/virtual-scheduler.mdx), 
-but you wouldn't want your virtual cluster to change the node itself. Another benefit of only syncing from host is that vCluster itself only requires read-only RBAC permissions. 
+A good example would be nodes, which are nice to view inside the virtual cluster and can be also used to enabled certain features such as [scheduling inside the vCluster](/vcluster/configure/vcluster-yaml/control-plane/other/advanced/virtual-scheduler.mdx),
+but you wouldn't want your virtual cluster to change the node itself. Another benefit of only syncing from host is that vCluster itself only requires read-only RBAC permissions.
 
 vCluster also allows to sync custom resources via the [custom resource definitions syncer](../configure/vcluster-yaml/sync/from-host/custom-resources.mdx)
 
-There are a couple of labels that are created on the host cluster by vCluster that never get synced to the virtual cluster resource. These labels are: 
+There are a couple of labels that are created on the host cluster by vCluster that never get synced to the virtual cluster resource. These labels are:
 
 * `release` (Label is needed to avoid conflicts with the vCluster pods themselves). This is only excluded in single-namespace mode as multi-namespace mode does sync all pods into separate namespaces.
 * `vcluster.loft.sh/namespace`
@@ -26,9 +26,11 @@ There are a couple of labels that are created on the host cluster by vCluster th
 * [CSINodes](../configure/vcluster-yaml/sync/from-host/csi-nodes.mdx)
 * [CSIDrivers](../configure/vcluster-yaml/sync/from-host/csi-drivers.mdx)
 * [CSIStorageCapacities](../configure/vcluster-yaml/sync/from-host/csi-storage-capacities.mdx)
+* [ConfigMaps](../configure/vcluster-yaml/sync/from-host/configmaps.mdx)
+* [Secrets](../configure/vcluster-yaml/sync/from-host/secrets.mdx)
 
 ### No bi-directional syncing
 
-Since syncing resources from the host cluster is in read only mode and changes in the virtual cluster do not 
-get applied to the resource in the host cluster, bi-directional syncing does not exist across these resources. 
+Since syncing resources from the host cluster is in read only mode and changes in the virtual cluster do not
+get applied to the resource in the host cluster, bi-directional syncing does not exist across these resources.
 

--- a/vcluster/_fragments/sync-from-host-secret-example.mdx
+++ b/vcluster/_fragments/sync-from-host-secret-example.mdx
@@ -6,9 +6,9 @@ import Flow, { Step } from "@site/src/components/Flow";
 
 
 
-## From host secret sync example
+## From host Secret sync example
 
-This guide shows how to sync Kubernetes secret from host clusters and how you can use them in your workload running inside virtual clusters.
+This guide shows how to sync Kubernetes Secret from host clusters and how you can use them in your workload running inside virtual clusters.
 
 ### Prerequisites
 
@@ -35,11 +35,11 @@ You can find your contexts by running `kubectl config get-contexts`
 :::
 
 
-### Enable from host syncing for secret
+### Enable from host syncing for Secret
 
 Enable the from host syncing for secrets in your virtual cluster configuration:
 
-```yaml title="Enable from host syncing for a secret"
+```yaml title="Enable from host syncing for a Secret"
 sync:
   fromHost:
     secrets:
@@ -51,22 +51,22 @@ sync:
 
 This configuration:
 
-- Enables from host syncing of the secret `shared-user-env` in the namespace `foobar`.
-- Automatically configures RBAC permissions for vCluster, so it can access this secret (you need to re-deploy vCluster for it to take place)
-- Makes this secret accessible as `user-env` in the `my-namespace` in your vCluster.
+- Enables from host syncing of the Secret `shared-user-env` in the namespace `foobar`.
+- Automatically configures RBAC permissions for vCluster, so it can access this Secret (you need to re-deploy vCluster for it to take place)
+- Makes this Secret accessible as `user-env` in the `my-namespace` in your vCluster.
 
 :::tip create virtual cluster
 Create or update a `virtual Cluster` following the [vCluster quick start
 guide](/vcluster/#deploy-vcluster).
 :::
 
-### Sync secret to virtual and use it in pod
+### Sync Secret to virtual and use it in pod
 
 <Flow id="secrets-from-host-example">
   <Step>
-    First, create a secret which you want to sync in the host cluster:
+    First, create a Secret which you want to sync in the host cluster:
 
-    ```bash title="Create secret in the host"
+    ```bash title="Create Secret in the host"
     kubectl --context="${HOST_CTX}" create secret generic shared-user-env \
     --namespace=foobar \
     --from-literal=MY_ENV_1=foo \
@@ -74,21 +74,21 @@ guide](/vcluster/#deploy-vcluster).
     ```
   </Step>
 
-  #### Ensure that secret got synced to the vCluster
+  #### Ensure that Secret got synced to the vCluster
 
-  Your secret should be now accessible in the virtual cluster.
+  Your Secret should be now accessible in the virtual cluster.
   Keep in mind, that any edit made in the virtual object is overwritten by the host object data.
 
   <Step>
-    Check if the secret is accessible in the virtual cluster:
+    Check if the Secret is accessible in the virtual cluster:
 
-    ```bash title="Get synced secret"
+    ```bash title="Get synced Secret"
     kubectl --context="${VCLUSTER_CTX}" get secrets --namespace my-namespace user-env -o yaml
     ```
 
     you should see similar output:
 
-    ```yaml title="secret contents"
+    ```yaml title="Secret contents"
     apiVersion: v1
     data:
       MY_ENV_1: Zm9v
@@ -110,7 +110,7 @@ guide](/vcluster/#deploy-vcluster).
 
   <Step>
 
-    Now, you can create a new pod in the `my-namespace` namespace and specify this secret as a source for environment variables.
+    Now, you can create a new pod in the `my-namespace` namespace and specify this Secret as a source for environment variables.
 
     Save this pod locally to the file called `pod.yaml`:
     ```yaml title="pod.yaml"
@@ -157,9 +157,9 @@ guide](/vcluster/#deploy-vcluster).
     ```bash title="Check environment variables"
     kubectl --context="${VCLUSTER_CTX}" exec -it --namespace my-namespace my-pod -- printenv | grep "MY_ENV"
     ```
-    you should see environment successfully injected from the secret:
+    you should see environment successfully injected from the Secret:
 
-    ```bash title="Environment variables from secret"
+    ```bash title="Environment variables from Secret"
     MY_ENV_1=foo
     MY_ENV_2=bar
     ```
@@ -169,8 +169,8 @@ guide](/vcluster/#deploy-vcluster).
   <Step>
     #### Summary
 
-    From host secret syncing allow you to make specific secret(s) from host clusters accessible inside your virtual clusters. You can make them accessible from different namespaces and/or with different names in the virtual cluster.
-    They are always synced from host to the virtual, so it is also possible to sync one host secret to the multiple virtual ones.
+    From host Secret syncing allow you to make specific Secret(s) from host clusters accessible inside your virtual clusters. You can make them accessible from different namespaces and/or with different names in the virtual cluster.
+    They are always synced from host to the virtual, so it is also possible to sync one host Secret to the multiple virtual ones.
     They can also be used as a volume or env source in your workloads.
 
   </Step>

--- a/vcluster/_fragments/sync-from-host-secret-example.mdx
+++ b/vcluster/_fragments/sync-from-host-secret-example.mdx
@@ -64,7 +64,7 @@ guide](/vcluster/#deploy-vcluster).
 
 <Flow id="secrets-from-host-example">
   <Step>
-    First, we will need to create a secret that we want to sync in the host cluster:
+    First, create a secret which you want to sync in the host cluster:
 
     ```bash title="Create secret in the host"
     kubectl --context="${HOST_CTX}" create secret generic shared-user-env \
@@ -76,11 +76,11 @@ guide](/vcluster/#deploy-vcluster).
 
   #### Ensure that secret got synced to the vCluster
 
-  Our secret should be now accessible in the virtual cluster.
+  Your secret should be now accessible in the virtual cluster.
   Keep in mind, that any edit made in the virtual object will be overwritten my the host object data.
 
   <Step>
-    Let's check if the secret is accessible in the virtual cluster:
+    Check if the secret is accessible in the virtual cluster:
 
     ```bash title="Get synced secret"
     kubectl --context="${VCLUSTER_CTX}" get secrets --namespace my-namespace user-env -o yaml
@@ -110,7 +110,7 @@ guide](/vcluster/#deploy-vcluster).
 
   <Step>
 
-    Now, we can create a new pod in the `my-namespace` namespace and specify this secret as a source for environment variables.
+    Now, you can create a new pod in the `my-namespace` namespace and specify this secret as a source for environment variables.
 
     Save this pod locally to the file called `pod.yaml`:
     ```yaml title="pod.yaml"
@@ -152,7 +152,7 @@ guide](/vcluster/#deploy-vcluster).
     kubectl --context="${VCLUSTER_CTX}" wait --for=condition=ready pod my-pod --namespace my-namespace --timeout=300s
     ```
 
-    once it is running, we can list pod's environment variables:
+    once it is running, you can list pod's environment variables:
 
     ```bash title="Check environment variables"
     kubectl --context="${VCLUSTER_CTX}" exec -it --namespace my-namespace my-pod -- printenv | grep "MY_ENV"

--- a/vcluster/_fragments/sync-from-host-secret-example.mdx
+++ b/vcluster/_fragments/sync-from-host-secret-example.mdx
@@ -10,23 +10,19 @@ import Flow, { Step } from "@site/src/components/Flow";
 
 This guide shows how to sync Kubernetes Secret from host clusters and how you can use them in your workload running inside virtual clusters.
 
-### Prerequisites
-
-- kubectl with access to the host cluster and virtual cluster.
-
 ### Set up cluster contexts
 
 Setting up the host and virtual cluster contexts makes it easier to switch
 between them.
 
-```bash
+```bash title="set up kubectl contexts"
 export HOST_CTX="your-host-context"
 export VCLUSTER_CTX="vcluster-ctx"
 ```
 
-then, create `foobar` namespace in your host cluster:
+then, create a namespace in your host cluster, use `foobar` as an example:
 
-```bash
+```bash title="create namespace"
 kubectl --context="${HOST_CTX}" create namespace foobar
 ```
 
@@ -60,7 +56,7 @@ Create or update a `virtual Cluster` following the [vCluster quick start
 guide](/vcluster/#deploy-vcluster).
 :::
 
-### Sync Secret to virtual and use it in pod
+### Sync Secret to virtual cluster and use it in pod
 
 <Flow id="secrets-from-host-example">
   <Step>
@@ -74,7 +70,7 @@ guide](/vcluster/#deploy-vcluster).
     ```
   </Step>
 
-  #### Ensure that Secret got synced to the vCluster
+  #### Ensure that Secret got synced to the virtual cluster
 
   Your Secret should be now accessible in the virtual cluster.
   Keep in mind, that any edit made in the virtual object is overwritten by the host object data.

--- a/vcluster/_fragments/sync-from-host-secret-example.mdx
+++ b/vcluster/_fragments/sync-from-host-secret-example.mdx
@@ -8,7 +8,7 @@ import Flow, { Step } from "@site/src/components/Flow";
 
 ## From host secret sync example
 
-This guide shows how to sync k8s secret from host and use it in your workload inside the virtual cluster.
+This guide shows how to sync Kubernetes secret from host clusters and how you can use them in your workload running inside virtual clusters.
 
 ### Prerequisites
 
@@ -169,9 +169,9 @@ guide](/vcluster/#deploy-vcluster).
   <Step>
     #### Summary
 
-    From host secret syncing allow you to make specific secret(s) from host accessible in your vCluster. You can make them accessible in the different namespaces and/or with different names in the virtual cluster.
+    From host secret syncing allow you to make specific secret(s) from host clusters accessible inside your virtual clusters. You can make them accessible from different namespaces and/or with different names in the virtual cluster.
     They are always synced from host to the virtual, so it is also possible to sync one host secret to the multiple virtual ones.
-    They can be used as a volume or env source in your workloads.
+    They can also be used as a volume or env source in your workloads.
 
   </Step>
 </Flow>

--- a/vcluster/_fragments/sync-from-host-secret-example.mdx
+++ b/vcluster/_fragments/sync-from-host-secret-example.mdx
@@ -1,0 +1,177 @@
+import Highlight from "@site/src/components/Highlight/Highlight";
+
+import Flow, { Step } from "@site/src/components/Flow";
+
+
+
+
+
+## From Host Secret Sync Example
+
+This guide shows how to sync k8s secret from host and use it in your workload inside the virtual cluster.
+
+### Prerequisites
+
+- kubectl with access to the host cluster and virtual cluster.
+
+### Set up cluster contexts
+
+Setting up the host and virtual cluster contexts makes it easier to switch
+between them.
+
+```bash
+export HOST_CTX="your-host-context"
+export VCLUSTER_CTX="vcluster-ctx"
+```
+
+then, create `foobar` namespace in your host cluster:
+
+```bash
+kubectl --context="${HOST_CTX}" create namespace foobar
+```
+
+:::tip
+You can find your contexts by running `kubectl config get-contexts`
+:::
+
+
+### Enable from host syncing for secret
+
+Enable the from host syncing for secrets in your virtual cluster configuration:
+
+```yaml title="Enable from host syncing for a secret"
+sync:
+  fromHost:
+    secrets:
+      enabled: true
+      selector:
+        mappings:
+          "foobar/shared-user-env": "my-namespace/user-env"
+```
+
+This configuration:
+
+- Enables from host syncing of the secret `shared-user-env` in the namespace `foobar`.
+- Automatically configures RBAC permissions for vCluster, so it can access this secret (you need to re-deploy vCluster for it to take place)
+- Makes this secret accessible as `user-env` in the `my-namespace` in your vCluster.
+
+:::tip create virtual cluster
+Create or update a `virtual Cluster` following the [vCluster quick start
+guide](/vcluster/#deploy-vcluster).
+:::
+
+### Sync secret to virtual and use it in pod
+
+<Flow id="secrets-from-host-example">
+  <Step>
+    First, we will need to create a secret that we want to sync in the host cluster:
+
+    ```bash title="Create secret in the host"
+    kubectl --context="${HOST_CTX}" create secret generic shared-user-env \
+    --namespace=foobar \
+    --from-literal=MY_ENV_1=foo \
+    --from-literal=MY_ENV_2=bar
+    ```
+  </Step>
+
+  #### Ensure that secret got synced to the vCluster
+
+  Our secret should be now accessible in the virtual cluster.
+  Keep in mind, that any edit made in the virtual object will be overwritten my the host object data.
+
+  <Step>
+    Let's check if the secret is accessible in the virtual cluster:
+
+    ```bash title="Get synced secret"
+    kubectl --context="${VCLUSTER_CTX}" get secrets --namespace my-namespace user-env -o yaml
+    ```
+
+    you should see similar output:
+
+    ```yaml title="secret contents"
+    apiVersion: v1
+    data:
+      MY_ENV_1: Zm9v
+      MY_ENV_2: YmFy
+    kind: Secret
+    metadata:
+      creationTimestamp: "2025-02-17T12:12:59Z"
+      name: user-env
+      namespace: my-namespace
+      resourceVersion: "15919"
+      uid: 26cc03d6-5cde-4090-9f9d-3e6fcbeefd24
+    type: Opaque
+    ```
+
+
+  </Step>
+
+  #### Use it in your workload
+
+  <Step>
+
+    Now, we can create a new pod in the `my-namespace` namespace and specify this secret as a source for environment variables.
+
+    Save this pod locally to the file called `pod.yaml`:
+    ```yaml title="pod.yaml"
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: my-pod
+      namespace: my-namespace
+    spec:
+      containers:
+      - name: busybox
+        image: busybox
+        command:
+        - sleep
+        - "inf"
+        env:
+        # Plain Text ENV
+        - name: DEMO_GREETING
+          value: "Hello from the environment"
+          envFrom:
+          - secretRef:
+            name: user-env
+    ```
+
+    then, create it in the virtual cluster:
+
+    ```bash title="Create pod"
+    kubectl --context="${VCLUSTER_CTX}" create -f pod.yaml
+    ```
+
+  </Step>
+  <Step>
+
+    #### Verify pod environment variables
+
+    <Highlight color="green">Virtual Cluster</Highlight> Wait for pod running
+
+    ```bash title="Wait for pod running"
+    kubectl --context="${VCLUSTER_CTX}" wait --for=condition=ready pod my-pod --namespace my-namespace --timeout=300s
+    ```
+
+    once it is running, we can list pod's environment variables:
+
+    ```bash title="Check environment variables"
+    kubectl --context="${VCLUSTER_CTX}" exec -it --namespace my-namespace my-pod -- printenv | grep "MY_ENV"
+    ```
+    you should see environment successfully injected from the secret:
+
+    ```bash title="Environment variables from secret"
+    MY_ENV_1=foo
+    MY_ENV_2=bar
+    ```
+
+  </Step>
+
+  <Step>
+    #### Summary
+
+    From host secret syncing allow you to make specific secret(s) from host accessible in your vCluster. You can make them accessible in the different namespaces and/or with different names in the virtual cluster.
+    They are always synced from host to the virtual, so it is also possible to sync one host secret to the multiple virtual ones.
+    They can be used as a volume or env source in your workloads.
+
+  </Step>
+</Flow>

--- a/vcluster/_fragments/sync-from-host-secret-example.mdx
+++ b/vcluster/_fragments/sync-from-host-secret-example.mdx
@@ -138,10 +138,9 @@ guide](/vcluster/#deploy-vcluster).
     ```
 
   </Step>
+
+  #### Verify pod environment variables
   <Step>
-
-    #### Verify pod environment variables
-
     <Highlight color="green">Virtual Cluster</Highlight> Wait for pod running
 
     ```bash title="Wait for pod running"
@@ -162,8 +161,8 @@ guide](/vcluster/#deploy-vcluster).
 
   </Step>
 
+  #### Summary
   <Step>
-    #### Summary
 
     From host Secret syncing allow you to make specific Secret(s) from host clusters accessible inside your virtual clusters. You can make them accessible from different namespaces and/or with different names in the virtual cluster.
     They are always synced from host to the virtual, so it is also possible to sync one host Secret to the multiple virtual ones.

--- a/vcluster/_fragments/sync-from-host-secret-example.mdx
+++ b/vcluster/_fragments/sync-from-host-secret-example.mdx
@@ -6,7 +6,7 @@ import Flow, { Step } from "@site/src/components/Flow";
 
 
 
-## From Host Secret Sync Example
+## From host secret sync example
 
 This guide shows how to sync k8s secret from host and use it in your workload inside the virtual cluster.
 
@@ -77,7 +77,7 @@ guide](/vcluster/#deploy-vcluster).
   #### Ensure that secret got synced to the vCluster
 
   Your secret should be now accessible in the virtual cluster.
-  Keep in mind, that any edit made in the virtual object will be overwritten my the host object data.
+  Keep in mind, that any edit made in the virtual object is overwritten by the host object data.
 
   <Step>
     Check if the secret is accessible in the virtual cluster:

--- a/vcluster/_partials/config/sync/fromHost/configMaps.mdx
+++ b/vcluster/_partials/config/sync/fromHost/configMaps.mdx
@@ -1,0 +1,257 @@
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps}
+
+ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-enabled}
+
+Enabled defines if this option should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches}
+
+Patches patch the resource according to the provided specification.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-path}
+
+Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-expression}
+
+Expression transforms the value according to the given JavaScript expression.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reverseExpression}
+
+ReverseExpression transforms the value according to the given JavaScript expression.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference}
+
+Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
+automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
+other names, in multi-namespace mode this will not translate the name.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-apiVersion}
+
+APIVersion is the apiVersion of the referenced object.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-apiVersionPath}
+
+APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-kind}
+
+Kind is the kind of the referenced object.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-kindPath}
+
+KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-namePath}
+
+NamePath is the optional relative path to the reference name within the object.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-namespacePath}
+
+NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
+metadata.namespace path of the object.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-labels}
+
+Labels treats the path value as a labels selector.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-selector}
+
+Selector for Namespace and Object
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-selector-mappings}
+
+Mappings is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
+There are several wildcards supported:
+1. To match all objects in host namespace and sync them to different namespace in vCluster:
+mappings:
+  "foo/*": "foo-in-virtual/*"
+2. To match specific object in the host namespace and sync it to the same namespace with the same name:
+mappings:
+  "foo/my-object": "foo/my-object"
+3. To match specific object in the host namespace and sync it to the same namespace with different name:
+mappings:
+  "foo/my-object": "foo/my-virtual-object"
+4. To match all objects in the vCluster host namespace and sync them to a different namespace in vCluster:
+mappings:
+  "": "my-virtual-namespace/*"
+5. To match specific objects in the vCluster host namespace and sync them to a different namespace in vCluster:
+mappings:
+  "/my-object": "my-virtual-namespace/my-object"
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>

--- a/vcluster/_partials/config/sync/fromHost/secrets.mdx
+++ b/vcluster/_partials/config/sync/fromHost/secrets.mdx
@@ -1,0 +1,257 @@
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets}
+
+Secrets defines if secrets in the host should get synced to the virtual cluster.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-enabled}
+
+Enabled defines if this option should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches}
+
+Patches patch the resource according to the provided specification.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-path}
+
+Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-expression}
+
+Expression transforms the value according to the given JavaScript expression.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reverseExpression}
+
+ReverseExpression transforms the value according to the given JavaScript expression.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference}
+
+Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
+automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
+other names, in multi-namespace mode this will not translate the name.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-apiVersion}
+
+APIVersion is the apiVersion of the referenced object.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-apiVersionPath}
+
+APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-kind}
+
+Kind is the kind of the referenced object.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-kindPath}
+
+KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-namePath}
+
+NamePath is the optional relative path to the reference name within the object.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-namespacePath}
+
+NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
+metadata.namespace path of the object.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-labels}
+
+Labels treats the path value as a labels selector.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-selector}
+
+Selector for Namespace and Object
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-selector-mappings}
+
+Mappings is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
+There are several wildcards supported:
+1. To match all objects in host namespace and sync them to different namespace in vCluster:
+mappings:
+  "foo/*": "foo-in-virtual/*"
+2. To match specific object in the host namespace and sync it to the same namespace with the same name:
+mappings:
+  "foo/my-object": "foo/my-object"
+3. To match specific object in the host namespace and sync it to the same namespace with different name:
+mappings:
+  "foo/my-object": "foo/my-virtual-object"
+4. To match all objects in the vCluster host namespace and sync them to a different namespace in vCluster:
+mappings:
+  "": "my-virtual-namespace/*"
+5. To match specific objects in the vCluster host namespace and sync them to a different namespace in vCluster:
+mappings:
+  "/my-object": "my-virtual-namespace/my-object"
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>

--- a/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
@@ -8,7 +8,7 @@ description: Configuration for ...
 import EnableSwitch from '../../../../_partials/config/sync/fromHost/configMaps.mdx'
 import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 import FromHostConfigMapExample from '../../../../_fragments/sync-from-host-configmap-example.mdx'
-import BasePrerequisites from '../../../../docs/_partials/base-prerequisites.mdx';
+import BasePrerequisites from '../../../../../docs/_partials/base-prerequisites.mdx'
 
 By default, this is turned off.
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
@@ -9,25 +9,25 @@ import EnableSwitch from '../../../../_partials/config/sync/fromHost/configMaps.
 import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 import FromHostConfigMapExample from '../../../../_fragments/sync-from-host-configmap-example.mdx'
 
-By default, this is disabled.
+By default, this is turned off.
 
 :::info No need to configure RBAC
-vCluster will automatically add the required cluster RBAC permissions for retrieving the custom resource definition and syncing the resources from the host to the virtual cluster.
+vCluster automatically adds the required cluster RBAC permissions for retrieving the config maps and syncing the resources from the host to the virtual cluster.
 :::
 
-Enabling this will allow you to sync ConfigMaps from the specified namespaces in the host to the specified namespaces in the vCluster.
+Enabling this allows you to sync ConfigMaps from the specified namespaces in the host to the specified namespaces in the vCluster.
 
 It is also possible to modify the name of the synced resource in the virtual cluster.
 
 There is no option to sync from all namespaces in the host.
 
-Sync is one-directional, from host to virtual. If you modify an object in the host, it will be synced to virtual object. When you delete virtual object, it will get re-created if the host object still exist.
+Sync is one-directional, from host to virtual. If you modify an object in the host, vCluster syncs the change to virtual object. When you delete virtual object, vCluster re-creates it if the host object still exist.
 
-Deleting host object will result in deleting virtual object.
+When you delete host object, vCluster deletes virtual object.
 
-Namespaces in the virtual cluster will get created automatically during the sync (if they do not exist already).
+Namespaces in the virtual cluster are created automatically during the sync (if they do not exist already).
 
-It is not possible to sync ConfigMaps that were already synced from virtual to host, they will be skipped by vCluster.
+It is not possible to sync ConfigMaps that were already synced from virtual to host, they are skipped by vCluster.
 
 :::info kube-root-ca configmap is skipped
 ConfigMaps named `kube-root-ca.crt` are skipped in the from host sync (even if they match the mappings specified in `vcluster.yaml`).
@@ -54,7 +54,7 @@ sync:
           "foo/*": "bar/*"
 ```
 
-## Sync only specific config maps from host namespace(s)
+## Sync only specific config maps from host namespace
 To sync only specific ConfigMaps from namespaces, you need to provide `namespace/name` as the key and value:
 
 ```yaml
@@ -70,7 +70,7 @@ sync:
 ```
 
 ## Sync all config maps from vCluster's host namespace
-There is also a handy syntax to sync all ConfigMaps from vCluster’s own host namespace to the virtual namespace. As vCluster’s namespace is not always known upfront (e.g. when vCluster is created by vCluster Platform), `""` (empty string) is treated as “vCluster’s own host namespace”.
+There is also a handy syntax to sync all ConfigMaps from vCluster’s own host namespace to the virtual namespace. As vCluster’s namespace is not always known upfront (e.g. when vCluster is created by the platform), `""` (empty string) is treated as “vCluster’s own host namespace”.
 
 ```yaml
 sync:
@@ -84,7 +84,7 @@ sync:
           "": "my-virtual"
 ```
 
-## Sync specific config map(s) from vCluster's host namespace
+## Sync specific config map from vCluster's host namespace
 you can also specify only a few ConfigMaps from vCluster’s own host namespace this way:
 
 ```yaml
@@ -120,7 +120,7 @@ sync:
 
 You can specify `reverseExpression` in the `sync.fromHost.configMaps.patches` .
 
-They will be applied on the host object and appear in the virtual object.
+They are applied on the host object and appear in the virtual object.
 
 `expressions` have no effect.
 
@@ -141,8 +141,8 @@ sync:
           reverseExpression: "value.startsWith('www.') ? value.slice(4) : value"
 ```
 
-1. Your ConfigMap in the host namespace `default` named `my-cm` will be synced to the namespace `barfoo2` in virtual and named `cm-my`.
-2. If `default/my-cm` host object has annotation which value starts with `www.` , e.g.: `my-address: www.loft.sh` then synced object in the virtual cluster `barfoo2/cm-my` will have annotation `my-address: loft.sh` .
+1. Your ConfigMap in the host namespace `default` named `my-cm` is synced to the namespace `barfoo2` in virtual and named `cm-my`.
+2. If `default/my-cm` host object has annotation which value starts with `www.` , e.g.: `my-address: www.loft.sh` then synced object in the virtual cluster `barfoo2/cm-my` has annotation `my-address: loft.sh` .
 
 
 <FromHostConfigMapExample />

--- a/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
@@ -12,24 +12,34 @@ import FromHostConfigMapExample from '../../../../_fragments/sync-from-host-conf
 By default, this is turned off.
 
 :::info No need to configure RBAC
-vCluster automatically adds the required cluster RBAC permissions for retrieving the config maps and syncing the resources from the host to the virtual cluster.
+vCluster automatically adds the required cluster RBAC permissions for retrieving the ConfigMaps and syncing the resources from the host to the virtual cluster.
 :::
 
 Enabling this allows you to sync ConfigMaps from the specified namespaces in the host to the specified namespaces in the vCluster.
+```yaml title="vcluster.yaml"
+sync:
+  fromHost:
+    configMaps:
+      enabled: true
+      selector:
+        mappings:
+          # syncs all ConfigMaps from "foo" namespace
+          # to the "bar" namespace in vCluster. ConfigMaps names are unchanged.
+          "foo/*": "bar/*"
+```
 
-It is also possible to modify the name of the synced resource in the virtual cluster.
 
-There is no option to sync from all namespaces in the host.
-
-Sync is one-directional, from host to virtual. If you modify an object in the host, vCluster syncs the change to virtual object. When you delete a virtual object, vCluster re-creates it if the host object still exist.
-
-When you delete a host object, vCluster deletes the corresponding virtual object.
+- It is also possible to modify the name of the synced resource in the virtual cluster.
+- There is no option to sync from all namespaces in the host.
+- Sync is one-directional, from host to virtual. If you modify an object in the host, vCluster syncs the change to virtual object.
+- When you delete a virtual object, vCluster re-creates it if the host object still exist.
+- When you delete a host object, vCluster deletes the corresponding virtual object.
 
 Namespaces in the virtual cluster are created automatically during the sync (if they do not exist already).
 
 It is not possible to sync ConfigMaps that were already synced from virtual to host, they are skipped by vCluster.
 
-:::info kube-root-ca configmap is skipped
+:::info kube-root-ca ConfigMap is skipped
 ConfigMaps named `kube-root-ca.crt` are skipped in the from host sync (even if they match the mappings specified in `vcluster.yaml`).
 :::
 
@@ -39,7 +49,7 @@ You can use synced ConfigMaps in your workloads as an environment variables sour
 All the specified namespaces have to exist in the host at the vCluster startup.
 
 
-## Sync all config maps from host namespace
+## Sync all ConfigMaps from host namespace
 To sync all ConfigMaps from a given namespace in the host to the given namespace in the virtual cluster, “namespace/*” wildcard can be used, e.g.:
 
 ```yaml
@@ -54,7 +64,7 @@ sync:
           "foo/*": "bar/*"
 ```
 
-## Sync only specific config maps from host namespace
+## Sync only specific ConfigMaps from host namespace
 To sync only specific ConfigMaps from namespaces, you need to provide `namespace/name` as the key and value:
 
 ```yaml
@@ -69,7 +79,7 @@ sync:
           "foo/cm-name": "bar/cm-name"
 ```
 
-## Sync all config maps from vCluster's host namespace
+## Sync all ConfigMaps from vCluster's host namespace
 There is also a handy syntax to sync all ConfigMaps from vCluster’s own host namespace to the virtual namespace. As vCluster’s namespace is not always known upfront (e.g. when vCluster is created by the platform), `""` (empty string) is treated as “vCluster’s own host namespace”.
 
 ```yaml
@@ -84,7 +94,7 @@ sync:
           "": "my-virtual"
 ```
 
-## Sync specific config map from vCluster's host namespace
+## Sync specific ConfigMap from vCluster's host namespace
 you can also specify only a few ConfigMaps from vCluster’s own host namespace this way:
 
 ```yaml
@@ -99,7 +109,7 @@ sync:
           "/my-cm": "my-virtual/my-cm"
 ```
 
-## Modify synced config map namespace and name in the virtual cluster
+## Modify synced ConfigMap namespace and name in the virtual cluster
 It’s also possible to modify ConfigMap name during the sync:
 
 ```yaml
@@ -136,7 +146,6 @@ sync:
           "default/my-cm": "barfoo2/cm-my"
       patches:
         - path: metadata.annotations[*]
-          #expression: '"my-prefix-"+value'
           # optional reverseExpression to reverse the change from the host cluster
           reverseExpression: "value.startsWith('www.') ? value.slice(4) : value"
 ```

--- a/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
@@ -21,9 +21,9 @@ It is also possible to modify the name of the synced resource in the virtual clu
 
 There is no option to sync from all namespaces in the host.
 
-Sync is one-directional, from host to virtual. If you modify an object in the host, vCluster syncs the change to virtual object. When you delete virtual object, vCluster re-creates it if the host object still exist.
+Sync is one-directional, from host to virtual. If you modify an object in the host, vCluster syncs the change to virtual object. When you delete a virtual object, vCluster re-creates it if the host object still exist.
 
-When you delete host object, vCluster deletes virtual object.
+When you delete a host object, vCluster deletes the corresponding virtual object.
 
 Namespaces in the virtual cluster are created automatically during the sync (if they do not exist already).
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
@@ -1,0 +1,152 @@
+---
+title: ConfigMaps
+sidebar_label: configmaps
+sidebar_position: 10
+description: Configuration for ...
+---
+
+import EnableSwitch from '../../../../_partials/config/sync/fromHost/configMaps.mdx'
+import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
+import FromHostConfigMapExample from '../../../../_fragments/sync-from-host-configmap-example.mdx'
+
+By default, this is disabled.
+
+:::info No need to configure RBAC
+vCluster will automatically add the required cluster RBAC permissions for retrieving the custom resource definition and syncing the resources from the host to the virtual cluster.
+:::
+
+Enabling this will allow you to sync ConfigMaps from the specified namespaces in the host to the specified namespaces in the vCluster.
+
+It is also possible to modify the name of the synced resource in the virtual cluster.
+
+There is no option to sync from all namespaces in the host.
+
+Sync is one-directional, from host to virtual. If you modify an object in the host, it will be synced to virtual object. When you delete virtual object, it will get re-created if the host object still exist.
+
+Deleting host object will result in deleting virtual object.
+
+Namespaces in the virtual cluster will get created automatically during the sync (if they do not exist already).
+
+It is not possible to sync ConfigMaps that were already synced from virtual to host, they will be skipped by vCluster.
+
+:::info kube-root-ca configmap is skipped
+ConfigMaps named `kube-root-ca.crt` are skipped in the from host sync (even if they match the mappings specified in `vcluster.yaml`).
+:::
+
+You can use synced ConfigMaps in your workloads as an environment variables source or a volume.
+
+## Prerequisites
+All the specified namespaces have to exist in the host at the vCluster startup.
+
+
+## Sync all config maps from host namespace
+To sync all ConfigMaps from a given namespace in the host to the given namespace in the virtual cluster, “namespace/*” wildcard can be used, e.g.:
+
+```yaml
+sync:
+  fromHost:
+    configMaps:
+      enabled: true
+      selector:
+        mappings:
+          # syncs all ConfigMaps from "foo" namespace
+          # to the "bar" namespace in vCluster. ConfigMaps names are unchanged.
+          "foo/*": "bar/*"
+```
+
+## Sync only specific config maps from host namespace(s)
+To sync only specific ConfigMaps from namespaces, you need to provide `namespace/name` as the key and value:
+
+```yaml
+sync:
+  fromHost:
+    configMaps:
+      enabled: true
+      selector:
+        mappings:
+          # syncs ConfigMap named "cm-name" from "foo" host namespace
+          # to the "bar" namespace in virtual.
+          "foo/cm-name": "bar/cm-name"
+```
+
+## Sync all config maps from vCluster's host namespace
+There is also a handy syntax to sync all ConfigMaps from vCluster’s own host namespace to the virtual namespace. As vCluster’s namespace is not always known upfront (e.g. when vCluster is created by vCluster Platform), `""` (empty string) is treated as “vCluster’s own host namespace”.
+
+```yaml
+sync:
+  fromHost:
+    configMaps:
+      enabled: true
+      selector:
+        mappings:
+          # syncs all ConfigMaps from vCluster's host namespace
+          # to "my-virtual" namespace in vCluster.
+          "": "my-virtual"
+```
+
+## Sync specific config map(s) from vCluster's host namespace
+you can also specify only a few ConfigMaps from vCluster’s own host namespace this way:
+
+```yaml
+sync:
+  fromHost:
+    configMaps:
+      enabled: true
+      selector:
+        mappings:
+          # syncs ConfigMap named "my-cm" from vCluster's host namespace
+          # to "my-virtual-namespace" in vCluster.
+          "/my-cm": "my-virtual/my-cm"
+```
+
+## Modify synced config map namespace and name in the virtual cluster
+It’s also possible to modify ConfigMap name during the sync:
+
+```yaml
+sync:
+  fromHost:
+    configMaps:
+      enabled: true
+      selector:
+        mappings:
+          # syncs "config" ConfigMap from "cert-manager" namespace in the host
+          # as "my-config" in "my-virtual" namespace in vCluster.
+          "cert-manager/config": "my-virtual/my-config"
+```
+
+## Pro patches
+
+<ProAdmonition/>
+
+You can specify `reverseExpression` in the `sync.fromHost.configMaps.patches` .
+
+They will be applied on the host object and appear in the virtual object.
+
+`expressions` have no effect.
+
+So, for the following `vcluster.yaml` :
+
+```yaml
+sync:
+  fromHost:
+    configMaps:
+      enabled: true
+      selector:
+        mappings:
+          "default/my-cm": "barfoo2/cm-my"
+      patches:
+        - path: metadata.annotations[*]
+          #expression: '"my-prefix-"+value'
+          # optional reverseExpression to reverse the change from the host cluster
+          reverseExpression: "value.startsWith('www.') ? value.slice(4) : value"
+```
+
+1. Your ConfigMap in the host namespace `default` named `my-cm` will be synced to the namespace `barfoo2` in virtual and named `cm-my`.
+2. If `default/my-cm` host object has annotation which value starts with `www.` , e.g.: `my-address: www.loft.sh` then synced object in the virtual cluster `barfoo2/cm-my` will have annotation `my-address: loft.sh` .
+
+
+<FromHostConfigMapExample />
+
+## Config reference
+
+<EnableSwitch/>

--- a/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
@@ -8,6 +8,7 @@ description: Configuration for ...
 import EnableSwitch from '../../../../_partials/config/sync/fromHost/configMaps.mdx'
 import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 import FromHostConfigMapExample from '../../../../_fragments/sync-from-host-configmap-example.mdx'
+import BasePrerequisites from '../../../../docs/_partials/base-prerequisites.mdx';
 
 By default, this is turned off.
 
@@ -15,8 +16,9 @@ By default, this is turned off.
 vCluster automatically adds the required cluster RBAC permissions for retrieving the ConfigMaps and syncing the resources from the host to the virtual cluster.
 :::
 
-Enabling this allows you to sync ConfigMaps from the specified namespaces in the host to the specified namespaces in the vCluster.
-```yaml title="vcluster.yaml"
+Enabling sync from host allows you to sync ConfigMaps from the specified namespaces in the host cluster to the specified namespaces in a virtual cluster.
+Here is how the required configuration in `vcluster.yam` looks like:
+```yaml title="configure ConfigMap sync from host"
 sync:
   fromHost:
     configMaps:
@@ -24,20 +26,19 @@ sync:
       selector:
         mappings:
           # syncs all ConfigMaps from "foo" namespace
-          # to the "bar" namespace in vCluster. ConfigMaps names are unchanged.
+          # to the "bar" namespace in a virtual cluster. ConfigMaps names are unchanged.
           "foo/*": "bar/*"
 ```
 
-
+Here are a few things to remember when configuring the sync:
 - It is also possible to modify the name of the synced resource in the virtual cluster.
 - There is no option to sync from all namespaces in the host.
 - Sync is one-directional, from host to virtual. If you modify an object in the host, vCluster syncs the change to virtual object.
 - When you delete a virtual object, vCluster re-creates it if the host object still exist.
 - When you delete a host object, vCluster deletes the corresponding virtual object.
+- It is not possible to sync ConfigMaps that were already synced from virtual to host, they are skipped by vCluster.
 
 Namespaces in the virtual cluster are created automatically during the sync (if they do not exist already).
-
-It is not possible to sync ConfigMaps that were already synced from virtual to host, they are skipped by vCluster.
 
 :::info kube-root-ca ConfigMap is skipped
 ConfigMaps named `kube-root-ca.crt` are skipped in the from host sync (even if they match the mappings specified in `vcluster.yaml`).
@@ -46,13 +47,14 @@ ConfigMaps named `kube-root-ca.crt` are skipped in the from host sync (even if t
 You can use synced ConfigMaps in your workloads as an environment variables source or a volume.
 
 ## Prerequisites
+<BasePrerequisites />
 All the specified namespaces have to exist in the host at the vCluster startup.
 
 
 ## Sync all ConfigMaps from host namespace
-To sync all ConfigMaps from a given namespace in the host to the given namespace in the virtual cluster, “namespace/*” wildcard can be used, e.g.:
+To sync all ConfigMaps from a given namespace in the host to the given namespace in the virtual cluster, use “namespace/*” wildcard, e.g.:
 
-```yaml
+```yaml title="configure ConfigMap sync from host namespace"
 sync:
   fromHost:
     configMaps:
@@ -60,14 +62,14 @@ sync:
       selector:
         mappings:
           # syncs all ConfigMaps from "foo" namespace
-          # to the "bar" namespace in vCluster. ConfigMaps names are unchanged.
+          # to the "bar" namespace in a virtual cluster. ConfigMaps names are unchanged.
           "foo/*": "bar/*"
 ```
 
 ## Sync only specific ConfigMaps from host namespace
 To sync only specific ConfigMaps from namespaces, you need to provide `namespace/name` as the key and value:
 
-```yaml
+```yaml title="configure ConfigMap sync from host for one object"
 sync:
   fromHost:
     configMaps:
@@ -79,40 +81,40 @@ sync:
           "foo/cm-name": "bar/cm-name"
 ```
 
-## Sync all ConfigMaps from vCluster's host namespace
-There is also a handy syntax to sync all ConfigMaps from vCluster’s own host namespace to the virtual namespace. As vCluster’s namespace is not always known upfront (e.g. when vCluster is created by the platform), `""` (empty string) is treated as “vCluster’s own host namespace”.
+## Sync all ConfigMaps from virtual cluster's host namespace
+There is also a handy syntax to sync all ConfigMaps from virtual cluster’s own host namespace to the virtual namespace. As virtual cluster’s namespace is not always known upfront (e.g. when virtual cluster is created by the platform), `""` (empty string) is treated as “virtual cluster’s own host namespace”.
 
-```yaml
+```yaml title="configure ConfigMap sync from host for virtual cluster's namespace"
 sync:
   fromHost:
     configMaps:
       enabled: true
       selector:
         mappings:
-          # syncs all ConfigMaps from vCluster's host namespace
-          # to "my-virtual" namespace in vCluster.
+          # syncs all ConfigMaps from virtual cluster's host namespace
+          # to "my-virtual" namespace in a virtual cluster.
           "": "my-virtual"
 ```
 
-## Sync specific ConfigMap from vCluster's host namespace
-you can also specify only a few ConfigMaps from vCluster’s own host namespace this way:
+## Sync specific ConfigMap from virtual cluster's host namespace
+you can also specify only a few ConfigMaps from virtual cluster’s own host namespace this way:
 
-```yaml
+```yaml title="configure ConfigMap sync from host for objects in virtual cluster's namespace"
 sync:
   fromHost:
     configMaps:
       enabled: true
       selector:
         mappings:
-          # syncs ConfigMap named "my-cm" from vCluster's host namespace
-          # to "my-virtual-namespace" in vCluster.
+          # syncs ConfigMap named "my-cm" from virtual cluster's host namespace
+          # to "my-virtual-namespace" in a virtual cluster.
           "/my-cm": "my-virtual/my-cm"
 ```
 
 ## Modify synced ConfigMap namespace and name in the virtual cluster
 It’s also possible to modify ConfigMap name during the sync:
 
-```yaml
+```yaml title="configure ConfigMap sync from host and modify name and namespace"
 sync:
   fromHost:
     configMaps:
@@ -120,11 +122,11 @@ sync:
       selector:
         mappings:
           # syncs "config" ConfigMap from "cert-manager" namespace in the host
-          # as "my-config" in "my-virtual" namespace in vCluster.
+          # as "my-config" in "my-virtual" namespace in a virtual cluster.
           "cert-manager/config": "my-virtual/my-config"
 ```
 
-## Pro patches
+## Patches
 
 <ProAdmonition/>
 
@@ -136,7 +138,7 @@ They are applied on the host object and appear in the virtual object.
 
 So, for the following `vcluster.yaml` :
 
-```yaml
+```yaml title="configure ConfigMap sync from host with patches"
 sync:
   fromHost:
     configMaps:

--- a/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
@@ -14,15 +14,11 @@ import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 vCluster allows you to sync custom resources from the host cluster to the virtual cluster. Resources will only be read by vCluster and then synced in read-only mode into the vCluster. vCluster will copy the CRD itself in the beginning from the host to the virtual cluster and then start syncing the resources into the vCluster. This is especially helpful if you want to show certain resources inside the vCluster, such as ClusterIssuers (for [cert-manager](https://cert-manager.io/)) or ClusterStores (for [external-secrets](https://external-secrets.io/latest/)).
 If you are looking to sync resources from the vCluster to the host cluster, see [syncing custom resources to the host cluster](../to-host/advanced/custom-resources)
 
-:::info Only Cluster-Scoped Resource
-This feature currently only works for cluster-scoped resources only.
-:::
-
 :::info No need to configure RBAC
 vCluster will automatically add the required cluster RBAC permissions for retrieving the custom resource definition and syncing the resources from the host to the virtual cluster.
 :::
 
-## Example
+## Cluster Scope Example
 
 To configure vCluster to sync ClusterIssuers from the host cluster (from [cert-manager](https://cert-manager.io/)):
 ```yaml
@@ -33,6 +29,148 @@ sync:
         enabled: true
         scope: Cluster
 ```
+
+## Namespaced Scope CRDs
+By default, this is disabled.
+
+Enabling this will allow you to sync namespaced CustomResources from the specified namespaces in the host to the specified namespaces in the vCluster.
+
+It is also possible to modify the name of the synced resource in the virtual cluster.
+
+There is no option to sync from all namespaces in the host.
+
+Sync is one-directional, from host to virtual. If you modify an object in the host, it will be synced to virtual object. When you delete virtual object, it will get re-created if the host object still exist.
+
+Deleting host object will result in deleting virtual object.
+
+### Prerequisites
+
+* All the specified namespaces have to exist in the host at the vCluster startup.
+* Custom Resource Definition needs to exist in the host at the vCluster startup.
+
+### Example
+
+:::info No need to configure RBAC
+vCluster will automatically add the required cluster RBAC permissions for retrieving the custom resource definition and syncing the resources from the host to the virtual cluster.
+:::
+
+For Namespaced Scoped Custom Resources, you need to specify `selector.mappings` in the config. This tells vCluster which host resources should be synced and where (in the virtual cluster).
+
+Namespaces in the virtual cluster will get created automatically during the sync (if they do not exist already).
+
+It is not possible to sync Custom Resources that were already synced from virtual to host, they will be skipped by vCluster.
+
+We will use cert-manager’s CertificateRequest custom resource in our examples.
+
+To sync all CustomResources from a given namespace in the host to the given namespace in the virtual cluster, “namespace/*” wildcard can be used, e.g.:
+
+```yaml
+sync:
+  fromHost:
+    customResources:
+      certificaterequests.cert-manager.io:
+        enabled: true
+        scope: Namespaced
+        selector:
+          mappings:
+	          # syncs all CertificateRequests from "foo" namespace
+	          # to the "bar" namespace in vCluster. CertificateRequests names are unchanged.
+            "foo/*": "bar/*"
+```
+
+To sync only specific CustomResources from namespaces, you need to provide `namespace/name` as the key and value:
+
+```yaml
+sync:
+  fromHost:
+    customResources:
+      certificaterequests.cert-manager.io:
+        enabled: true
+        scope: Namespaced
+        selector:
+          mappings:
+            # syncs CertificateRequest named "cm-name" from "foo" host namespace
+            # to the "bar" namespace in virtual.
+            "foo/cm-name": "bar/cm-name"
+```
+
+There is also a handy syntax to sync all CustomResources from vCluster’s own host namespace to the virtual namespace. As vCluster’s namespace is not always known upfront (e.g. when vCluster is created by vCluster Platform), `""` (empty string) is treated as “vCluster’s own host namespace”.
+
+```yaml
+sync:
+  fromHost:
+    customResources:
+      certificaterequests.cert-manager.io:
+        enabled: true
+        scope: Namespaced
+        selector:
+          mappings:
+            # syncs all CertificateRequests from vCluster's host namespace
+            # to "my-virtual" namespace in vCluster.
+            "": "my-virtual"
+```
+
+you can also specify only a few CustomResources from vCluster’s own host namespace this way:
+
+```yaml
+sync:
+  fromHost:
+    customResources:
+      certificaterequests.cert-manager.io:
+        enabled: true
+        scope: Namespaced
+        selector:
+          mappings:
+            # syncs CertificateRequest named "my-cm" from vCluster's host namespace
+            # to "my-virtual-namespace" in vCluster.
+            "/my-cm": "my-virtual/my-cm"
+```
+
+It’s also possible to modify CustomResource name during the sync:
+
+```yaml
+sync:
+  fromHost:
+    customResources:
+      certificaterequests.cert-manager.io:
+        enabled: true
+        scope: Namespaced
+        selector:
+          mappings:
+            # syncs "foo" CertificateRequest from "cert-manager" namespace in the host
+            # as "my-foo" in "my-virtual" namespace in vCluster.
+            "cert-manager/foo": "my-virtual/my-foo"
+```
+
+### Pro Patches
+
+You can specify `reverseExpression` in the `sync.fromHost.customResources[*].patches` .
+
+They will be applied on the host object and appear in the virtual object.
+
+`expressions` have no effect.
+
+So, for the following `vcluster.yaml` :
+
+```yaml
+sync:
+  fromHost:
+    customResources:
+      certificaterequests.cert-manager.io:
+        enabled: true
+        scope: Namespaced
+        selector:
+          mappings:
+            "default/my-cm": "barfoo2/cm-my"
+      patches:
+        - path: metadata.annotations[*]
+          #expression: '"my-prefix-"+value'
+          # optional reverseExpression to reverse the change from the host cluster
+          reverseExpression: "value.startsWith('www.') ? value.slice(4) : value"
+```
+
+1. Your CustomResource in the host namespace `default` named `my-cm` will be synced to the namespace `barfoo2` in virtual and named `cm-my`.
+2. If `default/my-cm` host object has annotation which value starts with `www.` , e.g.: `my-address: www.loft.sh` then synced object in the virtual cluster `barfoo2/cm-my` will have annotation `my-address: loft.sh` .
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
@@ -12,14 +12,14 @@ import NamespacedCustomResourcesExample from '../../../../_fragments/sync-from-h
 
 <ProAdmonition/>
 
-vCluster allows you to sync custom resources from the host cluster to the virtual cluster. Resources are only be read by vCluster and then synced in read-only mode into the vCluster. vCluster copies the CRD itself in the beginning from the host to the virtual cluster and then start syncing the resources into the vCluster. This is especially helpful if you want to show certain resources inside the vCluster, such as ClusterIssuers (for [cert-manager](https://cert-manager.io/)) or ClusterStores (for [external-secrets](https://external-secrets.io/latest/)).
+vCluster allows you to sync CustomResources from the host cluster to the virtual cluster. Resources are only be read by vCluster and then synced in read-only mode into the vCluster. vCluster copies the CRD itself in the beginning from the host to the virtual cluster and then start syncing the resources into the vCluster. This is especially helpful if you want to show certain resources inside the vCluster, such as ClusterIssuers (for [cert-manager](https://cert-manager.io/)) or ClusterStores (for [external-secrets](https://external-secrets.io/latest/)).
 If you are looking to sync resources from the vCluster to the host cluster, see [syncing custom resources to the host cluster](../to-host/advanced/custom-resources)
 
 :::info No need to configure RBAC
-vCluster automatically adds the required cluster RBAC permissions for retrieving the custom resource definition and syncing the resources from the host to the virtual cluster.
+vCluster automatically adds the required cluster RBAC permissions for retrieving the CustomResourceDefinition and syncing the resources from the host to the virtual cluster.
 :::
 
-## Cluster scope example
+## Cluster scoped example
 
 To configure vCluster to sync ClusterIssuers from the host cluster (from [cert-manager](https://cert-manager.io/)):
 ```yaml
@@ -30,38 +30,52 @@ sync:
         enabled: true
         scope: Cluster
 ```
-
-## Namespaced scope custom resource definitions
+<!-- vale Google.Headings = NO -->
+## Namespace scoped CustomResourceDefinitions
+<!-- vale Google.Headings = YES -->
 By default, this is turned off.
 
 Enabling this allow you to sync namespaced CustomResources from the specified namespaces in the host to the specified namespaces in the vCluster.
+```yaml title="vcluster.yaml"
+sync:
+  fromHost:
+    customResources:
+      certificaterequests.cert-manager.io:
+        enabled: true
+        scope: Namespaced
+        selector:
+          mappings:
+            # syncs all CertificateRequests from "foo" namespace
+            # to the "bar" namespace in vCluster. CertificateRequests names are unchanged.
+            "foo/*": "bar/*"
+```
 
-It is also possible to modify the name of the synced resource in the virtual cluster.
+- It is also possible to modify the name of the synced resource in the virtual cluster.
+- There is no option to sync from all namespaces in the host.
+- Sync is one-directional, from host to virtual. If you modify an object in the host, vCluster syncs the change to virtual object.
+- When you delete virtual object, vCluster re-creates it if the host object still exist.
+- When you delete host object, vCluster deletes virtual object.
 
-There is no option to sync from all namespaces in the host.
-
-Sync is one-directional, from host to virtual. If you modify an object in the host, vCluster syncs the change to virtual object. When you delete virtual object, vCluster re-creates it if the host object still exist.
-
-When you delete host object, vCluster deletes virtual object.
+Namespaces in the virtual cluster are created automatically during the sync (if they do not exist already).
 
 ### Prerequisites
 
 * All the specified namespaces have to exist in the host at the vCluster startup.
-* Custom Resource Definition needs to exist in the host at the vCluster startup.
+* CustomResourceDefinition needs to exist in the host at the vCluster startup.
 
 ### Example
 
 :::info No need to configure RBAC
-vCluster automatically adds the required cluster RBAC permissions for retrieving the custom resource definition and syncing the resources from the host to the virtual cluster.
+vCluster automatically adds the required cluster RBAC permissions for retrieving the CustomResourceDefinition and syncing the resources from the host to the virtual cluster.
 :::
 
-For Namespaced Scoped Custom Resources, you need to specify `selector.mappings` in the config. This tells vCluster which host resources should be synced and where (in the virtual cluster).
+For Namespace scoped CustomResources, you need to specify `selector.mappings` in the config. This tells vCluster which host resources should be synced and where (in the virtual cluster).
 
 Namespaces in the virtual cluster are created automatically during the sync (if they do not exist already).
 
-It is not possible to sync Custom Resources that were already synced from virtual to host, they are skipped by vCluster.
+It is not possible to sync CustomResources that were already synced from virtual to host, they are skipped by vCluster.
 
-Here is an example with cert-manager’s CertificateRequest custom resource.
+Here is an example with cert-manager’s CertificateRequest CustomResource.
 
 To sync all CustomResources from a given namespace in the host to the given namespace in the virtual cluster, “namespace/*” wildcard can be used, e.g.:
 
@@ -74,8 +88,8 @@ sync:
         scope: Namespaced
         selector:
           mappings:
-	          # syncs all CertificateRequests from "foo" namespace
-	          # to the "bar" namespace in vCluster. CertificateRequests names are unchanged.
+            # syncs all CertificateRequests from "foo" namespace
+            # to the "bar" namespace in vCluster. CertificateRequests names are unchanged.
             "foo/*": "bar/*"
 ```
 
@@ -165,7 +179,6 @@ sync:
             "default/my-cm": "barfoo2/cm-my"
       patches:
         - path: metadata.annotations[*]
-          #expression: '"my-prefix-"+value'
           # optional reverseExpression to reverse the change from the host cluster
           reverseExpression: "value.startsWith('www.') ? value.slice(4) : value"
 ```

--- a/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
@@ -22,7 +22,7 @@ vCluster automatically adds the required cluster RBAC permissions for retrieving
 ## Cluster scoped example
 
 To configure vCluster to sync ClusterIssuers from the host cluster (from [cert-manager](https://cert-manager.io/)):
-```yaml
+```yaml title="configure Cluster scoped CRD sync from host"
 sync:
   fromHost:
     customResources:
@@ -36,7 +36,7 @@ sync:
 By default, this is turned off.
 
 Enabling this allow you to sync namespaced CustomResources from the specified namespaces in the host to the specified namespaces in the vCluster.
-```yaml title="vcluster.yaml"
+```yaml title="configure Namespace scoped CRD sync from host"
 sync:
   fromHost:
     customResources:
@@ -46,7 +46,7 @@ sync:
         selector:
           mappings:
             # syncs all CertificateRequests from "foo" namespace
-            # to the "bar" namespace in vCluster. CertificateRequests names are unchanged.
+            # to the "bar" namespace in a virtual cluster. CertificateRequests names are unchanged.
             "foo/*": "bar/*"
 ```
 
@@ -79,7 +79,7 @@ Here is an example with cert-manager’s CertificateRequest CustomResource.
 
 To sync all CustomResources from a given namespace in the host to the given namespace in the virtual cluster, “namespace/*” wildcard can be used, e.g.:
 
-```yaml
+```yaml title="configure CustomResource sync from host namespace"
 sync:
   fromHost:
     customResources:
@@ -89,13 +89,13 @@ sync:
         selector:
           mappings:
             # syncs all CertificateRequests from "foo" namespace
-            # to the "bar" namespace in vCluster. CertificateRequests names are unchanged.
+            # to the "bar" namespace in a virtual cluster. CertificateRequests names are unchanged.
             "foo/*": "bar/*"
 ```
 
 To sync only specific CustomResources from namespaces, you need to provide `namespace/name` as the key and value:
 
-```yaml
+```yaml title="configure CustomResource sync from host for one object"
 sync:
   fromHost:
     customResources:
@@ -109,9 +109,9 @@ sync:
             "foo/cm-name": "bar/cm-name"
 ```
 
-There is also a handy syntax to sync all CustomResources from vCluster’s own host namespace to the virtual namespace. As vCluster’s namespace is not always known upfront (e.g. when vCluster is created by the platform), `""` (empty string) is treated as “vCluster’s own host namespace”.
+There is also a handy syntax to sync all CustomResources from virtual cluster’s own host namespace to the virtual namespace. As vCluster’s namespace is not always known upfront (e.g. when vCluster is created by the platform), `""` (empty string) is treated as “vCluster’s own host namespace”.
 
-```yaml
+```yaml title="configure CustomResource sync from host for virtual cluster's namespace"
 sync:
   fromHost:
     customResources:
@@ -120,14 +120,14 @@ sync:
         scope: Namespaced
         selector:
           mappings:
-            # syncs all CertificateRequests from vCluster's host namespace
-            # to "my-virtual" namespace in vCluster.
+            # syncs all CertificateRequests from virtual cluster's host namespace
+            # to "my-virtual" namespace in a virtual cluster.
             "": "my-virtual"
 ```
 
-you can also specify only a few CustomResources from vCluster’s own host namespace this way:
+you can also specify only a few CustomResources from virtual cluster’s own host namespace this way:
 
-```yaml
+```yaml title="configure CustomResource sync from host for objects in virtual cluster's namespace"
 sync:
   fromHost:
     customResources:
@@ -136,14 +136,14 @@ sync:
         scope: Namespaced
         selector:
           mappings:
-            # syncs CertificateRequest named "my-cm" from vCluster's host namespace
-            # to "my-virtual-namespace" in vCluster.
+            # syncs CertificateRequest named "my-cm" from virtual cluster's host namespace
+            # to "my-virtual-namespace" in a virtual cluster.
             "/my-cm": "my-virtual/my-cm"
 ```
 
 It’s also possible to modify CustomResource name during the sync:
 
-```yaml
+```yaml title="configure CustomResource sync from host and modify name and namespace"
 sync:
   fromHost:
     customResources:
@@ -153,11 +153,11 @@ sync:
         selector:
           mappings:
             # syncs "foo" CertificateRequest from "cert-manager" namespace in the host
-            # as "my-foo" in "my-virtual" namespace in vCluster.
+            # as "my-foo" in "my-virtual" namespace in a virtual cluster.
             "cert-manager/foo": "my-virtual/my-foo"
 ```
 
-### Pro patches
+### Patches
 
 You can specify `reverseExpression` in the `sync.fromHost.customResources[*].patches` .
 
@@ -167,7 +167,7 @@ They are applied on the host object and appear in the virtual object.
 
 So, for the following `vcluster.yaml` :
 
-```yaml
+```yaml title="configure CustomResource sync from host with patches"
 sync:
   fromHost:
     customResources:

--- a/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
@@ -8,6 +8,7 @@ description: Configuration for ...
 
 import CustomResourceDefinitions from '../../../../_partials/config/sync/fromHost/customResources.mdx'
 import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
+import NamespacedCustomResourcesExample from '../../../../_fragments/sync-from-host-namespaced-custom-resources-example.mdx'
 
 <ProAdmonition/>
 
@@ -171,6 +172,9 @@ sync:
 
 1. Your CustomResource in the host namespace `default` named `my-cm` will be synced to the namespace `barfoo2` in virtual and named `cm-my`.
 2. If `default/my-cm` host object has annotation which value starts with `www.` , e.g.: `my-address: www.loft.sh` then synced object in the virtual cluster `barfoo2/cm-my` will have annotation `my-address: loft.sh` .
+
+
+<NamespacedCustomResourcesExample/>
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
@@ -177,10 +177,10 @@ sync:
         selector:
           mappings:
             "default/my-cm": "barfoo2/cm-my"
-      patches:
-        - path: metadata.annotations[*]
-          # optional reverseExpression to reverse the change from the host cluster
-          reverseExpression: "value.startsWith('www.') ? value.slice(4) : value"
+        patches:
+          - path: metadata.annotations[*]
+            # optional reverseExpression to reverse the change from the host cluster
+            reverseExpression: "value.startsWith('www.') ? value.slice(4) : value"
 ```
 
 1. Your CustomResource in the host namespace `default` named `my-cm` is synced to the namespace `barfoo2` in virtual and named `cm-my`.

--- a/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
@@ -12,14 +12,14 @@ import NamespacedCustomResourcesExample from '../../../../_fragments/sync-from-h
 
 <ProAdmonition/>
 
-vCluster allows you to sync custom resources from the host cluster to the virtual cluster. Resources will only be read by vCluster and then synced in read-only mode into the vCluster. vCluster will copy the CRD itself in the beginning from the host to the virtual cluster and then start syncing the resources into the vCluster. This is especially helpful if you want to show certain resources inside the vCluster, such as ClusterIssuers (for [cert-manager](https://cert-manager.io/)) or ClusterStores (for [external-secrets](https://external-secrets.io/latest/)).
+vCluster allows you to sync custom resources from the host cluster to the virtual cluster. Resources are only be read by vCluster and then synced in read-only mode into the vCluster. vCluster copies the CRD itself in the beginning from the host to the virtual cluster and then start syncing the resources into the vCluster. This is especially helpful if you want to show certain resources inside the vCluster, such as ClusterIssuers (for [cert-manager](https://cert-manager.io/)) or ClusterStores (for [external-secrets](https://external-secrets.io/latest/)).
 If you are looking to sync resources from the vCluster to the host cluster, see [syncing custom resources to the host cluster](../to-host/advanced/custom-resources)
 
 :::info No need to configure RBAC
-vCluster will automatically add the required cluster RBAC permissions for retrieving the custom resource definition and syncing the resources from the host to the virtual cluster.
+vCluster automatically adds the required cluster RBAC permissions for retrieving the custom resource definition and syncing the resources from the host to the virtual cluster.
 :::
 
-## Cluster Scope Example
+## Cluster scope example
 
 To configure vCluster to sync ClusterIssuers from the host cluster (from [cert-manager](https://cert-manager.io/)):
 ```yaml
@@ -31,18 +31,18 @@ sync:
         scope: Cluster
 ```
 
-## Namespaced Scope CRDs
-By default, this is disabled.
+## Namespaced scope custom resource definitions
+By default, this is turned off.
 
-Enabling this will allow you to sync namespaced CustomResources from the specified namespaces in the host to the specified namespaces in the vCluster.
+Enabling this allow you to sync namespaced CustomResources from the specified namespaces in the host to the specified namespaces in the vCluster.
 
 It is also possible to modify the name of the synced resource in the virtual cluster.
 
 There is no option to sync from all namespaces in the host.
 
-Sync is one-directional, from host to virtual. If you modify an object in the host, it will be synced to virtual object. When you delete virtual object, it will get re-created if the host object still exist.
+Sync is one-directional, from host to virtual. If you modify an object in the host, vCluster syncs the change to virtual object. When you delete virtual object, vCluster re-creates it if the host object still exist.
 
-Deleting host object will result in deleting virtual object.
+When you delete host object, vCluster deletes virtual object.
 
 ### Prerequisites
 
@@ -52,16 +52,16 @@ Deleting host object will result in deleting virtual object.
 ### Example
 
 :::info No need to configure RBAC
-vCluster will automatically add the required cluster RBAC permissions for retrieving the custom resource definition and syncing the resources from the host to the virtual cluster.
+vCluster automatically adds the required cluster RBAC permissions for retrieving the custom resource definition and syncing the resources from the host to the virtual cluster.
 :::
 
 For Namespaced Scoped Custom Resources, you need to specify `selector.mappings` in the config. This tells vCluster which host resources should be synced and where (in the virtual cluster).
 
-Namespaces in the virtual cluster will get created automatically during the sync (if they do not exist already).
+Namespaces in the virtual cluster are created automatically during the sync (if they do not exist already).
 
-It is not possible to sync Custom Resources that were already synced from virtual to host, they will be skipped by vCluster.
+It is not possible to sync Custom Resources that were already synced from virtual to host, they are skipped by vCluster.
 
-We will use cert-manager’s CertificateRequest custom resource in our examples.
+Here is an example with cert-manager’s CertificateRequest custom resource.
 
 To sync all CustomResources from a given namespace in the host to the given namespace in the virtual cluster, “namespace/*” wildcard can be used, e.g.:
 
@@ -95,7 +95,7 @@ sync:
             "foo/cm-name": "bar/cm-name"
 ```
 
-There is also a handy syntax to sync all CustomResources from vCluster’s own host namespace to the virtual namespace. As vCluster’s namespace is not always known upfront (e.g. when vCluster is created by vCluster Platform), `""` (empty string) is treated as “vCluster’s own host namespace”.
+There is also a handy syntax to sync all CustomResources from vCluster’s own host namespace to the virtual namespace. As vCluster’s namespace is not always known upfront (e.g. when vCluster is created by the platform), `""` (empty string) is treated as “vCluster’s own host namespace”.
 
 ```yaml
 sync:
@@ -143,11 +143,11 @@ sync:
             "cert-manager/foo": "my-virtual/my-foo"
 ```
 
-### Pro Patches
+### Pro patches
 
 You can specify `reverseExpression` in the `sync.fromHost.customResources[*].patches` .
 
-They will be applied on the host object and appear in the virtual object.
+They are applied on the host object and appear in the virtual object.
 
 `expressions` have no effect.
 
@@ -170,8 +170,8 @@ sync:
           reverseExpression: "value.startsWith('www.') ? value.slice(4) : value"
 ```
 
-1. Your CustomResource in the host namespace `default` named `my-cm` will be synced to the namespace `barfoo2` in virtual and named `cm-my`.
-2. If `default/my-cm` host object has annotation which value starts with `www.` , e.g.: `my-address: www.loft.sh` then synced object in the virtual cluster `barfoo2/cm-my` will have annotation `my-address: loft.sh` .
+1. Your CustomResource in the host namespace `default` named `my-cm` is synced to the namespace `barfoo2` in virtual and named `cm-my`.
+2. If `default/my-cm` host object has annotation which value starts with `www.` , e.g.: `my-address: www.loft.sh` then synced object in the virtual cluster `barfoo2/cm-my` has annotation `my-address: loft.sh` .
 
 
 <NamespacedCustomResourcesExample/>

--- a/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
@@ -1,0 +1,151 @@
+---
+title: Secrets
+sidebar_label: secrets
+sidebar_position: 11
+description: Configuration for ...
+---
+
+import EnableSwitch from '../../../../_partials/config/sync/fromHost/secrets.mdx'
+import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
+import FromHostSecretExample from '../../../../_fragments/sync-from-host-secret-example.mdx'
+
+By default, this is disabled.
+
+:::info No need to configure RBAC
+vCluster will automatically add the required cluster RBAC permissions for retrieving the custom resource definition and syncing the resources from the host to the virtual cluster.
+:::
+
+Enabling this will allow you to sync Secrets from the specified namespaces in the host to the specified namespaces in the vCluster.
+
+It is also possible to modify the name of the synced resource in the virtual cluster.
+
+There is no option to sync from all namespaces in the host.
+
+Sync is one-directional, from host to virtual. If you modify an object in the host, it will be synced to virtual object. When you delete virtual object, it will get re-created if the host object still exist.
+
+Deleting host object will result in deleting virtual object.
+
+You can use synced Secrets in your workloads as an environment variables source or a volume.
+
+It is not possible to sync Secrets that were already synced from virtual to host, they will be skipped by vCluster.
+
+Namespaces in the virtual cluster will get created automatically during the sync (if they do not exist already).
+
+## Prerequisites
+All the specified namespaces have to exist in the host at the vCluster startup.
+
+
+## Sync all secrets from host namespace
+To sync all Secrets from a given namespace in the host to the given namespace in the virtual cluster, “namespace/*” wildcard can be used, e.g.:
+
+```yaml
+sync:
+  fromHost:
+    secrets:
+      enabled: true
+      selector:
+        mappings:
+          # syncs all Secrets from "foo" namespace
+          # to the "bar" namespace in vCluster. Secrets names are unchanged.
+          "foo/*": "bar/*"
+```
+
+
+## Sync only specific secrets from host namespace(s)
+To sync only specific Secrets from namespaces, you need to provide `namespace/name` as the key and value:
+
+```yaml
+sync:
+  fromHost:
+    secrets:
+      enabled: true
+      selector:
+        mappings:
+          # syncs Secret named "cm-name" from "foo" host namespace
+          # to the "bar" namespace in virtual.
+          "foo/cm-name": "bar/cm-name"
+```
+
+
+## Sync all secrets from vCluster's host namespace
+There is also a handy syntax to sync all Secrets from vCluster’s own host namespace to the virtual namespace. As vCluster’s namespace is not always known upfront (e.g. when vCluster is created by vCluster Platform), `""` (empty string) is treated as “vCluster’s own host namespace”.
+
+```yaml
+sync:
+  fromHost:
+    secrets:
+      enabled: true
+      selector:
+        mappings:
+          # syncs all Secrets from vCluster's host namespace
+          # to "my-virtual" namespace in vCluster.
+          "": "my-virtual"
+```
+
+
+## Sync specific secret(s) from vCluster's host namespace
+you can also specify only a few Secrets from vCluster’s own host namespace this way:
+
+```yaml
+sync:
+  fromHost:
+    secrets:
+      enabled: true
+      selector:
+        mappings:
+          # syncs Secret named "my-cm" from vCluster's host namespace
+          # to "my-virtual-namespace" in vCluster.
+          "/my-cm": "my-virtual/my-cm"
+```
+
+## Modify synced secret namespace and name in the virtual cluster
+It’s also possible to modify Secret name during the sync:
+
+```yaml
+sync:
+  fromHost:
+    secrets:
+      enabled: true
+      selector:
+        mappings:
+          # syncs "config" Secret from "cert-manager" namespace in the host
+          # as "my-config" in "my-virtual" namespace in vCluster.
+          "cert-manager/config": "my-virtual/my-config"
+```
+
+## Pro patches
+
+<ProAdmonition/>
+
+You can specify `reverseExpression` in the `sync.fromHost.secrets.patches` .
+
+They will be applied on the host object and appear in the virtual object.
+
+`expressions` have no effect.
+
+So, for the following `vcluster.yaml` :
+
+```yaml
+sync:
+  fromHost:
+    secrets:
+      enabled: true
+      selector:
+        mappings:
+          "default/my-cm": "barfoo2/cm-my"
+      patches:
+        - path: metadata.annotations[*]
+          #expression: '"my-prefix-"+value'
+          # optional reverseExpression to reverse the change from the host cluster
+          reverseExpression: "value.startsWith('www.') ? value.slice(4) : value"
+```
+
+1. Your Secret in the host namespace `default` named `my-cm` will be synced to the namespace `barfoo2` in virtual and named `cm-my`.
+2. If `default/my-cm` host object has annotation which value starts with `www.` , e.g.: `my-address: www.loft.sh` then synced object in the virtual cluster `barfoo2/cm-my` will have annotation `my-address: loft.sh` .
+
+
+<FromHostSecretExample />
+
+## Config reference
+
+<EnableSwitch/>

--- a/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
@@ -8,6 +8,7 @@ description: Configuration for ...
 import EnableSwitch from '../../../../_partials/config/sync/fromHost/secrets.mdx'
 import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 import FromHostSecretExample from '../../../../_fragments/sync-from-host-secret-example.mdx'
+import BasePrerequisites from '../../../../docs/_partials/base-prerequisites.mdx';
 
 By default, this is turned off.
 
@@ -15,8 +16,9 @@ By default, this is turned off.
 vCluster automatically adds the required cluster RBAC permissions for retrieving the Secrets and syncing the resources from the host to the virtual cluster.
 :::
 
-Enabling this allows you to sync Secrets from the specified namespaces in the host to the specified namespaces in the vCluster.
-```yaml title="vcluster.yaml"
+Enabling sync from host allows you to sync Secrets from the specified namespaces in the host cluster to the specified namespaces in a virtual cluster.
+Here is how the required configuration in `vcluster.yam` looks like:
+```yaml title="configure Secret sync from host"
 sync:
   fromHost:
     secrets:
@@ -24,30 +26,31 @@ sync:
       selector:
         mappings:
           # syncs all Secrets from "foo" namespace
-          # to the "bar" namespace in vCluster. Secrets names are unchanged.
+          # to the "bar" namespace in a virtual cluster. Secrets names are unchanged.
           "foo/*": "bar/*"
 ```
 
+Here are a few things to remember when configuring the sync:
 - It is also possible to modify the name of the synced resource in the virtual cluster.
 - There is no option to sync from all namespaces in the host.
 - Sync is one-directional, from host to virtual. If you modify an object in the host, vCluster syncs the change to virtual object.
 - When you delete a virtual object, vCluster re-creates it if the host object still exist.
 - When you delete a host object, vCluster deletes the corresponding virtual object.
-
-It is not possible to sync Secrets that were already synced from virtual to host, they are skipped by vCluster.
+- It is not possible to sync Secrets that were already synced from virtual to host, they are skipped by vCluster.
 
 Namespaces in the virtual cluster are created automatically during the sync (if they do not exist already).
 
 You can use synced Secrets in your workloads as an environment variables source or a volume.
 
 ## Prerequisites
+<BasePrerequisites />
 All the specified namespaces have to exist in the host at the vCluster startup.
 
 
 ## Sync all Secrets from host namespace
-To sync all Secrets from a given namespace in the host to the given namespace in the virtual cluster, “namespace/*” wildcard can be used, e.g.:
+To sync all Secrets from a given namespace in the host to the given namespace in the virtual cluster, use “namespace/*” wildcard, e.g.:
 
-```yaml
+```yaml title="configure Secret sync from host namespace"
 sync:
   fromHost:
     secrets:
@@ -55,7 +58,7 @@ sync:
       selector:
         mappings:
           # syncs all Secrets from "foo" namespace
-          # to the "bar" namespace in vCluster. Secrets names are unchanged.
+          # to the "bar" namespace in a virtual cluster. Secrets names are unchanged.
           "foo/*": "bar/*"
 ```
 
@@ -63,7 +66,7 @@ sync:
 ## Sync only specific Secrets from host namespace
 To sync only specific Secrets from namespaces, you need to provide `namespace/name` as the key and value:
 
-```yaml
+```yaml title="configure Secret sync from host for one object"
 sync:
   fromHost:
     secrets:
@@ -76,41 +79,41 @@ sync:
 ```
 
 
-## Sync all Secrets from vCluster's host namespace
-There is also a handy syntax to sync all Secrets from vCluster’s own host namespace to the virtual namespace. As vCluster’s namespace is not always known upfront (e.g. when vCluster is created by the platform), `""` (empty string) is treated as “vCluster’s own host namespace”.
+## Sync all Secrets from virtual cluster's host namespace
+There is also a handy syntax to sync all Secrets from virtual cluster’s own host namespace to the virtual namespace. As virtual cluster’s namespace is not always known upfront (e.g. when virtual cluster is created by the platform), `""` (empty string) is treated as “virtual cluster’s own host namespace”.
 
-```yaml
+```yaml title="configure Secret sync from host for virtual cluster's namespace"
 sync:
   fromHost:
     secrets:
       enabled: true
       selector:
         mappings:
-          # syncs all Secrets from vCluster's host namespace
-          # to "my-virtual" namespace in vCluster.
+          # syncs all Secrets from virtual cluster's host namespace
+          # to "my-virtual" namespace in a virtual cluster.
           "": "my-virtual"
 ```
 
 
-## Sync specific Secret from vCluster's host namespace
-you can also specify only a few Secrets from vCluster’s own host namespace this way:
+## Sync specific Secret from virtual cluster's host namespace
+you can also specify only a few Secrets from virtual cluster’s own host namespace this way:
 
-```yaml
+```yaml title="configure Secret sync from host for objects in virtual cluster's namespace"
 sync:
   fromHost:
     secrets:
       enabled: true
       selector:
         mappings:
-          # syncs Secret named "my-cm" from vCluster's host namespace
-          # to "my-virtual-namespace" in vCluster.
+          # syncs Secret named "my-cm" from virtual cluster's host namespace
+          # to "my-virtual-namespace" in a virtual cluster.
           "/my-cm": "my-virtual/my-cm"
 ```
 
 ## Modify synced Secret namespace and name in the virtual cluster
 It’s also possible to modify Secret name during the sync:
 
-```yaml
+```yaml title="configure Secret sync from host and modify name and namespace"
 sync:
   fromHost:
     secrets:
@@ -118,11 +121,11 @@ sync:
       selector:
         mappings:
           # syncs "config" Secret from "cert-manager" namespace in the host
-          # as "my-config" in "my-virtual" namespace in vCluster.
+          # as "my-config" in "my-virtual" namespace in a virtual cluster.
           "cert-manager/config": "my-virtual/my-config"
 ```
 
-## Pro patches
+## Patches
 
 <ProAdmonition/>
 
@@ -134,7 +137,7 @@ They are applied on the host object and appear in the virtual object.
 
 So, for the following `vcluster.yaml` :
 
-```yaml
+```yaml title="configure Secret sync from host with patches"
 sync:
   fromHost:
     secrets:

--- a/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
@@ -12,30 +12,39 @@ import FromHostSecretExample from '../../../../_fragments/sync-from-host-secret-
 By default, this is turned off.
 
 :::info No need to configure RBAC
-vCluster automatically adds the required cluster RBAC permissions for retrieving the secrets and syncing the resources from the host to the virtual cluster.
+vCluster automatically adds the required cluster RBAC permissions for retrieving the Secrets and syncing the resources from the host to the virtual cluster.
 :::
 
 Enabling this allows you to sync Secrets from the specified namespaces in the host to the specified namespaces in the vCluster.
+```yaml title="vcluster.yaml"
+sync:
+  fromHost:
+    secrets:
+      enabled: true
+      selector:
+        mappings:
+          # syncs all Secrets from "foo" namespace
+          # to the "bar" namespace in vCluster. Secrets names are unchanged.
+          "foo/*": "bar/*"
+```
 
-It is also possible to modify the name of the synced resource in the virtual cluster.
-
-There is no option to sync from all namespaces in the host.
-
-Sync is one-directional, from host to virtual. If you modify an object in the host, vCluster syncs the change to virtual object. When you delete a virtual object, vCluster re-creates it if the host object still exist.
-
-When you delete a host object, vCluster deletes the corresponding virtual object.
-
-You can use synced Secrets in your workloads as an environment variables source or a volume.
+- It is also possible to modify the name of the synced resource in the virtual cluster.
+- There is no option to sync from all namespaces in the host.
+- Sync is one-directional, from host to virtual. If you modify an object in the host, vCluster syncs the change to virtual object.
+- When you delete a virtual object, vCluster re-creates it if the host object still exist.
+- When you delete a host object, vCluster deletes the corresponding virtual object.
 
 It is not possible to sync Secrets that were already synced from virtual to host, they are skipped by vCluster.
 
 Namespaces in the virtual cluster are created automatically during the sync (if they do not exist already).
 
+You can use synced Secrets in your workloads as an environment variables source or a volume.
+
 ## Prerequisites
 All the specified namespaces have to exist in the host at the vCluster startup.
 
 
-## Sync all secrets from host namespace
+## Sync all Secrets from host namespace
 To sync all Secrets from a given namespace in the host to the given namespace in the virtual cluster, “namespace/*” wildcard can be used, e.g.:
 
 ```yaml
@@ -51,7 +60,7 @@ sync:
 ```
 
 
-## Sync only specific secrets from host namespace
+## Sync only specific Secrets from host namespace
 To sync only specific Secrets from namespaces, you need to provide `namespace/name` as the key and value:
 
 ```yaml
@@ -67,7 +76,7 @@ sync:
 ```
 
 
-## Sync all secrets from vCluster's host namespace
+## Sync all Secrets from vCluster's host namespace
 There is also a handy syntax to sync all Secrets from vCluster’s own host namespace to the virtual namespace. As vCluster’s namespace is not always known upfront (e.g. when vCluster is created by the platform), `""` (empty string) is treated as “vCluster’s own host namespace”.
 
 ```yaml
@@ -83,7 +92,7 @@ sync:
 ```
 
 
-## Sync specific secret from vCluster's host namespace
+## Sync specific Secret from vCluster's host namespace
 you can also specify only a few Secrets from vCluster’s own host namespace this way:
 
 ```yaml
@@ -98,7 +107,7 @@ sync:
           "/my-cm": "my-virtual/my-cm"
 ```
 
-## Modify synced secret namespace and name in the virtual cluster
+## Modify synced Secret namespace and name in the virtual cluster
 It’s also possible to modify Secret name during the sync:
 
 ```yaml
@@ -135,7 +144,6 @@ sync:
           "default/my-cm": "barfoo2/cm-my"
       patches:
         - path: metadata.annotations[*]
-          #expression: '"my-prefix-"+value'
           # optional reverseExpression to reverse the change from the host cluster
           reverseExpression: "value.startsWith('www.') ? value.slice(4) : value"
 ```

--- a/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
@@ -9,27 +9,27 @@ import EnableSwitch from '../../../../_partials/config/sync/fromHost/secrets.mdx
 import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 import FromHostSecretExample from '../../../../_fragments/sync-from-host-secret-example.mdx'
 
-By default, this is disabled.
+By default, this is turned off.
 
 :::info No need to configure RBAC
-vCluster will automatically add the required cluster RBAC permissions for retrieving the custom resource definition and syncing the resources from the host to the virtual cluster.
+vCluster automatically adds the required cluster RBAC permissions for retrieving the secrets and syncing the resources from the host to the virtual cluster.
 :::
 
-Enabling this will allow you to sync Secrets from the specified namespaces in the host to the specified namespaces in the vCluster.
+Enabling this allows you to sync Secrets from the specified namespaces in the host to the specified namespaces in the vCluster.
 
 It is also possible to modify the name of the synced resource in the virtual cluster.
 
 There is no option to sync from all namespaces in the host.
 
-Sync is one-directional, from host to virtual. If you modify an object in the host, it will be synced to virtual object. When you delete virtual object, it will get re-created if the host object still exist.
+Sync is one-directional, from host to virtual. If you modify an object in the host, vCluster syncs the change to virtual object. When you delete virtual object, vCluster re-creates it if the host object still exist.
 
-Deleting host object will result in deleting virtual object.
+When you delete host object, vCluster deletes virtual object.
 
 You can use synced Secrets in your workloads as an environment variables source or a volume.
 
-It is not possible to sync Secrets that were already synced from virtual to host, they will be skipped by vCluster.
+It is not possible to sync Secrets that were already synced from virtual to host, they are skipped by vCluster.
 
-Namespaces in the virtual cluster will get created automatically during the sync (if they do not exist already).
+Namespaces in the virtual cluster are created automatically during the sync (if they do not exist already).
 
 ## Prerequisites
 All the specified namespaces have to exist in the host at the vCluster startup.
@@ -51,7 +51,7 @@ sync:
 ```
 
 
-## Sync only specific secrets from host namespace(s)
+## Sync only specific secrets from host namespace
 To sync only specific Secrets from namespaces, you need to provide `namespace/name` as the key and value:
 
 ```yaml
@@ -68,7 +68,7 @@ sync:
 
 
 ## Sync all secrets from vCluster's host namespace
-There is also a handy syntax to sync all Secrets from vCluster’s own host namespace to the virtual namespace. As vCluster’s namespace is not always known upfront (e.g. when vCluster is created by vCluster Platform), `""` (empty string) is treated as “vCluster’s own host namespace”.
+There is also a handy syntax to sync all Secrets from vCluster’s own host namespace to the virtual namespace. As vCluster’s namespace is not always known upfront (e.g. when vCluster is created by the platform), `""` (empty string) is treated as “vCluster’s own host namespace”.
 
 ```yaml
 sync:
@@ -83,7 +83,7 @@ sync:
 ```
 
 
-## Sync specific secret(s) from vCluster's host namespace
+## Sync specific secret from vCluster's host namespace
 you can also specify only a few Secrets from vCluster’s own host namespace this way:
 
 ```yaml
@@ -119,7 +119,7 @@ sync:
 
 You can specify `reverseExpression` in the `sync.fromHost.secrets.patches` .
 
-They will be applied on the host object and appear in the virtual object.
+They are applied on the host object and appear in the virtual object.
 
 `expressions` have no effect.
 
@@ -140,8 +140,8 @@ sync:
           reverseExpression: "value.startsWith('www.') ? value.slice(4) : value"
 ```
 
-1. Your Secret in the host namespace `default` named `my-cm` will be synced to the namespace `barfoo2` in virtual and named `cm-my`.
-2. If `default/my-cm` host object has annotation which value starts with `www.` , e.g.: `my-address: www.loft.sh` then synced object in the virtual cluster `barfoo2/cm-my` will have annotation `my-address: loft.sh` .
+1. Your Secret in the host namespace `default` named `my-cm` is synced to the namespace `barfoo2` in virtual and named `cm-my`.
+2. If `default/my-cm` host object has annotation which value starts with `www.` , e.g.: `my-address: www.loft.sh` then synced object in the virtual cluster `barfoo2/cm-my` has annotation `my-address: loft.sh` .
 
 
 <FromHostSecretExample />

--- a/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
@@ -8,7 +8,7 @@ description: Configuration for ...
 import EnableSwitch from '../../../../_partials/config/sync/fromHost/secrets.mdx'
 import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 import FromHostSecretExample from '../../../../_fragments/sync-from-host-secret-example.mdx'
-import BasePrerequisites from '../../../../docs/_partials/base-prerequisites.mdx';
+import BasePrerequisites from '../../../../../docs/_partials/base-prerequisites.mdx'
 
 By default, this is turned off.
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
@@ -21,9 +21,9 @@ It is also possible to modify the name of the synced resource in the virtual clu
 
 There is no option to sync from all namespaces in the host.
 
-Sync is one-directional, from host to virtual. If you modify an object in the host, vCluster syncs the change to virtual object. When you delete virtual object, vCluster re-creates it if the host object still exist.
+Sync is one-directional, from host to virtual. If you modify an object in the host, vCluster syncs the change to virtual object. When you delete a virtual object, vCluster re-creates it if the host object still exist.
 
-When you delete host object, vCluster deletes virtual object.
+When you delete a host object, vCluster deletes the corresponding virtual object.
 
 You can use synced Secrets in your workloads as an environment variables source or a volume.
 


### PR DESCRIPTION
# Content Description
1. Adds docs for  config maps from host sync
2. Adds a fragment with a guide how to use config map from host sync
3. Adds docs for secrets from host sync
4. Adds a fragment with a guide how to use secret from host sync
5. Adds docs for namespaced custom resources from host sync
2. Adds a fragment with a guide how to use namespaced custom resources from host sync


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [From Host Sync Docs Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-401

