### PR TITLE
fix: update doc to address linter notes

### DIFF
--- a/.github/styles/Google/FirstPerson.yml
+++ b/.github/styles/Google/FirstPerson.yml
@@ -9,5 +9,4 @@ tokens:
   - (?:^|\s)I,\s
   - \bI'm\b
   - \bme\b
-  - \bmy\b
   - \bmine\b

--- a/vcluster/configure/vcluster-yaml/export-kube-config.mdx
+++ b/vcluster/configure/vcluster-yaml/export-kube-config.mdx
@@ -1,5 +1,5 @@
 ---
-title: Export Kube-Config
+title: Export kubeconfig
 sidebar_label: exportKubeConfig
 sidebar_position: 3
 ---

--- a/vcluster/configure/vcluster-yaml/export-kube-config.mdx
+++ b/vcluster/configure/vcluster-yaml/export-kube-config.mdx
@@ -6,10 +6,12 @@ sidebar_position: 3
 
 import ExportKubeConfig from '../../_partials/config/exportKubeConfig.mdx'
 
-Customize how vCluster exports the kubeconfig file to a secret, so you can use it, for example, in your ArgoCD or Terraform pipelines.
+Customize how vCluster exports the kubeconfig file to a secret for use in tools like ArgoCD or Terraform pipelines.
 
-vCluster always creates a kubeconfig in a secret called `vc-NAME` in the namespace where you deployed vCluster. Configure `exportKubeConfig` so vCluster creates an additional secret with the given configuration.
+By default, vCluster stores the kubeconfig in a secret named `vc-NAME` within the namespace where vCluster is deployed. 
+To create an additional secret with a specified configuration, configure `exportKubeConfig`.
 
+<!-- vale off -->
 {/*
 `--kube-config-context-name` is now the `context` property:
   - https://github.com/loft-sh/vcluster/issues/554 is the issue where this was requested
@@ -19,7 +21,7 @@ vCluster always creates a kubeconfig in a secret called `vc-NAME` in the namespa
 `--out-kube-config-secret-namespace` is now the `secret.namespace` property.
   - It appears in the "Tip" at the bottom of this section: https://www.vcluster.com/docs/using-vclusters/kube-context#retrieving-the-kube-config-from-the-vcluster-secret
 `--out-kube-config-secret` is now the `secret.name` property:
-  - It did not have a section in the old docs, but has been part of vcluster from the initial commit, and has always been set to `vc-{{ .Release.Name }}` by the helm chart.
+  - It did not have a section in the old docs, but has been part of vcluster from the initial commit, and has always been set to `vc-{{ .Release.Name }}` by the Helm chart.
   - We may not want people changing this.
 
 <br/>
@@ -31,13 +33,15 @@ vCluster always creates a kubeconfig in a secret called `vc-NAME` in the namespa
 | `--out-kube-config-secret`           | `secret.name`      | You can configure the secret's name, which otherwise uses the `vc-<cluster-name>` pattern.   |
 */}
 
-## Example using the same namespace for the secret
+<!-- vale on -->
 
-In this example:
+## Using the same namespace for the secret
 
-- You want to call this kubeconfig context `my-domain-context`.
-- You have exposed the virtual cluster on `https://my-domain.org` and want the kubeconfig to use that endpoint.
-- You named your cluster "my-cluster" but you want the secret's name to reflect the virtual cluster domain name.
+The following example configures a virtual cluster to use a specific kubeconfig context, server endpoint, and secret name within the same namespace:
+
+- Set the kubeconfig context name to `my-domain-context`.
+- Configure the kubeconfig to use `https://my-domain.org:443` as the endpoint for the exposed virtual cluster.
+- Ensure the secret name reflects the virtual cluster domain name instead of the default cluster name, "my-cluster".
 
 ```yaml
 exportKubeConfig:
@@ -47,15 +51,18 @@ exportKubeConfig:
     name: vc-my-domain
 ```
 
-## Example using a new namespace for the secret
+## Using a new namespace for the secret
 
-In this example:
+The following example configures a virtual cluster to store the kubeconfig secret in a separate namespace while maintaining proper access control:
 
-- You want to call this kubeconfig context `my-domain-context`.
-- You have exposed the virtual cluster on `https://my-domain.org` and want the kubeconfig to use that endpoint.
-- You created a namespace called `kubeconfig-secret-namespace` for the secret.
-- You named your cluster "my-cluster" but you want the secret's name to reflect the virtual cluster domain name.
-- You have acccess to the new namespace by creating a role and rolebinding pointing to the vCluster service account. Make sure that the new role has the same permissions as the vCluster app's role in the vCluster app's namespace. You can copy them directly from the ones created by vCluster when you deployed vCluster. vCluster permissions are dynamic, so updating some configurations may require you to update the unmanaged role in the target namespace.
+- Set the kubeconfig context name to `my-domain-context`.
+- Configure the kubeconfig to use `https://my-domain.org:443` as the virtual cluster endpoint.
+- Create a namespace called `kubeconfig-secret-namespace` to store the secret.
+- Name the secret `vc-my-domain` instead of using the default cluster name "my-cluster".
+- Additionally, grant access to the new namespace by creating a `Role` and `RoleBinding` for the vCluster service account:
+  - Configure the new role with the same permissions assigned to the vCluster app role in the original namespace.
+  - If needed, copy permissions from the default vCluster deployment.
+  - When vCluster permissions change, update the unmanaged role in the target namespace accordingly.
 
 ```yaml
 exportKubeConfig:

--- a/vcluster_versioned_docs/version-0.22.0/configure/vcluster-yaml/export-kube-config.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/configure/vcluster-yaml/export-kube-config.mdx
@@ -1,15 +1,17 @@
 ---
-title: Export Kube-Config
+title: Export kubeconfig
 sidebar_label: exportKubeConfig
 sidebar_position: 3
 ---
 
 import ExportKubeConfig from '../../_partials/config/exportKubeConfig.mdx'
 
-Customize how vCluster exports the kubeconfig file to a secret, so you can use it, for example, in your ArgoCD or Terraform pipelines.
+Customize how vCluster exports the kubeconfig file to a secret for use in tools like ArgoCD or Terraform pipelines.
 
-vCluster always creates a kubeconfig in a secret called `vc-NAME` in the namespace where you deployed vCluster. Configure `exportKubeConfig` so vCluster creates an additional secret with the given configuration.
+By default, vCluster stores the kubeconfig in a secret named `vc-NAME` within the namespace where vCluster is deployed. 
+To create an additional secret with a specified configuration, configure `exportKubeConfig`.
 
+<!-- vale off -->
 {/*
 `--kube-config-context-name` is now the `context` property:
   - https://github.com/loft-sh/vcluster/issues/554 is the issue where this was requested
@@ -19,7 +21,7 @@ vCluster always creates a kubeconfig in a secret called `vc-NAME` in the namespa
 `--out-kube-config-secret-namespace` is now the `secret.namespace` property.
   - It appears in the "Tip" at the bottom of this section: https://www.vcluster.com/docs/using-vclusters/kube-context#retrieving-the-kube-config-from-the-vcluster-secret
 `--out-kube-config-secret` is now the `secret.name` property:
-  - It did not have a section in the old docs, but has been part of vcluster from the initial commit, and has always been set to `vc-{{ .Release.Name }}` by the helm chart.
+  - It did not have a section in the old docs, but has been part of vcluster from the initial commit, and has always been set to `vc-{{ .Release.Name }}` by the Helm chart.
   - We may not want people changing this.
 
 <br/>
@@ -31,36 +33,41 @@ vCluster always creates a kubeconfig in a secret called `vc-NAME` in the namespa
 | `--out-kube-config-secret`           | `secret.name`      | You can configure the secret's name, which otherwise uses the `vc-<cluster-name>` pattern.   |
 */}
 
-## Example using the same namespace for the secret
+<!-- vale on -->
 
-In this example:
+## Using the same namespace for the secret
 
-- You want to call this kubeconfig context `my-domain-context`.
-- You have exposed the virtual cluster on `https://my-domain.org` and want the kubeconfig to use that endpoint.
-- You named your cluster "my-cluster" but you want the secret's name to reflect the virtual cluster domain name.
+The following example configures a virtual cluster to use a specific kubeconfig context, server endpoint, and secret name within the same namespace:
+
+- Set the kubeconfig context name to `my-domain-context`.
+- Configure the kubeconfig to use `https://my-domain.org:443` as the endpoint for the exposed virtual cluster.
+- Ensure the secret name reflects the virtual cluster domain name instead of the default cluster name, "my-cluster".
 
 ```yaml
 exportKubeConfig:
   context: my-domain-context
-  server: https://my-domain.org
+  server: https://my-domain.org:443
   secret:
     name: vc-my-domain
 ```
 
-## Example using a new namespace for the secret
+## Using a new namespace for the secret
 
-In this example:
+The following example configures a virtual cluster to store the kubeconfig secret in a separate namespace while maintaining proper access control:
 
-- You want to call this kubeconfig context `my-domain-context`.
-- You have exposed the virtual cluster on `https://my-domain.org` and want the kubeconfig to use that endpoint.
-- You created a namespace called `kubeconfig-secret-namespace` for the secret.
-- You named your cluster "my-cluster" but you want the secret's name to reflect the virtual cluster domain name.
-- You have acccess to the new namespace by creating a role and rolebinding pointing to the vCluster service account. Make sure that the new role has the same permissions as the vCluster app's role in the vCluster app's namespace. You can copy them directly from the ones created by vCluster when you deployed vCluster. vCluster permissions are dynamic, so updating some configurations may require you to update the unmanaged role in the target namespace.
+- Set the kubeconfig context name to `my-domain-context`.
+- Configure the kubeconfig to use `https://my-domain.org:443` as the virtual cluster endpoint.
+- Create a namespace called `kubeconfig-secret-namespace` to store the secret.
+- Name the secret `vc-my-domain` instead of using the default cluster name "my-cluster".
+- Additionally, grant access to the new namespace by creating a `Role` and `RoleBinding` for the vCluster service account:
+  - Configure the new role with the same permissions assigned to the vCluster app role in the original namespace.
+  - If needed, copy permissions from the default vCluster deployment.
+  - When vCluster permissions change, update the unmanaged role in the target namespace accordingly.
 
 ```yaml
 exportKubeConfig:
   context: my-domain-context
-  server: https://my-domain.org
+  server: https://my-domain.org:443
   secret:
     namespace: kubeconfig-secret-namespace
     name: vc-my-domain
@@ -69,3 +76,4 @@ exportKubeConfig:
 ## Config reference
 
 <ExportKubeConfig />
+


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
 Follow up PR to address linter issues and text from [PR 445](https://github.com/loft-sh/vcluster-docs/pull/475/files)

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Link to preview](https://deploy-preview-477--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/export-kube-config/) 


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-466

