### PR TITLE
fix: update for deprecated login command

### DIFF
--- a/platform/administer/users-permissions/access-keys.mdx
+++ b/platform/administer/users-permissions/access-keys.mdx
@@ -64,5 +64,5 @@ or team has access to already. This is a great option to use for keys generated 
 You can use an access key to login to vCluster Platform via the vCluster CLI:
 
 ```
-vcluster login my-vcluster-platform-url.com --access-key ACCESS_KEY
+vcluster platform login my-vcluster-platform-url.com --access-key ACCESS_KEY
 ```

--- a/platform/administer/users-permissions/managing-users/_partials/user/impersonate-cli.mdx
+++ b/platform/administer/users-permissions/managing-users/_partials/user/impersonate-cli.mdx
@@ -1,11 +1,11 @@
 To use vCluster CLI as the impersonated user, you can run the following command while impersonation is active:
 
 ```bash
-vcluster login localhost:9898 --insecure    # or use your loft.domain.tld instead of localhost, and ideally with a valid SSL cert and without the --insecure flag
+vcluster platform login localhost:9898 --insecure    # or use your loft.domain.tld instead of localhost, and ideally with a valid SSL cert and without the --insecure flag
 ```
 
 You can verify the login and print your user information via:
 
 ```bash
-vcluster login
+vcluster platform login
 ```

--- a/platform/administer/users-permissions/managing-users/impersonate.mdx
+++ b/platform/administer/users-permissions/managing-users/impersonate.mdx
@@ -120,13 +120,13 @@ You can also use the vCluster CLI as the impersonated user, to do this, simply r
 command while the impersonation is active.
 
 ```bash
-vcluster login localhost:9898 --insecure    # or use your loft.domain.tld instead of localhost, and ideally with a valid SSL cert and without the --insecure flag
+vcluster platform login localhost:9898 --insecure    # or use your loft.domain.tld instead of localhost, and ideally with a valid SSL cert and without the --insecure flag
 ```
 
 You can verify the login and print your user information via:
 
 ```bash
-vcluster login
+vcluster platform login
 ```
 
 ### 3. Configure Cluster Access
@@ -154,7 +154,7 @@ cluster:
   </Step>
   <Step>
     Find the user Anna in the list of users. Hover over the blue drop down
-    arrow in the Display Name column and click on the{" "}
+    arrow in the Display Name column and click the{" "}
     <Button>
       <svg
         viewBox="64 64 896 896"

--- a/platform/api/use-api.mdx
+++ b/platform/api/use-api.mdx
@@ -12,7 +12,7 @@ In order to access the vCluster platform management api, you'll need a vCluster 
 After you have obtained an access key, login into vCluster platform and connect to the management API:
 
 ```
-vcluster login [domain] --access-key=[ACCESS_KEY]
+vcluster platform login [domain] --access-key=[ACCESS_KEY]
 
 # Retrieve management API kube-context afterwards:
 vcluster platform connect management

--- a/platform/install/environments/gcp.mdx
+++ b/platform/install/environments/gcp.mdx
@@ -152,7 +152,7 @@ Username: admin
 Password: 9758c908-b931-4edd-b3cb-3f034e50651a  # Change via UI or via: vcluster platform reset password
 
 Login via UI:  https://hyx4907.loft.host
-Login via CLI: vcluster login https://hyx4907.loft.host
+Login via CLI: vcluster platform login https://hyx4907.loft.host
 
 #################################################################
 

--- a/platform/install/quick-start-guide.mdx
+++ b/platform/install/quick-start-guide.mdx
@@ -68,7 +68,7 @@ Password: 27177595-21bc-4ff9-9f3a-51e0f722408b  # Change via UI or via: vcluster
 
 # highlight-start
 Login via UI:  https://hth45c8.loft.host
-Login via CLI: vcluster login https://hth45c8.loft.host
+Login via CLI: vcluster platform login https://hth45c8.loft.host
 # highlight-end
 
 #################################################################
@@ -147,7 +147,7 @@ configuration options.
 While `vcluster platform start` logs you in automatically, you can also manually log in via the CLI:
 
 ```bash title="Platform login"
-vcluster login https://1rtjxak.loft.host      # See `vCluster platform start` output for login credentials and your actual sub-domain name (auto-generated).
+vcluster platform login https://1rtjxak.loft.host      # See `vCluster platform start` output for login credentials and your actual sub-domain name (auto-generated).
 ```
 
 This command opens the browser for signing in using the login data displayed in the output of `vcluster platform start`. Manual login may be necessary if accessing the platform from a different machine or if the automatic login process is interrupted.

--- a/platform/integrations/gitlab-ci.mdx
+++ b/platform/integrations/gitlab-ci.mdx
@@ -32,7 +32,7 @@ e2e:
   stage: test
   before_script:
     # Add --namespace to create a space for the e2e tests, see the tip below.
-    - vcluster login $VCLUSTER_PRO_URL --access-key $VCLUSTER_PRO_ACCESS_KEY
+    - vcluster platform login $VCLUSTER_PRO_URL --access-key $VCLUSTER_PRO_ACCESS_KEY
     - vcluster platform create vcluster "${CI_PROJECT_NAME}-${CI_COMMIT_SHORT_SHA}-${CI_PIPELINE_ID}" --project $VCLUSTER_PRO_PROJECT
     - apk add go make
   script:

--- a/platform/use-platform/troubleshooting/troubleshooting.mdx
+++ b/platform/use-platform/troubleshooting/troubleshooting.mdx
@@ -45,7 +45,7 @@ After that you can access vCluster Platform at `https://localhost:8080`. You can
 to this URL with:
 
 ```bash
-vcluster login localhost:8080 --insecure
+vcluster platform login localhost:8080 --insecure
 ```
 
 If you can access vCluster Platform via port-forwarding only, this is usually an indicator that the problem

--- a/vcluster/_partials/integrations/github-actions-pull-request-devspace.mdx
+++ b/vcluster/_partials/integrations/github-actions-pull-request-devspace.mdx
@@ -19,7 +19,7 @@ jobs:
         env:
           LOFT_URL: ${{ secrets.LOFT_URL }}
           ACCESS_KEY: ${{ secrets.ACCESS_KEY }}
-        run: vcluster login $LOFT_URL --access-key $ACCESS_KEY
+        run: vcluster platform login $LOFT_URL --access-key $ACCESS_KEY
       - name: Create PR Virtual Cluster
         env:
           NAME: repo-${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}
@@ -32,6 +32,6 @@ jobs:
 
 1. The [Setup DevSpace](https://github.com/loft-sh/setup-devspace) action installs the DevSpace CLI.
 2. The [Setup vCluster](https://github.com/loft-sh/setup-vcluster) action is used to install the vCluster CLI.
-3. The `vcluster login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
+3. The `vcluster platform login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
 4. The `vcluster create` command is used to create a unique virtual cluster using information about the pull request in the `default` project. This automatically configures the kube context for the next steps.
 5. Finally, use `devspace run e2e` to perform the needed steps to deploy and test `my-app`.

--- a/vcluster/_partials/integrations/github-actions-vclusters-pull-request-manual.mdx
+++ b/vcluster/_partials/integrations/github-actions-vclusters-pull-request-manual.mdx
@@ -17,7 +17,7 @@ jobs:
         env:
           LOFT_URL: ${{ secrets.LOFT_URL }}
           ACCESS_KEY: ${{ secrets.ACCESS_KEY }}
-        run: vcluster login $LOFT_URL --access-key $ACCESS_KEY
+        run: vcluster platform login $LOFT_URL --access-key $ACCESS_KEY
       - name: Create PR Virtual Cluster
         env:
           NAME: repo-${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}
@@ -37,7 +37,7 @@ jobs:
 **Explanation:**
 
 1. The [Setup vCluster](https://github.com/loft-sh/setup-vcluster) action is used to install the vCluster CLI.
-2. The `vcluster login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions). See [Access Keys](https://www.vcluster.com/docs/platform/administer/users-permissions/access-keys) for help generating a platform access key.
+2. The `vcluster platform login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions). See [Access Keys](https://www.vcluster.com/docs/platform/administer/users-permissions/access-keys) for help generating a platform access key.
 3. The `vcluster create` command is used to create a unique virtual cluster using information about the pull request in the `default` project. This automatically configures the kube context for the next steps.
 4. The next step deploys the application using the runner provided `kubectl` and manifests located under `./kubernetes`.
 5. Before running tests, use `kubectl` to wait for the `the-app` deployment to become ready.

--- a/vcluster/_partials/integrations/github-actions-vclusters-pull-request-use.mdx
+++ b/vcluster/_partials/integrations/github-actions-vclusters-pull-request-use.mdx
@@ -17,7 +17,7 @@ jobs:
         env:
           LOFT_URL: ${{ secrets.LOFT_URL }}
           ACCESS_KEY: ${{ secrets.ACCESS_KEY }}
-        run: vcluster login $LOFT_URL --access-key $ACCESS_KEY
+        run: vcluster platform login $LOFT_URL --access-key $ACCESS_KEY
       - name: Create PR Virtual Cluster
         env:
           NAME: repo-${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}
@@ -33,7 +33,7 @@ jobs:
 **Explanation:**
 
 1. The [Setup vCluster](https://github.com/loft-sh/setup-vcluster) action is used to install the vCluster CLI.
-2. The `vcluster login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
+2. The `vcluster platform login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
 3. The `vcluster create` command is used to create a unique virtual cluster using information about the pull request in the `default` project. This automatically configures the kube context for the next steps. The `--upgrade` flag has been added to reuse the existing virtual cluster and upgrade it to the latest version. Additional flags may be used to control the desired virtual cluster version.
 4. The next step deploys the application using the runner provided `kubectl` and manifests located under `./kubernetes`.
 5. Before running tests, use `kubectl` to wait for the `the-app` deployment to become ready.

--- a/vcluster/cli/0-20-cli-changes.mdx
+++ b/vcluster/cli/0-20-cli-changes.mdx
@@ -129,7 +129,7 @@ This is a list of commands that formerly in the `loft` CLI and now renamed in `v
 
     * `--driver` string : Specifies the driver to use for managing the virtual cluster (helm or platform).
 
- `vcluster login` 
+ `vcluster platform login` 
 
     * `--use-driver` string : Switches the vCluster driver between platform and helm. 
 

--- a/vcluster/cli/vcluster_login.md
+++ b/vcluster/cli/vcluster_login.md
@@ -1,26 +1,26 @@
 ---
-title: "vcluster login --help"
-sidebar_label: vcluster login
+title: "vcluster platform login --help"
+sidebar_label: vcluster platform login
 ---
 
 
-Login to a vCluster platform instance
+Log in to a vCluster platform instance.
 
 ## Synopsis
 
 ```
-vcluster login [VCLUSTER_PLATFORM_HOST] [flags]
+vcluster platform login [VCLUSTER_PLATFORM_HOST] [flags]
 ```
 
 ```
 ########################################################
-#################### vcluster login ####################
+#################### vcluster platform login ####################
 ########################################################
 Login into vCluster platform
 
 Example:
-vcluster login https://my-vcluster-platform.com
-vcluster login https://my-vcluster-platform.com --access-key myaccesskey
+vcluster platform login https://my-vcluster-platform.com
+vcluster platform login https://my-vcluster-platform.com --access-key myaccesskey
 ########################################################
 ```
 

--- a/vcluster_versioned_docs/version-0.20.0/_partials/integrations/github-actions-pull-request-devspace.mdx
+++ b/vcluster_versioned_docs/version-0.20.0/_partials/integrations/github-actions-pull-request-devspace.mdx
@@ -19,7 +19,7 @@ jobs:
         env:
           LOFT_URL: ${{ secrets.LOFT_URL }}
           ACCESS_KEY: ${{ secrets.ACCESS_KEY }}
-        run: vcluster login $LOFT_URL --access-key $ACCESS_KEY
+        run: vcluster platform login $LOFT_URL --access-key $ACCESS_KEY
       - name: Create PR Virtual Cluster
         env:
           NAME: pr-${{ github.event.pull_request.number }}-${{ github.sha }}-${{ github.run_id }}
@@ -32,6 +32,6 @@ jobs:
 
 1. The [Setup DevSpace](https://github.com/loft-sh/setup-devspace) action installs the DevSpace CLI.
 2. The [Setup vCluster](https://github.com/loft-sh/setup-vcluster) action is used to install the vCluster CLI.
-3. The `vcluster login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
+3. The `vcluster platform login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
 4. The `vcluster create` command is used to create a unique virtual cluster using information about the pull request in the `default` project. This automatically configures the kube context for the next steps.
 5. Finally, use `devspace run e2e` to perform the needed steps to deploy and test `my-app`.

--- a/vcluster_versioned_docs/version-0.20.0/_partials/integrations/github-actions-vclusters-pull-request-manual.mdx
+++ b/vcluster_versioned_docs/version-0.20.0/_partials/integrations/github-actions-vclusters-pull-request-manual.mdx
@@ -17,7 +17,7 @@ jobs:
         env:
           LOFT_URL: ${{ secrets.LOFT_URL }}
           ACCESS_KEY: ${{ secrets.ACCESS_KEY }}
-        run: vcluster login $LOFT_URL --access-key $ACCESS_KEY
+        run: vcluster platform login $LOFT_URL --access-key $ACCESS_KEY
       - name: Create PR Virtual Cluster
         env:
           NAME: pr-${{ github.event.pull_request.number }}-${{ github.sha }}-${{ github.run_id }}
@@ -37,7 +37,7 @@ jobs:
 **Explanation:**
 
 1. The [Setup vCluster](https://github.com/loft-sh/setup-vcluster) action is used to install the vCluster CLI.
-2. The `vcluster login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions). See [Access Keys](https://www.vcluster.com/docs/platform/administer/users-permissions/access-keys) for help generating a platform access key.
+2. The `vcluster platform login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions). See [Access Keys](https://www.vcluster.com/docs/platform/administer/users-permissions/access-keys) for help generating a platform access key.
 3. The `vcluster create` command is used to create a unique virtual cluster using information about the pull request in the `default` project. This automatically configures the kube context for the next steps.
 4. The next step deploys the application using the runner provided `kubectl` and manifests located under `./kubernetes`.
 5. Before running tests, use `kubectl` to wait for the `the-app` deployment to become ready.

--- a/vcluster_versioned_docs/version-0.20.0/_partials/integrations/github-actions-vclusters-pull-request-use.mdx
+++ b/vcluster_versioned_docs/version-0.20.0/_partials/integrations/github-actions-vclusters-pull-request-use.mdx
@@ -17,7 +17,7 @@ jobs:
         env:
           LOFT_URL: ${{ secrets.LOFT_URL }}
           ACCESS_KEY: ${{ secrets.ACCESS_KEY }}
-        run: vcluster login $LOFT_URL --access-key $ACCESS_KEY
+        run: vcluster platform login $LOFT_URL --access-key $ACCESS_KEY
       - name: Create PR Virtual Cluster
         env:
           NAME: pr-${{ github.event.pull_request.number }}-${{ github.sha }}-${{ github.run_id }}
@@ -33,7 +33,7 @@ jobs:
 **Explanation:**
 
 1. The [Setup vCluster](https://github.com/loft-sh/setup-vcluster) action is used to install the vCluster CLI.
-2. The `vcluster login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
+2. The `vcluster platform login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
 3. The `vcluster create` command is used to create a unique virtual cluster using information about the pull request in the `default` project. This automatically configures the kube context for the next steps. The `--upgrade` flag has been added to reuse the existing virtual cluster and upgrade it to the latest version. Additional flags may be used to control the desired virtual cluster version.
 4. The next step deploys the application using the runner provided `kubectl` and manifests located under `./kubernetes`.
 5. Before running tests, use `kubectl` to wait for the `the-app` deployment to become ready.

--- a/vcluster_versioned_docs/version-0.20.0/cli/0-20-cli-changes.mdx
+++ b/vcluster_versioned_docs/version-0.20.0/cli/0-20-cli-changes.mdx
@@ -129,7 +129,7 @@ This is a list of commands that formerly in the `loft` CLI and now renamed in `v
 
     * `--driver` string : Specifies the driver to use for managing the virtual cluster (helm or platform).
 
- `vcluster login` 
+ `vcluster platform login` 
 
     * `--use-driver` string : Switches the vCluster driver between platform and helm. 
 

--- a/vcluster_versioned_docs/version-0.20.0/cli/vcluster_login.md
+++ b/vcluster_versioned_docs/version-0.20.0/cli/vcluster_login.md
@@ -1,6 +1,6 @@
 ---
-title: "vcluster login --help"
-sidebar_label: vcluster login
+title: "vcluster platform login --help"
+sidebar_label: vcluster platform login
 ---
 
 
@@ -9,18 +9,18 @@ Login to a vCluster platform instance
 ## Synopsis
 
 ```
-vcluster login [VCLUSTER_PLATFORM_HOST] [flags]
+vcluster platform login [VCLUSTER_PLATFORM_HOST] [flags]
 ```
 
 ```
 ########################################################
-#################### vcluster login ####################
+#################### vcluster platform login ####################
 ########################################################
 Login into vCluster platform
 
 Example:
-vcluster login https://my-vcluster-platform.com
-vcluster login https://my-vcluster-platform.com --access-key myaccesskey
+vcluster platform login https://my-vcluster-platform.com
+vcluster platform login https://my-vcluster-platform.com --access-key myaccesskey
 ########################################################
 ```
 

--- a/vcluster_versioned_docs/version-0.21.0/_partials/integrations/github-actions-pull-request-devspace.mdx
+++ b/vcluster_versioned_docs/version-0.21.0/_partials/integrations/github-actions-pull-request-devspace.mdx
@@ -19,7 +19,7 @@ jobs:
         env:
           LOFT_URL: ${{ secrets.LOFT_URL }}
           ACCESS_KEY: ${{ secrets.ACCESS_KEY }}
-        run: vcluster login $LOFT_URL --access-key $ACCESS_KEY
+        run: vcluster platform login $LOFT_URL --access-key $ACCESS_KEY
       - name: Create PR Virtual Cluster
         env:
           NAME: pr-${{ github.event.pull_request.number }}-${{ github.sha }}-${{ github.run_id }}
@@ -32,6 +32,6 @@ jobs:
 
 1. The [Setup DevSpace](https://github.com/loft-sh/setup-devspace) action installs the DevSpace CLI.
 2. The [Setup vCluster](https://github.com/loft-sh/setup-vcluster) action is used to install the vCluster CLI.
-3. The `vcluster login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
+3. The `vcluster platform login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
 4. The `vcluster create` command is used to create a unique virtual cluster using information about the pull request in the `default` project. This automatically configures the kube context for the next steps.
 5. Finally, use `devspace run e2e` to perform the needed steps to deploy and test `my-app`.

--- a/vcluster_versioned_docs/version-0.21.0/_partials/integrations/github-actions-vclusters-pull-request-manual.mdx
+++ b/vcluster_versioned_docs/version-0.21.0/_partials/integrations/github-actions-vclusters-pull-request-manual.mdx
@@ -17,7 +17,7 @@ jobs:
         env:
           LOFT_URL: ${{ secrets.LOFT_URL }}
           ACCESS_KEY: ${{ secrets.ACCESS_KEY }}
-        run: vcluster login $LOFT_URL --access-key $ACCESS_KEY
+        run: vcluster platform login $LOFT_URL --access-key $ACCESS_KEY
       - name: Create PR Virtual Cluster
         env:
           NAME: pr-${{ github.event.pull_request.number }}-${{ github.sha }}-${{ github.run_id }}
@@ -37,7 +37,7 @@ jobs:
 **Explanation:**
 
 1. The [Setup vCluster](https://github.com/loft-sh/setup-vcluster) action is used to install the vCluster CLI.
-2. The `vcluster login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions). See [Access Keys](https://www.vcluster.com/docs/platform/administer/users-permissions/access-keys) for help generating a platform access key.
+2. The `vcluster platform login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions). See [Access Keys](https://www.vcluster.com/docs/platform/administer/users-permissions/access-keys) for help generating a platform access key.
 3. The `vcluster create` command is used to create a unique virtual cluster using information about the pull request in the `default` project. This automatically configures the kube context for the next steps.
 4. The next step deploys the application using the runner provided `kubectl` and manifests located under `./kubernetes`.
 5. Before running tests, use `kubectl` to wait for the `the-app` deployment to become ready.

--- a/vcluster_versioned_docs/version-0.21.0/_partials/integrations/github-actions-vclusters-pull-request-use.mdx
+++ b/vcluster_versioned_docs/version-0.21.0/_partials/integrations/github-actions-vclusters-pull-request-use.mdx
@@ -17,7 +17,7 @@ jobs:
         env:
           LOFT_URL: ${{ secrets.LOFT_URL }}
           ACCESS_KEY: ${{ secrets.ACCESS_KEY }}
-        run: vcluster login $LOFT_URL --access-key $ACCESS_KEY
+        run: vcluster platform login $LOFT_URL --access-key $ACCESS_KEY
       - name: Create PR Virtual Cluster
         env:
           NAME: pr-${{ github.event.pull_request.number }}-${{ github.sha }}-${{ github.run_id }}
@@ -33,7 +33,7 @@ jobs:
 **Explanation:**
 
 1. The [Setup vCluster](https://github.com/loft-sh/setup-vcluster) action is used to install the vCluster CLI.
-2. The `vcluster login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
+2. The `vcluster platform login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
 3. The `vcluster create` command is used to create a unique virtual cluster using information about the pull request in the `default` project. This automatically configures the kube context for the next steps. The `--upgrade` flag has been added to reuse the existing virtual cluster and upgrade it to the latest version. Additional flags may be used to control the desired virtual cluster version.
 4. The next step deploys the application using the runner provided `kubectl` and manifests located under `./kubernetes`.
 5. Before running tests, use `kubectl` to wait for the `the-app` deployment to become ready.

--- a/vcluster_versioned_docs/version-0.21.0/cli/0-20-cli-changes.mdx
+++ b/vcluster_versioned_docs/version-0.21.0/cli/0-20-cli-changes.mdx
@@ -129,7 +129,7 @@ This is a list of commands that formerly in the `loft` CLI and now renamed in `v
 
     * `--driver` string : Specifies the driver to use for managing the virtual cluster (helm or platform).
 
- `vcluster login` 
+ `vcluster platform login` 
 
     * `--use-driver` string : Switches the vCluster driver between platform and helm. 
 

--- a/vcluster_versioned_docs/version-0.21.0/cli/vcluster_login.md
+++ b/vcluster_versioned_docs/version-0.21.0/cli/vcluster_login.md
@@ -1,6 +1,6 @@
 ---
-title: "vcluster login --help"
-sidebar_label: vcluster login
+title: "vcluster platform login --help"
+sidebar_label: vcluster platform login
 ---
 
 
@@ -9,18 +9,18 @@ Login to a vCluster platform instance
 ## Synopsis
 
 ```
-vcluster login [VCLUSTER_PLATFORM_HOST] [flags]
+vcluster platform login [VCLUSTER_PLATFORM_HOST] [flags]
 ```
 
 ```
 ########################################################
-#################### vcluster login ####################
+#################### vcluster platform login ####################
 ########################################################
 Login into vCluster platform
 
 Example:
-vcluster login https://my-vcluster-platform.com
-vcluster login https://my-vcluster-platform.com --access-key myaccesskey
+vcluster platform login https://my-vcluster-platform.com
+vcluster platform login https://my-vcluster-platform.com --access-key myaccesskey
 ########################################################
 ```
 

--- a/vcluster_versioned_docs/version-0.22.0/_partials/integrations/github-actions-pull-request-devspace.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/_partials/integrations/github-actions-pull-request-devspace.mdx
@@ -19,7 +19,7 @@ jobs:
         env:
           LOFT_URL: ${{ secrets.LOFT_URL }}
           ACCESS_KEY: ${{ secrets.ACCESS_KEY }}
-        run: vcluster login $LOFT_URL --access-key $ACCESS_KEY
+        run: vcluster platform login $LOFT_URL --access-key $ACCESS_KEY
       - name: Create PR Virtual Cluster
         env:
           NAME: pr-${{ github.event.pull_request.number }}-${{ github.sha }}-${{ github.run_id }}
@@ -32,6 +32,6 @@ jobs:
 
 1. The [Setup DevSpace](https://github.com/loft-sh/setup-devspace) action installs the DevSpace CLI.
 2. The [Setup vCluster](https://github.com/loft-sh/setup-vcluster) action is used to install the vCluster CLI.
-3. The `vcluster login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
+3. The `vcluster platform login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
 4. The `vcluster create` command is used to create a unique virtual cluster using information about the pull request in the `default` project. This automatically configures the kube context for the next steps.
 5. Finally, use `devspace run e2e` to perform the needed steps to deploy and test `my-app`.

--- a/vcluster_versioned_docs/version-0.22.0/_partials/integrations/github-actions-vclusters-pull-request-manual.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/_partials/integrations/github-actions-vclusters-pull-request-manual.mdx
@@ -17,7 +17,7 @@ jobs:
         env:
           LOFT_URL: ${{ secrets.LOFT_URL }}
           ACCESS_KEY: ${{ secrets.ACCESS_KEY }}
-        run: vcluster login $LOFT_URL --access-key $ACCESS_KEY
+        run: vcluster platform login $LOFT_URL --access-key $ACCESS_KEY
       - name: Create PR Virtual Cluster
         env:
           NAME: pr-${{ github.event.pull_request.number }}-${{ github.sha }}-${{ github.run_id }}
@@ -37,7 +37,7 @@ jobs:
 **Explanation:**
 
 1. The [Setup vCluster](https://github.com/loft-sh/setup-vcluster) action is used to install the vCluster CLI.
-2. The `vcluster login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions). See [Access Keys](https://www.vcluster.com/docs/platform/administer/users-permissions/access-keys) for help generating a platform access key.
+2. The `vcluster platform login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions). See [Access Keys](https://www.vcluster.com/docs/platform/administer/users-permissions/access-keys) for help generating a platform access key.
 3. The `vcluster create` command is used to create a unique virtual cluster using information about the pull request in the `default` project. This automatically configures the kube context for the next steps.
 4. The next step deploys the application using the runner provided `kubectl` and manifests located under `./kubernetes`.
 5. Before running tests, use `kubectl` to wait for the `the-app` deployment to become ready.

--- a/vcluster_versioned_docs/version-0.22.0/_partials/integrations/github-actions-vclusters-pull-request-use.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/_partials/integrations/github-actions-vclusters-pull-request-use.mdx
@@ -17,7 +17,7 @@ jobs:
         env:
           LOFT_URL: ${{ secrets.LOFT_URL }}
           ACCESS_KEY: ${{ secrets.ACCESS_KEY }}
-        run: vcluster login $LOFT_URL --access-key $ACCESS_KEY
+        run: vcluster platform login $LOFT_URL --access-key $ACCESS_KEY
       - name: Create PR Virtual Cluster
         env:
           NAME: pr-${{ github.event.pull_request.number }}-${{ github.sha }}-${{ github.run_id }}
@@ -33,7 +33,7 @@ jobs:
 **Explanation:**
 
 1. The [Setup vCluster](https://github.com/loft-sh/setup-vcluster) action is used to install the vCluster CLI.
-2. The `vcluster login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
+2. The `vcluster platform login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
 3. The `vcluster create` command is used to create a unique virtual cluster using information about the pull request in the `default` project. This automatically configures the kube context for the next steps. The `--upgrade` flag has been added to reuse the existing virtual cluster and upgrade it to the latest version. Additional flags may be used to control the desired virtual cluster version.
 4. The next step deploys the application using the runner provided `kubectl` and manifests located under `./kubernetes`.
 5. Before running tests, use `kubectl` to wait for the `the-app` deployment to become ready.

--- a/vcluster_versioned_docs/version-0.22.0/cli/0-20-cli-changes.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/cli/0-20-cli-changes.mdx
@@ -129,7 +129,7 @@ This is a list of commands that formerly in the `loft` CLI and now renamed in `v
 
     * `--driver` string : Specifies the driver to use for managing the virtual cluster (helm or platform).
 
- `vcluster login` 
+ `vcluster platform login` 
 
     * `--use-driver` string : Switches the vCluster driver between platform and helm. 
 

--- a/vcluster_versioned_docs/version-0.22.0/cli/vcluster_login.md
+++ b/vcluster_versioned_docs/version-0.22.0/cli/vcluster_login.md
@@ -1,6 +1,6 @@
 ---
-title: "vcluster login --help"
-sidebar_label: vcluster login
+title: "vcluster platform login --help"
+sidebar_label: vcluster platform login
 ---
 
 
@@ -9,18 +9,18 @@ Login to a vCluster platform instance
 ## Synopsis
 
 ```
-vcluster login [VCLUSTER_PLATFORM_HOST] [flags]
+vcluster platform login [VCLUSTER_PLATFORM_HOST] [flags]
 ```
 
 ```
 ########################################################
-#################### vcluster login ####################
+#################### vcluster platform login ####################
 ########################################################
 Login into vCluster platform
 
 Example:
-vcluster login https://my-vcluster-platform.com
-vcluster login https://my-vcluster-platform.com --access-key myaccesskey
+vcluster platform login https://my-vcluster-platform.com
+vcluster platform login https://my-vcluster-platform.com --access-key myaccesskey
 ########################################################
 ```
 

--- a/vcluster_versioned_docs/version-0.23.0/_partials/integrations/github-actions-pull-request-devspace.mdx
+++ b/vcluster_versioned_docs/version-0.23.0/_partials/integrations/github-actions-pull-request-devspace.mdx
@@ -19,7 +19,7 @@ jobs:
         env:
           LOFT_URL: ${{ secrets.LOFT_URL }}
           ACCESS_KEY: ${{ secrets.ACCESS_KEY }}
-        run: vcluster login $LOFT_URL --access-key $ACCESS_KEY
+        run: vcluster platform login $LOFT_URL --access-key $ACCESS_KEY
       - name: Create PR Virtual Cluster
         env:
           NAME: repo-${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}
@@ -32,6 +32,6 @@ jobs:
 
 1. The [Setup DevSpace](https://github.com/loft-sh/setup-devspace) action installs the DevSpace CLI.
 2. The [Setup vCluster](https://github.com/loft-sh/setup-vcluster) action is used to install the vCluster CLI.
-3. The `vcluster login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
+3. The `vcluster platform login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
 4. The `vcluster create` command is used to create a unique virtual cluster using information about the pull request in the `default` project. This automatically configures the kube context for the next steps.
 5. Finally, use `devspace run e2e` to perform the needed steps to deploy and test `my-app`.

--- a/vcluster_versioned_docs/version-0.23.0/_partials/integrations/github-actions-vclusters-pull-request-manual.mdx
+++ b/vcluster_versioned_docs/version-0.23.0/_partials/integrations/github-actions-vclusters-pull-request-manual.mdx
@@ -17,7 +17,7 @@ jobs:
         env:
           LOFT_URL: ${{ secrets.LOFT_URL }}
           ACCESS_KEY: ${{ secrets.ACCESS_KEY }}
-        run: vcluster login $LOFT_URL --access-key $ACCESS_KEY
+        run: vcluster platform login $LOFT_URL --access-key $ACCESS_KEY
       - name: Create PR Virtual Cluster
         env:
           NAME: repo-${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}
@@ -37,7 +37,7 @@ jobs:
 **Explanation:**
 
 1. The [Setup vCluster](https://github.com/loft-sh/setup-vcluster) action is used to install the vCluster CLI.
-2. The `vcluster login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions). See [Access Keys](https://www.vcluster.com/docs/platform/administer/users-permissions/access-keys) for help generating a platform access key.
+2. The `vcluster platform login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions). See [Access Keys](https://www.vcluster.com/docs/platform/administer/users-permissions/access-keys) for help generating a platform access key.
 3. The `vcluster create` command is used to create a unique virtual cluster using information about the pull request in the `default` project. This automatically configures the kube context for the next steps.
 4. The next step deploys the application using the runner provided `kubectl` and manifests located under `./kubernetes`.
 5. Before running tests, use `kubectl` to wait for the `the-app` deployment to become ready.

--- a/vcluster_versioned_docs/version-0.23.0/_partials/integrations/github-actions-vclusters-pull-request-use.mdx
+++ b/vcluster_versioned_docs/version-0.23.0/_partials/integrations/github-actions-vclusters-pull-request-use.mdx
@@ -17,7 +17,7 @@ jobs:
         env:
           LOFT_URL: ${{ secrets.LOFT_URL }}
           ACCESS_KEY: ${{ secrets.ACCESS_KEY }}
-        run: vcluster login $LOFT_URL --access-key $ACCESS_KEY
+        run: vcluster platform login $LOFT_URL --access-key $ACCESS_KEY
       - name: Create PR Virtual Cluster
         env:
           NAME: repo-${{ github.event.repository.name }}-pr-${{ github.event.pull_request.number }}
@@ -33,7 +33,7 @@ jobs:
 **Explanation:**
 
 1. The [Setup vCluster](https://github.com/loft-sh/setup-vcluster) action is used to install the vCluster CLI.
-2. The `vcluster login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
+2. The `vcluster platform login` command is used to log in to the organization's platform instance. Environment variables `LOFT_URL` and `ACCESS_KEY` are populated using [GitHub secrets](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions).
 3. The `vcluster create` command is used to create a unique virtual cluster using information about the pull request in the `default` project. This automatically configures the kube context for the next steps. The `--upgrade` flag has been added to reuse the existing virtual cluster and upgrade it to the latest version. Additional flags may be used to control the desired virtual cluster version.
 4. The next step deploys the application using the runner provided `kubectl` and manifests located under `./kubernetes`.
 5. Before running tests, use `kubectl` to wait for the `the-app` deployment to become ready.

--- a/vcluster_versioned_docs/version-0.23.0/cli/0-20-cli-changes.mdx
+++ b/vcluster_versioned_docs/version-0.23.0/cli/0-20-cli-changes.mdx
@@ -129,7 +129,7 @@ This is a list of commands that formerly in the `loft` CLI and now renamed in `v
 
     * `--driver` string : Specifies the driver to use for managing the virtual cluster (helm or platform).
 
- `vcluster login` 
+ `vcluster platform login` 
 
     * `--use-driver` string : Switches the vCluster driver between platform and helm. 
 

--- a/vcluster_versioned_docs/version-0.23.0/cli/vcluster_login.md
+++ b/vcluster_versioned_docs/version-0.23.0/cli/vcluster_login.md
@@ -1,6 +1,6 @@
 ---
-title: "vcluster login --help"
-sidebar_label: vcluster login
+title: "vcluster platform login --help"
+sidebar_label: vcluster platform login
 ---
 
 
@@ -9,18 +9,18 @@ Login to a vCluster platform instance
 ## Synopsis
 
 ```
-vcluster login [VCLUSTER_PLATFORM_HOST] [flags]
+vcluster platform login [VCLUSTER_PLATFORM_HOST] [flags]
 ```
 
 ```
 ########################################################
-#################### vcluster login ####################
+#################### vcluster platform login ####################
 ########################################################
 Login into vCluster platform
 
 Example:
-vcluster login https://my-vcluster-platform.com
-vcluster login https://my-vcluster-platform.com --access-key myaccesskey
+vcluster platform login https://my-vcluster-platform.com
+vcluster platform login https://my-vcluster-platform.com --access-key myaccesskey
 ########################################################
 ```
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Update docs to reflect `vcluster platform login` command 
- Relates to https://github.com/loft-sh/vcluster/pull/2577

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->



## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-354

