### PR TITLE
fix: Add UI and CLI options for share

### DIFF
--- a/platform/_partials/vcluster/share-cli.mdx
+++ b/platform/_partials/vcluster/share-cli.mdx
@@ -1,4 +1,6 @@
 To grant a user access to a virtual cluster with Loft CLI, run the following command:
 ```bash
-loft share vcluster [optional:name] --user other-user --project my-project
+vcluster platform share vcluster VCLUSTER_NAME [flags]
 ```
+
+See the [Loft CLI documentation](/vcluster/cli/vcluster_platform_share_vcluster) for more information.

--- a/platform/_partials/vcluster/share-cli.mdx
+++ b/platform/_partials/vcluster/share-cli.mdx
@@ -1,0 +1,4 @@
+To grant a user access to a virtual cluster with Loft CLI, run the following command:
+```bash
+loft share vcluster [optional:name] --user other-user --project my-project
+```

--- a/platform/_partials/vcluster/share-ui.mdx
+++ b/platform/_partials/vcluster/share-ui.mdx
@@ -1,3 +1,16 @@
+import Flow, { Step } from "@site/src/components/Flow";
+import NavStep from "@site/src/components/NavStep";
+import Button from "@site/src/components/Button";
+import Label from "@site/src/components/Label";
+
+import FragmentProjectSelect from "../../_fragments/ui-steps/project-select.mdx"
+import FragmentVirtualClustertSelect from "../../_fragments/ui-steps/virtual-cluster-select.mdx"
+import FragmentVirtualClustertNew from "../../_fragments/ui-steps/virtual-cluster-new.mdx"
+
+import PartialVirtualClusterUseCLI from "./use-vcluster.mdx";
+import PartialVirtualClusterCreateOptionalUI from "./create-ui-optional-fields.mdx";
+
+
 <Flow id="vcluster-share-ui">
   <Step>
     From the project drop-down menu (top left corner), select the project to find your virtual cluster.

--- a/platform/_partials/vcluster/share-ui.mdx
+++ b/platform/_partials/vcluster/share-ui.mdx
@@ -1,0 +1,25 @@
+<Flow id="vcluster-share-ui">
+  <Step>
+    From the project drop-down menu (top left corner), select the project to find your virtual cluster.
+  </Step>
+  <Step>
+    Click <NavStep>Virtual Clusters</NavStep>.
+  </Step>
+  <Step>
+    Click <Label>Edit</Label> on the virtual cluster that you want to edit.
+  </Step>
+  <Step>
+    Click <NavStep>Permissions</NavStep>.
+    </Step>
+  <Step>
+    Click <Label>Add Permission </Label> to input and select the user or team to add. If the user or team you want to grant access to is not listed, verify that they have access to the project.
+  </Step>
+  <Step>
+    Specify the <Label>Cluster Role</Label> you want to assign the user or team.
+  </Step>
+  <Step>
+    After specifying all virtual options, click {" "}
+    <Button>Save Changes</Button>.
+  </Step>
+</Flow>
+

--- a/platform/use-platform/virtual-clusters/add-virtual-clusters.mdx
+++ b/platform/use-platform/virtual-clusters/add-virtual-clusters.mdx
@@ -1,5 +1,5 @@
 ---
-title: Add Existing Virtual Clusters
+title: Add existing virtual clusters
 sidebar_label: Add Existing
 sidebar_position: 2
 ---

--- a/platform/use-platform/virtual-clusters/create/create-no-template.mdx
+++ b/platform/use-platform/virtual-clusters/create/create-no-template.mdx
@@ -1,5 +1,5 @@
 ---
-title: Manually Configure a Virtual Cluster
+title: Manually configure a virtual cluster
 sidebar_label: Configure Manually
 sidebar_position: 2
 ---

--- a/platform/use-platform/virtual-clusters/create/create-with-template.mdx
+++ b/platform/use-platform/virtual-clusters/create/create-with-template.mdx
@@ -1,5 +1,5 @@
 ---
-title: Create Virtual Cluster from a Template
+title: Create a virtual cluster from a template
 sidebar_label: Create Using Template
 sidebar_position: 1
 ---

--- a/platform/use-platform/virtual-clusters/manage-access.mdx
+++ b/platform/use-platform/virtual-clusters/manage-access.mdx
@@ -17,6 +17,8 @@ import PartialVirtualClusterShareCLI from '../../_partials/vcluster/share-cli.md
 
 Grant users or teams access to a virtual cluster using either the Loft UI or CLI. 
 
+<br />
+
 <Tabs
     defaultValue="ui"
     values={[

--- a/platform/use-platform/virtual-clusters/manage-access.mdx
+++ b/platform/use-platform/virtual-clusters/manage-access.mdx
@@ -20,8 +20,8 @@ Grant users or teams access to a virtual cluster using either the Loft UI or CLI
 <Tabs
     defaultValue="ui"
     values={[
-      {label: 'UI', value: 'ui'},
-      {label: 'CLI', value: 'cli'},
+      {label: 'Using the UI', value: 'ui'},
+      {label: 'Using the CLI', value: 'cli'},
     ]}>
     <TabItem value="ui">
       <PartialVirtualClusterShareUI/>

--- a/platform/use-platform/virtual-clusters/manage-access.mdx
+++ b/platform/use-platform/virtual-clusters/manage-access.mdx
@@ -1,5 +1,5 @@
 ---
-title: Share Access to the Virtual Cluster
+title: Share access to the virtual cluster
 sidebar_label: Share Access
 sidebar_position: 4
 ---
@@ -14,6 +14,8 @@ import PartialVirtualClusterShareUI from '../../_partials/vcluster/share-ui.mdx'
 import PartialVirtualClusterShareCLI from '../../_partials/vcluster/share-cli.mdx'
 
 # Grant access to a virtual cluster
+
+Grant users or teams access to a virtual cluster using either the Loft UI or CLI. 
 
 <Tabs
     defaultValue="ui"

--- a/platform/use-platform/virtual-clusters/manage-access.mdx
+++ b/platform/use-platform/virtual-clusters/manage-access.mdx
@@ -13,7 +13,7 @@ import Button from "@site/src/components/Button";
 import PartialVirtualClusterShareUI from '../../_partials/vcluster/share-ui.mdx'
 import PartialVirtualClusterShareCLI from '../../_partials/vcluster/share-cli.mdx'
 
-# Grant Access to a virtual cluster
+# Grant access to a virtual cluster
 
 <Tabs
     defaultValue="ui"

--- a/platform/use-platform/virtual-clusters/manage-access.mdx
+++ b/platform/use-platform/virtual-clusters/manage-access.mdx
@@ -10,32 +10,21 @@ import Flow, { Step } from "@site/src/components/Flow";
 import NavStep from "@site/src/components/NavStep";
 import Label from "@site/src/components/Label";
 import Button from "@site/src/components/Button";
+import PartialVirtualClusterShareUI from '../../_partials/vcluster/share-ui.mdx'
+import PartialVirtualClusterShareCLI from '../../_partials/vcluster/share-cli.mdx'
 
 # Grant Access to a virtual cluster
 
-<Flow id="vcluster-share-ui">
-  <Step>
-    From the project drop-down menu (top left corner), select the project to find your virtual cluster.
-  </Step>
-  <Step>
-    Click on <NavStep>Virtual Clusters</NavStep>.
-  </Step>
-  <Step>
-    Click on <Label>Edit</Label> on the virtual cluster that you want to edit.
-  </Step>
-  <Step>
-    Click on the <NavStep>Permissions</NavStep>.
-    </Step>
-  <Step>
-    Click the <Label>Add Permission to"</Label> input and select the user or team to add. If you don't see the user or team you want to grant access in there,
-    confirm that they have project access.
-  </Step>
-  <Step>
-    Specify the <Label>Cluster Role</Label> you want to assign the user or team.
-  </Step>
-  <Step>
-    Once all virtual options have been specified, click the{" "}
-    <Button>Save Changes</Button>.
-  </Step>
-</Flow>
-
+<Tabs
+    defaultValue="ui"
+    values={[
+      {label: 'UI', value: 'ui'},
+      {label: 'CLI', value: 'cli'},
+    ]}>
+    <TabItem value="ui">
+      <PartialVirtualClusterShareUI/>
+    </TabItem>
+    <TabItem value="cli">
+      <PartialVirtualClusterShareCLI/>
+    </TabItem>
+</Tabs>

--- a/platform/use-platform/virtual-clusters/retrieve-kube-config.mdx
+++ b/platform/use-platform/virtual-clusters/retrieve-kube-config.mdx
@@ -4,11 +4,9 @@ sidebar_label: Connect
 sidebar_position: 3
 ---
 
-To "use" a virtual cluster, as in connect to the virtual cluster Kubernetes API server, you can
-manually construct a kubeconfig or use the vCluster CLI to automatically create and update your
-kubeconfig.
+To connect to a virtual cluster's Kubernetes API server, you can either manually create a kubeconfig file or use the vCluster CLI to generate and update it automatically.
 
-## Retrieve via vcluster CLI
+## Retrieve using the vCluster CLI
 
 The easiest way to retrieve a kubeconfig for your virtual cluster is by using the vCluster CLI.
 
@@ -34,7 +32,7 @@ If you have direct [cluster endpoints](../../administer/clusters/advanced/multi-
 enabled, the resulting kubeconfig will look different.
 :::
 
-## Create the Kubeconfig Without the CLI
+## Create kubeconfig without the CLI
 
 You can also create a kubeconfig manually by creating an [access key](../../administer/users-permissions/access-keys.mdx) for
 your user first and then using the following template, with the following placeholders:
@@ -44,7 +42,7 @@ your user first and then using the following template, with the following placeh
 - **$LOFT_HOST**: the loft host you connect to
 - **$ACCESS_KEY**: the access key to use
 
-Then replace these placeholders in the following template and save it as `my-kubeconfig.yaml`:
+Then replace the placeholders in the following template and save the configuration as `my-kubeconfig.yaml`:
 
 ```yaml
 apiVersion: v1
@@ -67,7 +65,7 @@ users:
       token: $ACCESS_KEY
 ```
 
-You can then access your virtual cluster by using the freshly created kubeconfig file:
+You can access your virtual cluster by using the freshly created kubeconfig file:
 
 ```bash
 KUBECONFIG=my-kubeconfig.yaml kubectl get namespaces

--- a/platform/use-platform/virtual-clusters/retrieve-kube-config.mdx
+++ b/platform/use-platform/virtual-clusters/retrieve-kube-config.mdx
@@ -1,5 +1,5 @@
 ---
-title: Get Kubeconfig File for your Virtual Cluster
+title: Get a kubeconfig file for your virtual cluster
 sidebar_label: Connect
 sidebar_position: 3
 ---


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

Makes the Ui procedure into an partial and adds CLI step


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

[Link to preview](https://deploy-preview-476--vcluster-docs-site.netlify.app/docs/platform/use-platform/virtual-clusters/manage-access/?x0=2)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-222

