### PR TITLE
fix: typo in vcluster.yaml

### DIFF
--- a/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
@@ -17,7 +17,7 @@ vCluster automatically adds the required cluster RBAC permissions for retrieving
 :::
 
 Enabling sync from host allows you to sync ConfigMaps from the specified namespaces in the host cluster to the specified namespaces in a virtual cluster.
-Here is how the required configuration in `vcluster.yam` looks like:
+Here is how the required configuration in `vcluster.yaml` looks like:
 ```yaml title="configure ConfigMap sync from host"
 sync:
   fromHost:

--- a/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
@@ -17,7 +17,7 @@ vCluster automatically adds the required cluster RBAC permissions for retrieving
 :::
 
 Enabling sync from host allows you to sync Secrets from the specified namespaces in the host cluster to the specified namespaces in a virtual cluster.
-Here is how the required configuration in `vcluster.yam` looks like:
+Here is how the required configuration in `vcluster.yaml` looks like:
 ```yaml title="configure Secret sync from host"
 sync:
   fromHost:


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

