### PR TITLE
rename selector.mappings to mappings.byName in the from host sync con…

### DIFF
--- a/vcluster/_fragments/sync-from-host-configmap-example.mdx
+++ b/vcluster/_fragments/sync-from-host-configmap-example.mdx
@@ -38,8 +38,8 @@ sync:
   fromHost:
     configMaps:
       enabled: true
-      selector:
-        mappings:
+      mappings:
+        byName:
           "foobar2/config": "my-namespace/config"
 ```
 

--- a/vcluster/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
+++ b/vcluster/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
@@ -89,8 +89,8 @@ sync:
       examples.demo.loft.sh:
         enabled: true
         scope: Namespaced
-        selector:
-          mappings:
+        mappings:
+          byName:
             "": "default"
 ```
 

--- a/vcluster/_fragments/sync-from-host-secret-example.mdx
+++ b/vcluster/_fragments/sync-from-host-secret-example.mdx
@@ -40,8 +40,8 @@ sync:
   fromHost:
     secrets:
       enabled: true
-      selector:
-        mappings:
+      mappings:
+        byName:
           "foobar/shared-user-env": "my-namespace/user-env"
 ```
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
@@ -59,8 +59,8 @@ sync:
   fromHost:
     configMaps:
       enabled: true
-      selector:
-        mappings:
+      mappings:
+        byName:
           # syncs all ConfigMaps from "foo" namespace
           # to the "bar" namespace in a virtual cluster. ConfigMaps names are unchanged.
           "foo/*": "bar/*"
@@ -74,8 +74,8 @@ sync:
   fromHost:
     configMaps:
       enabled: true
-      selector:
-        mappings:
+      mappings:
+        byName:
           # syncs ConfigMap named "cm-name" from "foo" host namespace
           # to the "bar" namespace in virtual.
           "foo/cm-name": "bar/cm-name"
@@ -89,8 +89,8 @@ sync:
   fromHost:
     configMaps:
       enabled: true
-      selector:
-        mappings:
+      mappings:
+        byName:
           # syncs all ConfigMaps from virtual cluster's host namespace
           # to "my-virtual" namespace in a virtual cluster.
           "": "my-virtual"
@@ -104,8 +104,8 @@ sync:
   fromHost:
     configMaps:
       enabled: true
-      selector:
-        mappings:
+      mappings:
+        byName:
           # syncs ConfigMap named "my-cm" from virtual cluster's host namespace
           # to "my-virtual-namespace" in a virtual cluster.
           "/my-cm": "my-virtual/my-cm"
@@ -119,8 +119,8 @@ sync:
   fromHost:
     configMaps:
       enabled: true
-      selector:
-        mappings:
+      mappings:
+        byName:
           # syncs "config" ConfigMap from "cert-manager" namespace in the host
           # as "my-config" in "my-virtual" namespace in a virtual cluster.
           "cert-manager/config": "my-virtual/my-config"
@@ -143,8 +143,8 @@ sync:
   fromHost:
     configMaps:
       enabled: true
-      selector:
-        mappings:
+      mappings:
+        byName:
           "default/my-cm": "barfoo2/cm-my"
       patches:
         - path: metadata.annotations[*]

--- a/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
@@ -43,8 +43,8 @@ sync:
       certificaterequests.cert-manager.io:
         enabled: true
         scope: Namespaced
-        selector:
-          mappings:
+        mappings:
+          byName:
             # syncs all CertificateRequests from "foo" namespace
             # to the "bar" namespace in a virtual cluster. CertificateRequests names are unchanged.
             "foo/*": "bar/*"
@@ -69,7 +69,7 @@ Namespaces in the virtual cluster are created automatically during the sync (if 
 vCluster automatically adds the required cluster RBAC permissions for retrieving the CustomResourceDefinition and syncing the resources from the host to the virtual cluster.
 :::
 
-For Namespace scoped CustomResources, you need to specify `selector.mappings` in the config. This tells vCluster which host resources should be synced and where (in the virtual cluster).
+For Namespace scoped CustomResources, you need to specify `mappings.byName` in the config. This tells vCluster which host resources should be synced and where (in the virtual cluster).
 
 Namespaces in the virtual cluster are created automatically during the sync (if they do not exist already).
 
@@ -86,8 +86,8 @@ sync:
       certificaterequests.cert-manager.io:
         enabled: true
         scope: Namespaced
-        selector:
-          mappings:
+        mappings:
+          byName:
             # syncs all CertificateRequests from "foo" namespace
             # to the "bar" namespace in a virtual cluster. CertificateRequests names are unchanged.
             "foo/*": "bar/*"
@@ -102,8 +102,8 @@ sync:
       certificaterequests.cert-manager.io:
         enabled: true
         scope: Namespaced
-        selector:
-          mappings:
+        mappings:
+          byName:
             # syncs CertificateRequest named "cm-name" from "foo" host namespace
             # to the "bar" namespace in virtual.
             "foo/cm-name": "bar/cm-name"
@@ -118,8 +118,8 @@ sync:
       certificaterequests.cert-manager.io:
         enabled: true
         scope: Namespaced
-        selector:
-          mappings:
+        mappings:
+          byName:
             # syncs all CertificateRequests from virtual cluster's host namespace
             # to "my-virtual" namespace in a virtual cluster.
             "": "my-virtual"
@@ -134,8 +134,8 @@ sync:
       certificaterequests.cert-manager.io:
         enabled: true
         scope: Namespaced
-        selector:
-          mappings:
+        mappings:
+          byName:
             # syncs CertificateRequest named "my-cm" from virtual cluster's host namespace
             # to "my-virtual-namespace" in a virtual cluster.
             "/my-cm": "my-virtual/my-cm"
@@ -150,8 +150,8 @@ sync:
       certificaterequests.cert-manager.io:
         enabled: true
         scope: Namespaced
-        selector:
-          mappings:
+        mappings:
+          byName:
             # syncs "foo" CertificateRequest from "cert-manager" namespace in the host
             # as "my-foo" in "my-virtual" namespace in a virtual cluster.
             "cert-manager/foo": "my-virtual/my-foo"
@@ -174,8 +174,8 @@ sync:
       certificaterequests.cert-manager.io:
         enabled: true
         scope: Namespaced
-        selector:
-          mappings:
+        mappings:
+          byName:
             "default/my-cm": "barfoo2/cm-my"
         patches:
           - path: metadata.annotations[*]

--- a/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
@@ -23,8 +23,8 @@ sync:
   fromHost:
     secrets:
       enabled: true
-      selector:
-        mappings:
+      mappings:
+        byName:
           # syncs all Secrets from "foo" namespace
           # to the "bar" namespace in a virtual cluster. Secrets names are unchanged.
           "foo/*": "bar/*"
@@ -55,8 +55,8 @@ sync:
   fromHost:
     secrets:
       enabled: true
-      selector:
-        mappings:
+      mappings:
+        byName:
           # syncs all Secrets from "foo" namespace
           # to the "bar" namespace in a virtual cluster. Secrets names are unchanged.
           "foo/*": "bar/*"
@@ -71,8 +71,8 @@ sync:
   fromHost:
     secrets:
       enabled: true
-      selector:
-        mappings:
+      mappings:
+        byName:
           # syncs Secret named "cm-name" from "foo" host namespace
           # to the "bar" namespace in virtual.
           "foo/cm-name": "bar/cm-name"
@@ -87,8 +87,8 @@ sync:
   fromHost:
     secrets:
       enabled: true
-      selector:
-        mappings:
+      mappings:
+        byName:
           # syncs all Secrets from virtual cluster's host namespace
           # to "my-virtual" namespace in a virtual cluster.
           "": "my-virtual"
@@ -103,8 +103,8 @@ sync:
   fromHost:
     secrets:
       enabled: true
-      selector:
-        mappings:
+      mappings:
+        byName:
           # syncs Secret named "my-cm" from virtual cluster's host namespace
           # to "my-virtual-namespace" in a virtual cluster.
           "/my-cm": "my-virtual/my-cm"
@@ -118,8 +118,8 @@ sync:
   fromHost:
     secrets:
       enabled: true
-      selector:
-        mappings:
+      mappings:
+        byName:
           # syncs "config" Secret from "cert-manager" namespace in the host
           # as "my-config" in "my-virtual" namespace in a virtual cluster.
           "cert-manager/config": "my-virtual/my-config"
@@ -142,8 +142,8 @@ sync:
   fromHost:
     secrets:
       enabled: true
-      selector:
-        mappings:
+      mappings:
+        byName:
           "default/my-cm": "barfoo2/cm-my"
       patches:
         - path: metadata.annotations[*]


### PR DESCRIPTION
# Content Description
rename selector.mappings to mappings.byName in the from host sync configuration


## Preview Link 
[docs preview](https://netlify.preview/docs/xxxx)


## Internal Reference
part of ENG-5885

next RC will update partials accordingly

