### PR TITLE
feat: create airgapped vcluster deployment docs

### DIFF
--- a/staging/airgaped-vcluster-deployment.mdx
+++ b/staging/airgaped-vcluster-deployment.mdx
@@ -1,0 +1,98 @@
+---
+title: Deploy vcluster in an air-gaped env without an internal helm repo
+sidebar_label: Deploy vcluster (air-gaped)
+description: Deploy vcluster in an air-gaped env without an internal helm repo
+---
+
+## Summary
+
+The most common method of installing vCluster is with Helm. The LoftLabs charts site is used when installations are connected to the Internet. A local Helm repository is needed for an air-gap installation. If one is not available but a local web server is, this method could be used. 
+
+In this article, we'll use a private-hosted Gitlab as the web server.
+
+## Prerequisits
+
+- A web server, reachable via http/https to store the helm chart and index.yaml.
+
+- In this article, we'll use a privately hosted GitLab instance as the web server.
+
+- An Internet-connected machine with helm binary to download the chats from the internet and push to the web server.
+
+## How-to steps
+
+### Part 1 - download the helm chart
+
+1. Add and update the loft helm repo on a machine with internet access
+  ```
+  helm repo add loft https://charts.loft.sh
+  helm repo update
+  ```
+
+2. Pull the helm chart to your local disk
+  ```
+  helm pull loft/vcluster --version 0.23.0
+  ```
+
+3. Store the chart on your web server
+   Here, we are using git to move the chart to the git web server.
+  ```
+  git clone <gitlab repo url>
+  cd <gitlab repo>
+  mkdir vcluster
+  mv vcluster-0.23.0.tgz vcluster
+  ```
+
+4. Use the helm repo index command to create an index.yaml file and push it to the gitlab repo, you need to ensure the --url you specify is where the vcluster-0.23.0.tgz is available to the cluster in which the helm chart will be deployed.
+  ```
+  helm repo index vcluster --url https://url-to-vcluster-directory
+  git add -A
+  git commit -m "pushing vcluster helm chart"
+  git push
+  ```
+Example:
+  ```
+  helm repo index vcluster --url https://your-private-server.com/your-username/your-private-project/path-to-vcluster-chart
+  ```
+
+### Part 2 - Deploy vcluster using the Git URL for the helm chart
+
+### When using helm command
+  ```
+  helm upgrade --install my-vcluster vcluster --values vcluster.yaml --repo https://your-private-server.com/your-username/your-private-project/path-to-vcluster-chart-directory --version 0.23.0 --namespace my-namespace --repository-config='' 
+  ```
+
+### When using the vCluster Platform
+
+- Use the following if using vCluster Platform UI to deploy the vcluster.
+
+  - If using a template, modify the template and add the URL under the `repo:` section as shown below and save it.
+
+    ```
+    kind: VirtualClusterTemplate
+    apiVersion: management.loft.sh/v1
+    metadata:
+    spec:
+      template:
+        helmRelease:
+          chart:
+            repo: https://your-private-server.com/your-username/your-private-project/path-to-vcluster-chart-directory
+            version: 0.23.0
+    ```
+
+  - If not using template - add the URL in the `repo:` section of the VirtualClusterInstance crd directly as shown below.
+
+    ```
+    kind: VirtualClusterInstance
+    apiVersion: management.loft.sh/v1
+    metadata:
+    spec:
+      template: 
+        helmRelease:
+          chart:
+            repo: https://your-private-server.com/your-username/your-private-project/path-to-vcluster-chart-directory
+            version: 0.23.0
+    ```
+     
+
+  - Click on Create virtual cluster to verify.
+


### PR DESCRIPTION
Deploy vcluster in an air-gaped env without an internal helm repo

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

