### PR TITLE
feat: remove latest release column from vcluster support matrix table

### DIFF
--- a/docs/_partials/vcluster_supported_versions.mdx
+++ b/docs/_partials/vcluster_supported_versions.mdx
@@ -3,11 +3,11 @@ active support, it moves to into maintenance support for 3 months, where only se
 
 ## vCluster releases
 
-| Release | Released | Active Support End Date | Maintenance Support End Date | Latest Release |
-|---|---|---|---|---|
-| v0.22 | December 18, 2024 | March 18, 2025 | June 18, 2025 | v0.22.0 |
-| v0.21 | November 11, 2024 | February 11, 2025 | May 11, 2025 | v0.21.3 |
-| v0.20 | August 14, 2024 | November 14, 2024 | February 14, 2025 | v0.20.5
-| v0.19 | February 12, 2024 | April 1, 2025* | July 1, 2025 | v0.19.9 |
+| Release | Released | Active Support End Date | Maintenance Support End Date |
+|---|---|---|---|
+| v0.22 | December 18, 2024 | March 18, 2025 | June 18, 2025 |
+| v0.21 | November 11, 2024 | February 11, 2025 | May 11, 2025 |
+| v0.20 | August 14, 2024 | November 14, 2024 | February 14, 2025 |
+| v0.19 | February 12, 2024 | April 1, 2025* | July 1, 2025 |
 
 \* Due to the number of breaking changes from v0.19 to v0.20, v0.19 has an extended active support end date. Review the [migration guide](/vcluster/reference/migrations/0-20-migration) to upgrade your v0.19 to v0.20 virtual clusters.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- remove latest release column from vcluster support matrix table
- since this is a partial, it will affect all the documents that reference it

```plaintext
vcluster_versioned_docs/version-0.20.0/deploy/supported_versions.mdx
vcluster_versioned_docs/version-0.22.0/deploy/supported_versions.mdx
vcluster_versioned_docs/version-0.21.0/deploy/supported_versions.mdx
vcluster/deploy/upgrade/supported_versions.mdx
```

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[vCluster releases](https://deploy-preview-470--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/upgrade/supported_versions#vcluster-releases)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-461

