### PR TITLE
feat: enterprise pricing admonitions

### DIFF
--- a/src/css/general.scss
+++ b/src/css/general.scss
@@ -10,6 +10,37 @@ body {
   --ifm-footer-background-color: var(--ifm-color-secondary);
 }
 
+.enterprise-starter .alert--info {
+  background: #fff0e4;
+  border-left-color: #EB7A23;
+}
+
+.enterprise-advanced .alert--info {
+  background: #fff0e4;
+  border-left-color: #EB7A23;
+}
+
+.enterprise-ultimate .alert--info {
+  background: #fff0e4;
+  border-left-color: #EB7A23;
+}
+
+.enterprise-starter .alert--info svg,
+.enterprise-advanced .alert--info svg,
+.enterprise-ultimate .alert--info svg {
+  background: url('/media/vcluster_symbol_dark_2.svg');
+  background-size: contain;
+  width: 24px;
+  height: 24px;
+  color: transparent;
+  fill: transparent;
+}
+
+.enterprise-ultimate .alert--info {
+  background: #fff0e4;
+  border-left-color: #EB7A23;
+}
+
 .embed-container {
   position: relative;
   padding-bottom: 56.25%;

--- a/src/css/sidebar.scss
+++ b/src/css/sidebar.scss
@@ -14,7 +14,7 @@
     position: relative;
 
     &::after {
-      content: "PRO";
+      content: "ENTERPRISE";
 
       // Technical settings:
       display: block;

--- a/vcluster/_partials/admonitions/pro-advanced-admonition.mdx
+++ b/vcluster/_partials/admonitions/pro-advanced-admonition.mdx
@@ -4,7 +4,7 @@ import Admonition from '@theme/Admonition';
 <div class="enterprise-advanced">
 :::info Enterprise-Only Feature
 
-Description: This feature is available exclusively in vCluster Enterprise Advanced and Ultimate plans. Learn more about our [pricing plans](https://www.vcluster.com/pricing) or [contact our sales team](https://www.vcluster.com/enterprise-demo) to explore how vCluster Enterprise can support your needs.
+This feature is only available in the vCluster Enterprise Advanced and Ultimate plans. See our [pricing plans](https://www.vcluster.com/pricing) or [contact our sales team](https://www.vcluster.com/enterprise-demo) for more information.
 
 :::
 </div>

--- a/vcluster/_partials/admonitions/pro-advanced-admonition.mdx
+++ b/vcluster/_partials/admonitions/pro-advanced-admonition.mdx
@@ -1,0 +1,10 @@
+import Admonition from '@theme/Admonition';
+
+<br></br>
+<div class="enterprise-advanced">
+:::info Enterprise-Only Feature
+
+Description: This feature is available exclusively in vCluster Enterprise Advanced and Ultimate plans. Learn more about our [pricing plans](https://www.vcluster.com/pricing) or [contact our sales team](https://www.vcluster.com/enterprise-demo) to explore how vCluster Enterprise can support your needs.
+
+:::
+</div>

--- a/vcluster/_partials/admonitions/pro-starter-admonition.mdx
+++ b/vcluster/_partials/admonitions/pro-starter-admonition.mdx
@@ -4,7 +4,7 @@ import Admonition from '@theme/Admonition';
 <div class="enterprise-starter">
 :::info Enterprise-Only Feature
 
-Description: This feature is available exclusively in vCluster Enterprise Starter, Advanced and Ultimate plans. Learn more about our [pricing plans](https://www.vcluster.com/pricing) or [contact our sales team](https://www.vcluster.com/enterprise-demo) to explore how vCluster Enterprise can support your needs.
+This feature is only available in the vCluster Enterprise Starter, Advanced, and Ultimate plans. See our [pricing plans](https://www.vcluster.com/pricing) or [contact our sales team](https://www.vcluster.com/enterprise-demo) for more information.
 
 :::
 </div>

--- a/vcluster/_partials/admonitions/pro-starter-admonition.mdx
+++ b/vcluster/_partials/admonitions/pro-starter-admonition.mdx
@@ -1,0 +1,10 @@
+import Admonition from '@theme/Admonition';
+
+<br></br>
+<div class="enterprise-starter">
+:::info Enterprise-Only Feature
+
+Description: This feature is available exclusively in vCluster Enterprise Starter, Advanced and Ultimate plans. Learn more about our [pricing plans](https://www.vcluster.com/pricing) or [contact our sales team](https://www.vcluster.com/enterprise-demo) to explore how vCluster Enterprise can support your needs.
+
+:::
+</div>

--- a/vcluster/_partials/admonitions/pro-ultimate-admonition.mdx
+++ b/vcluster/_partials/admonitions/pro-ultimate-admonition.mdx
@@ -1,0 +1,10 @@
+import Admonition from '@theme/Admonition';
+
+<br></br>
+<div class="enterprise-ultimate">
+:::info Enterprise-Only Feature
+
+Description: This feature is available exclusively in vCluster Enterprise Ultimate plans. Learn more about our [pricing plans](https://www.vcluster.com/pricing) or [contact our sales team](https://www.vcluster.com/enterprise-demo) to explore how vCluster Enterprise can support your needs.
+
+:::
+</div>

--- a/vcluster/_partials/admonitions/pro-ultimate-admonition.mdx
+++ b/vcluster/_partials/admonitions/pro-ultimate-admonition.mdx
@@ -4,7 +4,7 @@ import Admonition from '@theme/Admonition';
 <div class="enterprise-ultimate">
 :::info Enterprise-Only Feature
 
-Description: This feature is available exclusively in vCluster Enterprise Ultimate plans. Learn more about our [pricing plans](https://www.vcluster.com/pricing) or [contact our sales team](https://www.vcluster.com/enterprise-demo) to explore how vCluster Enterprise can support your needs.
+This feature is only available in the vCluster Enterprise Ultimate plans. See our [pricing plans](https://www.vcluster.com/pricing) or [contact our sales team](https://www.vcluster.com/enterprise-demo) for more information.
 
 :::
 </div>


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- rename sidebar pro label to enterprise
- introduce custom enterprise admonitions

The admonitions can be referenced as separate partials on any page. Will be versioned with vcluster versions.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
N/A

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-452

