### PR TITLE
Update HA and PVC incompatibility to make it more obvious

### DIFF
--- a/platform/configure/advanced/audit.mdx
+++ b/platform/configure/advanced/audit.mdx
@@ -113,7 +113,11 @@ Below you can find a complete policy reference:
 
 ## Persisting audit logs
 
-There are two ways to persist platform audit logs: deploying the platform with a persistent volume claim (PVC) or connecting the platform to a persistent database. The PVC approach does not work for HA mode for the platform.
+There are two ways to persist platform audit logs: deploying the platform with a persistent volume claim (PVC) or connecting the platform to a persistent database. 
+
+:::info HA only supported with persistent database
+If you are running the platform in high availability (HA mode), the only way to persist audit logs is to use a persistent database. The PVC approach does not work.
+:::
 
 ### Deploy the platform with a PVC to save audit logs
 

--- a/platform/configure/advanced/audit.mdx
+++ b/platform/configure/advanced/audit.mdx
@@ -1,5 +1,5 @@
 ---
-title: Enabling Audit Logging
+title: Enable Audit Logging
 sidebar_label: Enable Audit Logging
 sidebar_position: 2
 description: Learn how to enable and configure audit logging to track activities in the platform, including management instance changes and cluster operations.
@@ -65,7 +65,7 @@ The platform provides audit levels, which are preconfigured audit policies for t
 For all of these levels certain internal read-only APIs are not logged since those might pollute the log and drastically increase log size. To log these, create a custom audit policy as described below.
 :::
 
-Configure the audit level through the platform config, which can be modified either through the platform UI or helm:
+Configure the audit level through the platform config, which can be modified either through the platform UI or Helm:
 
 <Tabs
   defaultValue="ui"
@@ -130,7 +130,7 @@ audit:
     # size: 30Gi
 ```
 
-Apply the values via helm:
+Apply the values using Helm:
 
 ```bash title="Apply helm values"
 helm upgrade vcluster-platform vcluster-platform -n vcluster-platform --version 4.0.0-alpha.12 \
@@ -170,7 +170,7 @@ audit:
 
 To easily export the audit events to third party systems, enable the audit log
 sidecar that prints all the audit events onto stdout in a separate container which can then be easily watched and exported.
-Enabling the sidecar is only possible through helm values.
+Enabling the sidecar is only possible through Helm values.
 
 Create a `values.yaml` with the following contents:
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
For audit logging persistence, it was hidden that PVC method was not supported, so made it a call out. 

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENG-3792

