### PR TITLE
feat: clearly indicate which versions are out of support

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -127,13 +127,13 @@ const config = {
             badge: true,
           },
           "0.21.0": {
-            label: "v0.21",
-            banner: "none",
+            label: "v0.21 (EOL)",
+            banner: "unmaintained",
             badge: true,
           },
           "0.20.0": {
-            label: "v0.20",
-            banner: "none",
+            label: "v0.20 (EOL)",
+            banner: "unmaintained",
             badge: true,
           },
         },


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Indicates which versions are out of support (EOL).

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-509--vcluster-docs-site.netlify.app/docs/vcluster

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-460

