### PR TITLE
chore: generate partials for reuse-namespace config for main

### DIFF
--- a/hack/vcluster/partials/main.go
+++ b/hack/vcluster/partials/main.go
@@ -95,6 +95,7 @@ var paths = []string{
 	"controlPlane/backingStore/database/external",
 	"controlPlane/backingStore",
 	"controlPlane",
+	"reuseNamespace",
 }
 
 func main() {

--- a/vcluster/_partials/config/reuseNamespace.mdx
+++ b/vcluster/_partials/config/reuseNamespace.mdx
@@ -1,0 +1,14 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+## `reuseNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#reuseNamespace}
+
+ReuseNamespace allows reusing the same namespace to create multiple vClusters.
+This flag is deprecated, as this scenario will be removed entirely in upcoming releases.
+
+</summary>
+
+
+
+</details>


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
There is an addition of a config `reuse-namespace` regarding multiple vcluster creation inside the same namespace. This PR generates the partials for that.


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC- (regarding [ENG-5363](https://linear.app/loft/issue/ENG-5363/deprecate-multiple-vclusters-per-namespace#comment-c95bcf55))

