### PR TITLE
Update connect-helm.mdx - include managementNamespace field in the Cluster resource

### DIFF
--- a/platform/_partials/cluster/connect-helm.mdx
+++ b/platform/_partials/cluster/connect-helm.mdx
@@ -74,6 +74,6 @@ helm upgrade loft vcluster-platform --install \
   --set insecure=$(echo $CLUSTER_ACCESS_KEY | jq -r .insecure)
 ```
 
-This command will automatically install the Platform Agent in the cluster that is your current context.
+This command automatically installs the Platform Agent in the cluster that is your current context.
 However, if you want to connect a cluster that is not your current context, you can append the `--kube-context` flag to specify the context of the cluster you want to connect.
 

--- a/platform/_partials/cluster/connect-helm.mdx
+++ b/platform/_partials/cluster/connect-helm.mdx
@@ -37,6 +37,7 @@ metadata:
 spec:
   displayName: $CLUSTER_NAME
   networkPeer: true
+  managementNamespace: vcluster-platform
 EOF
 ```
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
The helm instructions for the agent installation use "vcluster-platform" as target namespace. The same namespace needs to be set in the Cluster resource in the .spec.managementNamespace otherwise upgrades and configuration changes of the agent will fail.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Document Preview](https://deploy-preview-493--vcluster-docs-site.netlify.app/docs/platform/administer/clusters/connect-cluster?x0=3)