### PR TITLE
Update Export kubeconfig docs

### DIFF
--- a/vcluster/configure/vcluster-yaml/export-kube-config.mdx
+++ b/vcluster/configure/vcluster-yaml/export-kube-config.mdx
@@ -51,15 +51,14 @@ exportKubeConfig:
   server: https://my-domain.org:443
 ```
 
-Configuring the default secret does not affect the [additional kubeconfig secrets](#export-additional-secret) that are
-configured separately with the `exportKubeConfig.additionalSecrets` field. E.g. in the above example, custom context and
-server values are used only for the default secret `vc-NAME` and do not affect the additional secrets that you may have
-configured.
+Customizing the default secret does not affect the additional kubeconfig secrets that are configured separately with the
+`exportKubeConfig.additionalSecrets` field. E.g. in the above example, custom context and server values are used only
+for the default secret `vc-NAME` and do not affect the additional secrets that you may have configured.
 
 :::note
 
 All fields that are used to configure the default secret are also used for the secret specified with the deprecated
-`exportKubeConfig.secret` field. More details in the [migration section below](#migrate-customized-deprecated-secret-to-exportkubeconfigadditionalsecrets).
+`exportKubeConfig.secret` field. More details in the [migration section below](#migrate-customized-deprecated-secret-to-new-additional-secrets).
 
 :::
 
@@ -143,7 +142,7 @@ are used to customize the default secret, e.g. `exportKubeConfig.context`, `expo
 
 For example, with the following config, vCluster exports the kubeconfig secret named `vc-my-domain`, where kubeconfig has
 context `my-domain-context` and server endpoint `https://my-domain.org:443`, but it also exports the default kubeconfig
-secret with the same context and server values.
+secret with those same context and server values.
 
 ```yaml
 exportKubeConfig:

--- a/vcluster/configure/vcluster-yaml/export-kube-config.mdx
+++ b/vcluster/configure/vcluster-yaml/export-kube-config.mdx
@@ -58,7 +58,7 @@ configured.
 
 :::note
 
-All fields that are used to configure the default secret will also be used for the secret specified with the deprecated
+All fields that are used to configure the default secret are also used for the secret specified with the deprecated
 `exportKubeConfig.secret` field. More details in the [migration section below](#migrate-customized-deprecated-secret-to-exportkubeconfigadditionalsecrets).
 
 :::
@@ -69,8 +69,8 @@ You can export additional kubeconfig secrets by specifying `exportKubeConfig.add
 
 ### Using the default namespace for the additional secret
 
-The following example configures a virtual cluster to export an additional secret `vc-my-domain`, which will be created
-in the namespace where vCluster is deployed.
+The following example configures a virtual cluster to export an additional secret `vc-my-domain`, which is created in
+the namespace where vCluster is deployed.
 
 In this example, the additional secret `vc-my-domain` is configured in the following way:
 - Set the kubeconfig context name to `my-domain-context`.
@@ -141,9 +141,9 @@ exportKubeConfig:
 The secret that is specified with the deprecated `exportKubeConfig.secret` field is customized with the same fields that
 are used to customize the default secret, e.g. `exportKubeConfig.context`, `exportKubeConfig.server`, etc.
 
-For example, the following config will export the kubeconfig secret named `vc-my-domain`, where kubeconfig will have
-context `my-domain-context` and server endpoint `https://my-domain.org:443`, but it will also export the default
-kubeconfig secret with the same context and server values.
+For example, with the following config, vCluster exports the kubeconfig secret named `vc-my-domain`, where kubeconfig has
+context `my-domain-context` and server endpoint `https://my-domain.org:443`, but it also exports the default kubeconfig
+secret with the same context and server values.
 
 ```yaml
 exportKubeConfig:
@@ -167,8 +167,8 @@ exportKubeConfig:
     server: https://my-domain.org:443
 ```
 
-In this example, both the default secret `vc-NAME` and the additional secret `vc-my-domain` will use custom values for
-the context and the server.
+In this example, both the default secret `vc-NAME` and the additional secret `vc-my-domain` use the same custom values
+for the context and the server.
 
 2\. Customize only the additional kubeconfig secret.
 
@@ -180,7 +180,7 @@ exportKubeConfig:
     server: https://my-domain.org:443
 ```
 
-In this example, only the additional secret `vc-my-domain` will use custom values for the context and the server.
+In this example, only the additional secret `vc-my-domain` uses custom values for the context and the server.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/export-kube-config.mdx
+++ b/vcluster/configure/vcluster-yaml/export-kube-config.mdx
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 import ExportKubeConfig from '../../_partials/config/exportKubeConfig.mdx'
 
-Customize how vCluster exports the kubeconfig file to a secret for use in tools like ArgoCD, Flux or Terraform pipelines.
+Customize how vCluster exports the kubeconfig file to a secret for use in tools like ArgoCD, Flux, or Terraform pipelines.
 
 By default, vCluster stores the kubeconfig in a secret named `vc-NAME` within the namespace where vCluster is deployed. 
 You can [customize this default secret](#customize-the-default-secret).

--- a/vcluster/configure/vcluster-yaml/export-kube-config.mdx
+++ b/vcluster/configure/vcluster-yaml/export-kube-config.mdx
@@ -114,13 +114,13 @@ exportKubeConfig:
 
 ### Deprecated `exportKubeConfig.secret` config
 
-Starting from version 0.24.0, `exportKubeConfig.secret` config is deprecated in favor of `exportKubeConfig.additionalSecrets`.
+Starting from version 0.24.0, the `exportKubeConfig.secret` configuration is deprecated and replaced by `exportKubeConfig.additionalSecrets`.
 
-#### Migrate deprecated secret to new additional secrets
+#### Migrate a deprecated secret to new additional secrets
 
-It is highly recommended to migrate the deprecated `exportKubeConfig.secret` config to the new `exportKubeConfig.additionalSecrets`.
+It is recommended to migrate the deprecated `exportKubeConfig.secret` config to the new `exportKubeConfig.additionalSecrets`.
 
-If you had `my-secret` secret configured like this:
+If `my-secret` is configured such as:
 
 ```yaml
 exportKubeConfig:
@@ -128,7 +128,7 @@ exportKubeConfig:
     name: my-secret
 ```
 
-You can migrate it to the new additional secret like this:
+You can migrate the secret to the new additional secret with the following:
 
 ```yaml
 exportKubeConfig:
@@ -136,14 +136,16 @@ exportKubeConfig:
   - name: my-secret
 ```
 
-#### Migrate customized deprecated secret to new additional secrets
+#### Migrate a customized deprecated secret to new additional secrets
 
-The secret that is specified with the deprecated `exportKubeConfig.secret` field is customized with the same fields that
-are used to customize the default secret, e.g. `exportKubeConfig.context`, `exportKubeConfig.server`, etc.
+The secret defined using the deprecated `exportKubeConfig.secret` field is customized using the same configuration fields (such as `exportKubeConfig.context`, `exportKubeConfig.server`) as the default kubeconfig secret.
 
-For example, with the following config, vCluster exports the kubeconfig secret named `vc-my-domain`, where kubeconfig has
-context `my-domain-context` and server endpoint `https://my-domain.org:443`, but it also exports the default kubeconfig
-secret with those same context and server values.
+For example, in the following configuration, vCluster exports a kubeconfig secret named `vc-my-domain` with:
+
+- Context: `my-domain-context`
+- Server endpoint: `https://my-domain.org:443`
+
+vCluster also exports the default kubeconfig secret using these same context and server values.
 
 ```yaml
 exportKubeConfig:
@@ -171,7 +173,7 @@ In this example, both the default secret `vc-NAME` and the additional secret `vc
 for the context and the server, which gives you the same exported kubeconfig secrets as with the old config that used
 the deprecated `exportKubeConfig.secret`.
 
-You may want to export the additional secret with different config values for the context and the server. You can achieve
+You might want to export the additional secret with different config values for the context and the server. You can achieve
 this by customizing the additional secret differently than the default secret:
 
 ```yaml

--- a/vcluster/configure/vcluster-yaml/export-kube-config.mdx
+++ b/vcluster/configure/vcluster-yaml/export-kube-config.mdx
@@ -57,8 +57,9 @@ for the default secret `vc-NAME` and do not affect the additional secrets that y
 
 :::note
 
-All fields that are used to customize the default secret are also used to customize the secret specified with the deprecated
-`exportKubeConfig.secret` field. More details in the [migration section below](#migrate-customized-deprecated-secret-to-new-additional-secrets).
+The default secret and the secret specified with the deprecated `exportKubeConfig.secret` field are customized with
+the same set of fields (`exportKubeConfig.context`, `exportKubeConfig.server`, etc), so setting these fields customizes
+both the default and the deprecated secret in the same way. More details in the [migration section below](#migrate-customized-deprecated-secret-to-new-additional-secrets).
 
 :::
 

--- a/vcluster/configure/vcluster-yaml/export-kube-config.mdx
+++ b/vcluster/configure/vcluster-yaml/export-kube-config.mdx
@@ -6,10 +6,12 @@ sidebar_position: 3
 
 import ExportKubeConfig from '../../_partials/config/exportKubeConfig.mdx'
 
-Customize how vCluster exports the kubeconfig file to a secret for use in tools like ArgoCD or Terraform pipelines.
+Customize how vCluster exports the kubeconfig file to a secret for use in tools like ArgoCD, Flux or Terraform pipelines.
 
 By default, vCluster stores the kubeconfig in a secret named `vc-NAME` within the namespace where vCluster is deployed. 
-To create an additional secret with a specified configuration, configure `exportKubeConfig`.
+You can [customize this default secret](#customize-the-default-secret).
+
+In addition to the default secret, you can also [export additional kubeconfig secrets](#export-additional-secrets).
 
 <!-- vale off -->
 {/*
@@ -35,30 +37,67 @@ To create an additional secret with a specified configuration, configure `export
 
 <!-- vale on -->
 
-## Using the same namespace for the secret
+## Customize the default secret
 
-The following example configures a virtual cluster to use a specific kubeconfig context, server endpoint, and secret name within the same namespace:
+The following example configures a virtual cluster to use a specific kubeconfig context and server endpoint for the default
+kubeconfig secret `vc-NAME`:
 
 - Set the kubeconfig context name to `my-domain-context`.
 - Configure the kubeconfig to use `https://my-domain.org:443` as the endpoint for the exposed virtual cluster.
-- Ensure the secret name reflects the virtual cluster domain name instead of the default cluster name, "my-cluster".
 
 ```yaml
 exportKubeConfig:
   context: my-domain-context
   server: https://my-domain.org:443
-  secret:
-    name: vc-my-domain
 ```
 
-## Using a new namespace for the secret
+Configuring the default secret does not affect the [additional kubeconfig secrets](#export-additional-secret) that are
+configured separately with the `exportKubeConfig.additionalSecrets` field. E.g. in the above example, custom context and
+server values are used only for the default secret `vc-NAME` and do not affect the additional secrets that you may have
+configured.
 
-The following example configures a virtual cluster to store the kubeconfig secret in a separate namespace while maintaining proper access control:
+:::note
+
+All fields that are used to configure the default secret will also be used for the secret specified with the deprecated
+`exportKubeConfig.secret` field. More details in the [migration section below](#migrate-customized-deprecated-secret-to-exportkubeconfigadditionalsecrets).
+
+:::
+
+## Export additional secrets
+
+You can export additional kubeconfig secrets by specifying `exportKubeConfig.additionalSecrets`.
+
+### Using the default namespace for the additional secret
+
+The following example configures a virtual cluster to export an additional secret `vc-my-domain`, which will be created
+in the namespace where vCluster is deployed.
+
+In this example, the additional secret `vc-my-domain` is configured in the following way:
+- Set the kubeconfig context name to `my-domain-context`.
+- Configure the kubeconfig to use `https://my-domain.org:443` as the server endpoint for the exposed virtual cluster.
+
+```yaml
+exportKubeConfig:
+  additionalSecrets:
+  - name: vc-my-domain
+    context: my-domain-context
+    server: https://my-domain.org:443
+```
+
+You can create multiple additional secrets. Each additional secret is configured separately, and configuring additional
+secrets does not affect the default kubeconfig secret. E.g. in the above example, custom context and server values are
+used only for the additional secret `vc-my-domain` and do not affect the default kubeconfig secret, nor any other
+additional secret that you may have configured.
+
+### Using a new namespace for the additional secret
+
+The following example configures a virtual cluster to store the kubeconfig secret in a separate namespace while maintaining
+proper access control:
 
 - Set the kubeconfig context name to `my-domain-context`.
 - Configure the kubeconfig to use `https://my-domain.org:443` as the virtual cluster endpoint.
 - Create a namespace called `kubeconfig-secret-namespace` to store the secret.
-- Name the secret `vc-my-domain` instead of using the default cluster name "my-cluster".
+- Name the secret `vc-my-domain` instead of using the default "vc-NAME" (where `NAME` is the vCluster name).
 - Additionally, grant access to the new namespace by creating a `Role` and `RoleBinding` for the vCluster service account:
   - Configure the new role with the same permissions assigned to the vCluster app role in the original namespace.
   - If needed, copy permissions from the default vCluster deployment.
@@ -66,12 +105,82 @@ The following example configures a virtual cluster to store the kubeconfig secre
 
 ```yaml
 exportKubeConfig:
+  additionalSecrets:
+  - namespace: kubeconfig-secret-namespace
+    name: vc-my-domain
+    context: my-domain-context
+    server: https://my-domain.org:443
+```
+
+### Deprecated `exportKubeConfig.secret` config
+
+Starting from version 0.24.0, we have deprecated `exportKubeConfig.secret` config in favor of `exportKubeConfig.additionalSecrets`.
+
+#### Migrate deprecated secret to new additional secrets
+
+We highly recommend to migrate the deprecated `exportKubeConfig.secret` config to the new `exportKubeConfig.additionalSecrets`.
+
+If you had `my-secret` secret configured like this:
+
+```yaml
+exportKubeConfig:
+  secret:
+    name: my-secret
+```
+
+You can migrate it to the new additional secret like this:
+
+```yaml
+exportKubeConfig:
+  additionalSecrets:
+  - name: my-secret
+```
+
+#### Migrate customized deprecated secret to new additional secrets
+
+The secret that is specified with the deprecated `exportKubeConfig.secret` field is customized with the same fields that
+are used to customize the default secret, e.g. `exportKubeConfig.context`, `exportKubeConfig.server`, etc.
+
+For example, the following config will export the kubeconfig secret named `vc-my-domain`, where kubeconfig will have
+context `my-domain-context` and server endpoint `https://my-domain.org:443`, but it will also export the default
+kubeconfig secret with the same context and server values.
+
+```yaml
+exportKubeConfig:
   context: my-domain-context
   server: https://my-domain.org:443
   secret:
-    namespace: kubeconfig-secret-namespace
     name: vc-my-domain
 ```
+
+When migrating this customized deprecated secret to the new additional secrets, you have the following two options.
+
+1\. Customize both the default and the additional kubeconfig secret.
+
+```yaml
+exportKubeConfig:
+  context: my-domain-context
+  server: https://my-domain.org:443
+  additionalSecrets:
+  - name: vc-my-domain
+    context: my-domain-context
+    server: https://my-domain.org:443
+```
+
+In this example, both the default secret `vc-NAME` and the additional secret `vc-my-domain` will use custom values for
+the context and the server.
+
+2\. Customize only the additional kubeconfig secret.
+
+```yaml
+exportKubeConfig:
+  additionalSecrets:
+  - name: vc-my-domain
+    context: my-domain-context
+    server: https://my-domain.org:443
+```
+
+In this example, only the additional secret `vc-my-domain` will use custom values for the context and the server.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/export-kube-config.mdx
+++ b/vcluster/configure/vcluster-yaml/export-kube-config.mdx
@@ -114,11 +114,11 @@ exportKubeConfig:
 
 ### Deprecated `exportKubeConfig.secret` config
 
-Starting from version 0.24.0, we have deprecated `exportKubeConfig.secret` config in favor of `exportKubeConfig.additionalSecrets`.
+Starting from version 0.24.0, `exportKubeConfig.secret` config is deprecated in favor of `exportKubeConfig.additionalSecrets`.
 
 #### Migrate deprecated secret to new additional secrets
 
-We highly recommend to migrate the deprecated `exportKubeConfig.secret` config to the new `exportKubeConfig.additionalSecrets`.
+It is highly recommended to migrate the deprecated `exportKubeConfig.secret` config to the new `exportKubeConfig.additionalSecrets`.
 
 If you had `my-secret` secret configured like this:
 

--- a/vcluster/configure/vcluster-yaml/export-kube-config.mdx
+++ b/vcluster/configure/vcluster-yaml/export-kube-config.mdx
@@ -57,7 +57,7 @@ for the default secret `vc-NAME` and do not affect the additional secrets that y
 
 :::note
 
-All fields that are used to configure the default secret are also used for the secret specified with the deprecated
+All fields that are used to customize the default secret are also used to customize the secret specified with the deprecated
 `exportKubeConfig.secret` field. More details in the [migration section below](#migrate-customized-deprecated-secret-to-new-additional-secrets).
 
 :::
@@ -71,7 +71,7 @@ You can export additional kubeconfig secrets by specifying `exportKubeConfig.add
 The following example configures a virtual cluster to export an additional secret `vc-my-domain`, which is created in
 the namespace where vCluster is deployed.
 
-In this example, the additional secret `vc-my-domain` is configured in the following way:
+In this example, the additional secret `vc-my-domain` is customized in the following way:
 - Set the kubeconfig context name to `my-domain-context`.
 - Configure the kubeconfig to use `https://my-domain.org:443` as the server endpoint for the exposed virtual cluster.
 

--- a/vcluster/configure/vcluster-yaml/export-kube-config.mdx
+++ b/vcluster/configure/vcluster-yaml/export-kube-config.mdx
@@ -168,7 +168,21 @@ exportKubeConfig:
 ```
 
 In this example, both the default secret `vc-NAME` and the additional secret `vc-my-domain` use the same custom values
-for the context and the server.
+for the context and the server, which gives you the same exported kubeconfig secrets as with the old config that used
+the deprecated `exportKubeConfig.secret`.
+
+You may want to export the additional secret with different config values for the context and the server. You can achieve
+this by customizing the additional secret differently than the default secret:
+
+```yaml
+exportKubeConfig:
+  context: my-domain-context
+  server: https://my-domain.org:443
+  additionalSecrets:
+  - name: vc-my-domain
+    context: my-other-domain-context
+    server: https://my-other-domain.org:443
+```
 
 2\. Customize only the additional kubeconfig secret.
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

Update Export kubeConfig docs so they reflect the latest implementation changes from https://github.com/loft-sh/vcluster/pull/2542. We have added a new `exportKubeConfig.additionalSecrets` config and deprecated `exportKubeConfig.secret`.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Export kubeconfig Preview](https://deploy-preview-504--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/export-kube-config/)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENG-6080

