### PR TITLE
feat: migrate platform to a different kubernetes cluster

### DIFF
--- a/platform/administer/upgrade-migrate/migrate-to-hostcluster.mdx
+++ b/platform/administer/upgrade-migrate/migrate-to-hostcluster.mdx
@@ -10,28 +10,47 @@ import BasePrerequisites from '../../_partials/install/base-prerequisites.mdx';
 
 This guide explains how to migrate the platform to a different Kubernetes cluster, which may be necessary during cluster decommissioning or cloud platform migration.
 
-## Use cases
-- Decommissioning the cluster where the platform is installed
-- Migrating the platform to a different cluster while cleaning up the original cluster
-- Migrating the platform to a new cluster and keeping the original cluster as a connected cluster
+## When to migrate
 
-## Scope
+Migrating a platform to a new Kubernetes cluster is necessary in certain cases, such as infrastructure upgrades, cluster decommissioning, or scaling needs. Migrate the platform in the following situations :
 
-The platform on a dedicated Kubernetes cluster with its own ingress and DNS record
+- The existing cluster is being decommissioned. The platform must move to a new cluster.
 
-### Out of scope
-The following scenarios require different migration approaches and are not covered in this guide:
-- The platform that uses the Loft router (with hostname `<something.loft.host>`) - requires special DNS handling
-- The platform that is deployed or managed by an automated deployment tool like `ArgoCD` - requires coordination with GitOps workflows
-- The platform with virtual cluster instances running on the same Kubernetes host cluster - these instances require separate migration after the platform migration
-- The destination Kubernetes cluster has a virtual cluster agent - requires agent decommissioning first
+- The platform is migrating to a new cluster. The original cluster is going to be cleaned up.
+
+- The platform is migrating to a new cluster. The original cluster is going to be remain connected.
+
+
+### Migration considerations
+
+:::warning
+IMPORTANT: the platform must run on a dedicated Kubernetes cluster. It must have its own ingress and DNS record before migration. Ensure these conditions are met before proceeding.
+:::
+
+Review the following factors before migrating. These scenarios require a different migration approach.
+
+- **Loft router configurations**
+  If the platform uses the Loft router (`<something.loft.host>`), special DNS handling is required. The DNS records must be updated to reflect the new cluster. Failure to update DNS settings can cause routing issues and service downtime.
+
+- **Automated deployment tools**
+  If the platform is managed by an automated deployment tool such as `ArgoCD`, migration must be coordinated with GitOps workflows. Changes to cluster configuration must be reflected in the repository before deployment. Skipping this step can lead to drift between the declared and actual state of the platform.
+
+- **Virtual cluster dependencies**
+  If the platform has virtual cluster instances running on the same Kubernetes host cluster, these instances do not migrate automatically. They require a separate migration process after the platform has been moved. Migrating only the platform without considering virtual clusters can cause service disruptions and dependency issues.
+
+- **Virtual cluster agent on the destination cluster**
+  If the destination Kubernetes cluster has a virtual cluster agent, it must be decommissioned before migration. The agent can interfere with the new platform installation, potentially leading to scheduling conflicts and unexpected behavior.
+
+Not addressing these considerations before migration can lead to DNS misconfigurations, deployment failures, and conflicts with existing workloads.
 
 ## Prerequisites
 
 ### Base prerequisites
+
 <BasePrerequisites />
 
 ### Platform specific prerequisites
+
 - Storage space for backup (approximately 1GB).
 - Access to DNS management for the platform's domain
 - Only one platform instance can exist per Kubernetes cluster. Do not install the platform twice in the same Kubernetes host cluster.

--- a/platform/administer/upgrade-migrate/migrate-to-hostcluster.mdx
+++ b/platform/administer/upgrade-migrate/migrate-to-hostcluster.mdx
@@ -1,19 +1,19 @@
 ---
 title: Migrate the platform to a different cluster
-sidebar_label: Migrate to a different cluster
+sidebar_label: Migrate Clusters
 sidebar_position: 1
-description: Learn how to migrate vcluster platform from one Kubernetes cluster to another.
+description: Learn how to migrate vCluster platform from one Kubernetes cluster to another.
 ---
 
 import Flow, { Step } from '@site/src/components/Flow'
-import BasePrerequisites from '../../docs/_partials/base-prerequisites.mdx';
+import BasePrerequisites from '../../_partials/install/base-prerequisites.mdx';
 
 This guide explains how to migrate the platform to a different Kubernetes cluster, which may be necessary during cluster decommissioning or cloud platform migration.
 
 ## Use cases
 - Decommissioning the cluster where the platform is installed
 - Migrating the platform to a different cluster while cleaning up the original cluster
-- Migrating the platform while preserving virtual clusters or spaces on the original cluster for use as a connected cluster
+- Migrating the platform to a new cluster and keeping the original cluster as a connected cluster
 
 ## Scope
 
@@ -23,7 +23,7 @@ The platform on a dedicated Kubernetes cluster with its own ingress and DNS reco
 The following scenarios require different migration approaches and are not covered in this guide:
 - The platform that uses the Loft router (with hostname `<something.loft.host>`) - requires special DNS handling
 - The platform that is deployed or managed by an automated deployment tool like `ArgoCD` - requires coordination with GitOps workflows
-- The platform has managed virtual cluster instances running on the same Kubernetes host cluster - requires additional instance migration steps
+- The platform with virtual cluster instances running on the same Kubernetes host cluster - these instances require separate migration after the platform migration
 - The destination Kubernetes cluster has a virtual cluster agent - requires agent decommissioning first
 
 ## Prerequisites
@@ -74,13 +74,6 @@ Optional: stop `ArgoCD` sync of any virtual clusters
 [Perform a backup of the source platform](/platform/administer/backup-restore/backup-restore-platform)
 </Step>
 
-<Step>
-Backup the license certificate:
-  ```bash title="Backup license certificate"
-  kubectl get secret loft-cert -n vcluster-platform -o yaml > loft-cert-backup.yaml
-  ```
-</Step>
-
 ### Execute migration
 
 <Step>
@@ -92,10 +85,6 @@ kubectl scale deployment loft --replicas=0 -n vcluster-platform
 </Step>
 
 <Step>
-If the original cluster is going to be connected to the platform: modify the `VirtualClusterInstances` hosted in the platform cluster to reference the new cluster name
-</Step>
-
-<Step>
 [Restore the backup to the new installation](https://www.vcluster.com/docs/platform/administer/backup-restore/backup-restore-platform#restoring-vcluster-platform-from-backup)
 </Step>
 
@@ -103,30 +92,28 @@ If the original cluster is going to be connected to the platform: modify the `Vi
 Apply the license certificate to the new cluster:
 
   ```bash title="Apply license certificate"
-  # Create a clean secret file for the target namespace
+  TARGET_NAMESPACE='vcluster-platform'
+  CA_CERT=$(kubectl get secret loft-cert -n vcluster-platform -o jsonpath="{.data.ca\.crt}")
+  TLS_CERT=$(kubectl get secret loft-cert -n vcluster-platform -o jsonpath="{.data.tls\.crt}")
+  PRIVATE_KEY=$(kubectl get secret loft-cert -n vcluster-platform -o jsonpath="{.data.tls\.key}")
 
-  TARGET_NAMESPACE="vcluster-platform" # Change this to match your target namespace if needed
-
-  # Get the license data from the backup
-  LICENSE_DATA=$(grep -A1 "license:" loft-cert-backup.yaml | tail -n1 | awk '{print $1}')
-  PRIVATE_KEY=$(grep -A1 "privateKey:" loft-cert-backup.yaml | tail -n1 | awk '{print $1}')
-
-  # Create a clean secret file
-  cat << EOF > loft-cert-clean.yaml
+  cat <<EOF > loft-cert-clean.yaml
   apiVersion: v1
   kind: Secret
   metadata:
     name: loft-cert
     namespace: ${TARGET_NAMESPACE}
+  type: kubernetes.io/tls
   data:
-    license: ${LICENSE_DATA}
-    privateKey: ${PRIVATE_KEY}
-  type: Opaque
+    ca.crt: ${CA_CERT}
+    tls.crt: ${TLS_CERT}
+    tls.key: ${PRIVATE_KEY}
   EOF
-
   ```
 
   ```bash title="Apply license certificate"
+  kubectl scale deployment loft --replicas=0 -n vcluster-platform
+  kubectl delete secret loft-cert -n ${TARGET_NAMESPACE} --ignore-not-found
   kubectl create -f loft-cert-clean.yaml
   ```
 

--- a/platform/administer/upgrade-migrate/migrate-to-hostcluster.mdx
+++ b/platform/administer/upgrade-migrate/migrate-to-hostcluster.mdx
@@ -32,7 +32,7 @@ The following scenarios require different migration approaches and are not cover
 <BasePrerequisites />
 
 ### Platform specific prerequisites
-- Storage space for backup (approximately 1GB)
+- Storage space for backup (approximately 1GB).
 - Access to DNS management for the platform's domain
 - Only one platform instance can exist per Kubernetes cluster. Do not install the platform twice in the same Kubernetes host cluster.
 - The migration process requires 15-30 minutes of downtime. Communicate this downtime to end users.

--- a/platform/how-to/migrate-to-hostcluster.mdx
+++ b/platform/how-to/migrate-to-hostcluster.mdx
@@ -1,0 +1,179 @@
+---
+title: Migrate the platform to a different cluster
+sidebar_label: Migrate to a different cluster
+sidebar_position: 1
+description: Learn how to migrate vcluster platform from one Kubernetes cluster to another.
+---
+
+import Flow, { Step } from '@site/src/components/Flow'
+import BasePrerequisites from '../../docs/_partials/base-prerequisites.mdx';
+
+This guide explains how to migrate the platform to a different Kubernetes cluster, which may be necessary during cluster decommissioning or cloud platform migration.
+
+## Use cases
+- Decommissioning the cluster where the platform is installed
+- Migrating the platform to a different cluster while cleaning up the original cluster
+- Migrating the platform while preserving virtual clusters or spaces on the original cluster for use as a connected cluster
+
+## Scope
+
+The platform on a dedicated Kubernetes cluster with its own ingress and DNS record
+
+### Out of scope
+The following scenarios require different migration approaches and are not covered in this guide:
+- The platform that uses the Loft router (with hostname `<something.loft.host>`) - requires special DNS handling
+- The platform that is deployed or managed by an automated deployment tool like `ArgoCD` - requires coordination with GitOps workflows
+- The platform has managed virtual cluster instances running on the same Kubernetes host cluster - requires additional instance migration steps
+- The destination Kubernetes cluster has a virtual cluster agent - requires agent decommissioning first
+
+## Prerequisites
+
+### Base prerequisites
+<BasePrerequisites />
+
+### Platform specific prerequisites
+- Storage space for backup (approximately 1GB)
+- Access to DNS management for the platform's domain
+- Only one platform instance can exist per Kubernetes cluster. Do not install the platform twice in the same Kubernetes host cluster.
+- The migration process requires 15-30 minutes of downtime. Communicate this downtime to end users.
+- The source and destination installations must use the same platform version. Version changes during migration are not supported.
+
+## Migration steps
+
+<Flow id="migration procedure">
+
+### Install the platform in the new cluster
+<Step>
+Configuration
+
+- Use the Helm values from the original installation, making adjustments to values like `ingressClass` or `storageClass` as necessary
+- If your project namespaces have the "loft-p-" prefix, set `projectNamespacePrefix: loft-p-` in your configuration
+</Step>
+
+<Step>
+Installation
+
+Install the platform in the new cluster following the [quick start guide](/platform/install/quick-start-guide).
+
+:::info Avoid DNS conflicts
+When using cloud-managed ingress, use a temporary hostname to prevent conflicts with the running platform instance.
+:::
+</Step>
+
+### Prepare for migration
+
+<Step>
+Send downtime communication to end users
+</Step>
+
+<Step>
+Optional: stop `ArgoCD` sync of any virtual clusters
+</Step>
+
+<Step>
+[Perform a backup of the source platform](/platform/administer/backup-restore/backup-restore-platform)
+</Step>
+
+<Step>
+Backup the license certificate:
+  ```bash title="Backup license certificate"
+  kubectl get secret loft-cert -n vcluster-platform -o yaml > loft-cert-backup.yaml
+  ```
+</Step>
+
+### Execute migration
+
+<Step>
+Scale down the source platform:
+
+```bash title="Scale down the platform deployment"
+kubectl scale deployment loft --replicas=0 -n vcluster-platform
+```
+</Step>
+
+<Step>
+If the original cluster is going to be connected to the platform: modify the `VirtualClusterInstances` hosted in the platform cluster to reference the new cluster name
+</Step>
+
+<Step>
+[Restore the backup to the new installation](https://www.vcluster.com/docs/platform/administer/backup-restore/backup-restore-platform#restoring-vcluster-platform-from-backup)
+</Step>
+
+<Step>
+Apply the license certificate to the new cluster:
+
+  ```bash title="Apply license certificate"
+  # Create a clean secret file for the target namespace
+
+  TARGET_NAMESPACE="vcluster-platform" # Change this to match your target namespace if needed
+
+  # Get the license data from the backup
+  LICENSE_DATA=$(grep -A1 "license:" loft-cert-backup.yaml | tail -n1 | awk '{print $1}')
+  PRIVATE_KEY=$(grep -A1 "privateKey:" loft-cert-backup.yaml | tail -n1 | awk '{print $1}')
+
+  # Create a clean secret file
+  cat << EOF > loft-cert-clean.yaml
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: loft-cert
+    namespace: ${TARGET_NAMESPACE}
+  data:
+    license: ${LICENSE_DATA}
+    privateKey: ${PRIVATE_KEY}
+  type: Opaque
+  EOF
+
+  ```
+
+  ```bash title="Apply license certificate"
+  kubectl create -f loft-cert-clean.yaml
+  ```
+
+</Step>
+<Step>
+Update the hostname in the platform configuration as described in the [configuration guide](https://www.vcluster.com/docs/platform/configure/config#changing-the-lofthost-variable)
+</Step>
+<Step>
+Update the DNS record to point to the new cluster if needed
+</Step>
+<Step>
+If the original cluster is going to be used as a connected cluster: connect it to the new platform installation
+</Step>
+
+</Flow>
+
+## Post-migration validation
+<Flow id="post-migration validation">
+<Step>
+Log in to the platform UI and verify object presence:
+   - Check for all expected projects
+   - Verify user access and permissions
+   - Confirm virtual cluster listings
+</Step>
+<Step>
+Verify license status in the platform UI:
+   - Navigate to Settings → License
+   - Confirm license is active and correct
+</Step>
+<Step>
+Restart platform agents on connected clusters:
+
+  ```bash title="Restart platform agents"
+  kubectl rollout restart deployment loft -n vcluster-platform
+  ```
+</Step>
+<Step>
+Validate the core capabilities of the platform:
+   - Single Sign-on: test login with all configured providers
+   - Log access: verify log retrieval from multiple virtual clusters
+   - Virtual cluster creation: create a test cluster
+   - Sleep mode: test sleep/wake feature
+</Step>
+<Step>
+Optional: restart `ArgoCD` sync if previously stopped
+</Step>
+<Step>
+Send end-of-downtime communication to end users
+</Step>
+</Flow>


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Migrate the platform to a different cluster](https://deploy-preview-492--vcluster-docs-site.netlify.app/docs/platform/administer/upgrade-migrate/migrate-to-hostcluster)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-266

