### PR TITLE
Fixed minor documentation errors in vcluster platform(v4.x)

### DIFF
--- a/platform/api/authentication.mdx
+++ b/platform/api/authentication.mdx
@@ -8,7 +8,7 @@ import PartialAccessKeyCreateUI from './_partials/access-key/create-ui.mdx'
 
 ## Access Keys
 
-Access keys let you authenticate with vCluster Platform API endpoints and vCluster CLI in non-interactive environments such as from within CI/CD pipelines.
+Access keys let you authenticate with vCluster platform API endpoints and vCluster CLI in non-interactive environments such as from within CI/CD pipelines.
 
 
 ## Create Access Key
@@ -20,7 +20,7 @@ Access keys let you authenticate with vCluster Platform API endpoints and vClust
 
 ### Log in via CLI
 
-You can use an access key to log into vCluster Platform from non-interactive environments:
+You can use an access key to log into vCluster platform from non-interactive environments:
 ```bash
 vcluster platform login [domain] --access-key=[ACCESS_KEY]
 

--- a/platform/api/authentication.mdx
+++ b/platform/api/authentication.mdx
@@ -6,21 +6,21 @@ sidebar_position: 1
 
 import PartialAccessKeyCreateUI from './_partials/access-key/create-ui.mdx'
 
-## Access Keys
+## Access keys
 
-Access keys let you authenticate with the platform API endpoints and vCluster CLI in non-interactive environments such as from within CI/CD pipelines.
+Access keys allow you to authenticate with the platform API endpoints and the vCluster CLI in non-interactive environments, for example, in CI/CD pipelines.
 
 
-## Create Access Key
+## Create an access key
 
 <PartialAccessKeyCreateUI/>
 
+## Use access keys
 
-## Use Access Key
-
-### Log in via CLI
+### Log in using the CLI
 
 You can use an access key to log into the platform from non-interactive environments:
+
 ```bash
 vcluster platform login [domain] --access-key=[ACCESS_KEY]
 
@@ -31,17 +31,11 @@ vcluster platform connect management
 kubectl get users
 ```
 
-### Optional: Create Kube-Context manually
+### Manually create kube config
 
-You can create the kube config also manually by creating an access key for
-your user first and then using the following template, with the following placeholders:
+Optionally, you can manually create your kube config by first generating an access key and then using the following template:  
 
-* **$LOFT_HOST**: the loft host you connect to
-* **$ACCESS_KEY**: the access key to use
-
-Then replace these placeholders in the following template and save it as `my-kube-config.yaml`:
-
-```yaml
+```yaml title="my-kube-config.yaml"
 apiVersion: v1
 kind: Config
 clusters:
@@ -62,7 +56,15 @@ users:
     token: $ACCESS_KEY
 ```
 
-You can then access your virtual cluster by using the freshly created kube config file:
+Replace the following placeholders:
+
+* `$LOFT_URL`: the loft host you connect to
+* `$ACCESS_KEY`: the access key
+
+Save the modified template as `my-kube-config.yaml`. 
+
+You can access your virtual cluster using the newly created kube config file:
+
 ```bash
 KUBECONFIG=my-kube-config.yaml kubectl get users
 ```

--- a/platform/api/authentication.mdx
+++ b/platform/api/authentication.mdx
@@ -8,7 +8,7 @@ import PartialAccessKeyCreateUI from './_partials/access-key/create-ui.mdx'
 
 ## Access Keys
 
-Access keys let you authenticate with Loft API endpoints and vCluster CLI in non-interactive environments such as from within CI/CD pipelines.
+Access keys let you authenticate with vCluster Platform API endpoints and vCluster CLI in non-interactive environments such as from within CI/CD pipelines.
 
 
 ## Create Access Key
@@ -20,12 +20,12 @@ Access keys let you authenticate with Loft API endpoints and vCluster CLI in non
 
 ### Log in via CLI
 
-You can use an access key to log into Loft from non-interactive environments:
+You can use an access key to log into vCluster Platform from non-interactive environments:
 ```bash
-loft login [domain] --access-key=[ACCESS_KEY]
+vcluster platform login [domain] --access-key=[ACCESS_KEY]
 
 # Retrieve management API kube-context afterwards:
-loft use management
+vcluster platform connect management
 
 # Retrieve users
 kubectl get users

--- a/platform/api/authentication.mdx
+++ b/platform/api/authentication.mdx
@@ -8,7 +8,7 @@ import PartialAccessKeyCreateUI from './_partials/access-key/create-ui.mdx'
 
 ## Access Keys
 
-Access keys let you authenticate with vCluster platform API endpoints and vCluster CLI in non-interactive environments such as from within CI/CD pipelines.
+Access keys let you authenticate with the platform API endpoints and vCluster CLI in non-interactive environments such as from within CI/CD pipelines.
 
 
 ## Create Access Key
@@ -20,7 +20,7 @@ Access keys let you authenticate with vCluster platform API endpoints and vClust
 
 ### Log in via CLI
 
-You can use an access key to log into vCluster platform from non-interactive environments:
+You can use an access key to log into the platform from non-interactive environments:
 ```bash
 vcluster platform login [domain] --access-key=[ACCESS_KEY]
 

--- a/platform/api/resources/config.mdx
+++ b/platform/api/resources/config.mdx
@@ -5,7 +5,7 @@ sidebar_label: Loft Config
 import Reference from "../_partials/resources/config/reference.mdx"
 import Retrieve from "../_partials/resources/config/retrieve.mdx"
 
-You can retrieve the Loft config through this API.
+You can retrieve the vCluster Platform config through this API.
 
 ## Example Config
 

--- a/platform/api/resources/config.mdx
+++ b/platform/api/resources/config.mdx
@@ -5,7 +5,7 @@ sidebar_label: Loft Config
 import Reference from "../_partials/resources/config/reference.mdx"
 import Retrieve from "../_partials/resources/config/retrieve.mdx"
 
-You can retrieve the vCluster Platform config through this API.
+You can retrieve the platform config through this API.
 
 ## Example Config
 

--- a/platform/api/resources/config.mdx
+++ b/platform/api/resources/config.mdx
@@ -5,11 +5,10 @@ sidebar_label: Loft Config
 import Reference from "../_partials/resources/config/reference.mdx"
 import Retrieve from "../_partials/resources/config/retrieve.mdx"
 
-You can retrieve the platform config through this API.
+You can retrieve the platform configuration using this API.
 
-## Example Config
+## Example config
 
-An example Config:
 ```yaml
 apiVersion: management.loft.sh/v1
 kind: Config
@@ -29,7 +28,7 @@ status:
 
 ```
 
-## Config Reference
+## Config reference
 
 <Reference />
 

--- a/platform/api/resources/team.mdx
+++ b/platform/api/resources/team.mdx
@@ -8,7 +8,7 @@ import Create from "../_partials/resources/teams/create.mdx"
 import Update from "../_partials/resources/teams/update.mdx"
 import Delete from "../_partials/resources/teams/delete.mdx"
 
-Teams are composed of multiple users and define a way to manage cluster access or other objects for multiple users at once. You can assign users automatically to teams by their groups, which can be synced from an authentication provider. Teams can also access Loft through their own access keys and own spaces or other objects.
+Teams are composed of multiple users and define a way to manage cluster access or other objects for multiple users at once. You can assign users automatically to teams by their groups, which can be synced from an authentication provider. Teams can also access vCluster Platform through their own access keys and own spaces or other objects.
 
 ## Example Team
 

--- a/platform/api/resources/team.mdx
+++ b/platform/api/resources/team.mdx
@@ -8,7 +8,7 @@ import Create from "../_partials/resources/teams/create.mdx"
 import Update from "../_partials/resources/teams/update.mdx"
 import Delete from "../_partials/resources/teams/delete.mdx"
 
-Teams are composed of multiple users and define a way to manage cluster access or other objects for multiple users at once. You can assign users automatically to teams by their groups, which can be synced from an authentication provider. Teams can also access vCluster Platform through their own access keys and own spaces or other objects.
+Teams are composed of multiple users and define a way to manage cluster access or other objects for multiple users at once. You can assign users automatically to teams by their groups, which can be synced from an authentication provider. Teams can also access vCluster platform through their own access keys and own spaces or other objects.
 
 ## Example Team
 

--- a/platform/api/resources/team.mdx
+++ b/platform/api/resources/team.mdx
@@ -8,7 +8,7 @@ import Create from "../_partials/resources/teams/create.mdx"
 import Update from "../_partials/resources/teams/update.mdx"
 import Delete from "../_partials/resources/teams/delete.mdx"
 
-Teams are composed of multiple users and define a way to manage cluster access or other objects for multiple users at once. You can assign users automatically to teams by their groups, which can be synced from an authentication provider. Teams can also access vCluster platform through their own access keys and own spaces or other objects.
+Teams are composed of multiple users and define a way to manage cluster access or other objects for multiple users at once. You can assign users automatically to teams by their groups, which can be synced from an authentication provider. Teams can also access the platform through their own access keys and own spaces or other objects.
 
 ## Example Team
 

--- a/platform/api/resources/team.mdx
+++ b/platform/api/resources/team.mdx
@@ -13,6 +13,7 @@ Teams are composed of multiple users and define a way to manage cluster access o
 ## Example Team
 
 An example Team:
+
 ```yaml
 apiVersion: management.loft.sh/v1
 kind: Team
@@ -28,7 +29,6 @@ spec:
   - loft:admins
   username: loftadmins
 status: {}
-
 ```
 
 ## Team Reference

--- a/platform/api/resources/user.mdx
+++ b/platform/api/resources/user.mdx
@@ -8,7 +8,7 @@ import Create from "../_partials/resources/users/create.mdx"
 import Update from "../_partials/resources/users/update.mdx"
 import Delete from "../_partials/resources/users/delete.mdx"
 
-Users that can access Loft.
+Users that can access vCluster Platform.
 
 ## Example User
 

--- a/platform/api/resources/user.mdx
+++ b/platform/api/resources/user.mdx
@@ -8,7 +8,7 @@ import Create from "../_partials/resources/users/create.mdx"
 import Update from "../_partials/resources/users/update.mdx"
 import Delete from "../_partials/resources/users/delete.mdx"
 
-Users that can access vCluster Platform.
+Users that can access the platform.
 
 ## Example User
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Fixed minor changes in documentation that were still referring to loft instead of vCluster platform


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

