### PR TITLE
chore(vale): add missing American spelling words

### DIFF
--- a/.github/styles/Google/AmericanSpelling.yml
+++ b/.github/styles/Google/AmericanSpelling.yml
@@ -43,6 +43,7 @@ swap:
   enrol: enroll
   enrolment: enrollment
   enthral: enthrall
+  fantasise: fantasize
   favourite: favorite
   fibre: fiber
   fillet: filet
@@ -53,6 +54,7 @@ swap:
   grey: gray
   humour: humor
   honour: honor
+  idolise: idolize
   initialled: initialed
   initialling: initialing
   instil: instill


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Add spellings to vale list
    - fantasise vs. fantasize
    - idolise vs. idolize
