### PR TITLE
added the port in server url for exported kubeconfig

### DIFF
--- a/vcluster/configure/vcluster-yaml/export-kube-config.mdx
+++ b/vcluster/configure/vcluster-yaml/export-kube-config.mdx
@@ -42,7 +42,7 @@ In this example:
 ```yaml
 exportKubeConfig:
   context: my-domain-context
-  server: https://my-domain.org
+  server: https://my-domain.org:443
   secret:
     name: vc-my-domain
 ```
@@ -60,7 +60,7 @@ In this example:
 ```yaml
 exportKubeConfig:
   context: my-domain-context
-  server: https://my-domain.org
+  server: https://my-domain.org:443
   secret:
     namespace: kubeconfig-secret-namespace
     name: vc-my-domain


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Added port in server url as per https://github.com/loft-sh/vcluster/blob/main/pkg/cli/connect_helm.go#L366


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

