### PR TITLE
vcluster-debug-logs

### DIFF
--- a/staging/How to Enable Debug Logging for vCluster.mdx
+++ b/staging/How to Enable Debug Logging for vCluster.mdx
@@ -1,0 +1,33 @@
+# Enabling Debug Logging in vCluster
+
+Debug logging can be useful for troubleshooting issues in vCluster. This guide explains how to enable debug logging by modifying the vCluster configuration.
+
+## Steps to Enable Debug Logging
+
+### 1\. Edit the vCluster Configuration
+
+Open your vCluster configuration file (`vcluster.yaml`) or the Helm values file used during installation.
+
+### 2\. Add the Debug Flag
+
+Modify the configuration to include the debug environment variable:
+
+```
+controlPlane:
+  statefulSet:
+    env:
+    - name: "DEBUG"
+      value: "true"
+```
+
+### 3\. Apply the Configuration
+
+Run the following command to apply the updated configuration:
+
+```
+helm upgrade <vcluster-helm-release-name> loft/vcluster -n <vcluster-namespace> -f vcluster.yaml
+```
+
+## Conclusion
+
+Enabling debug logging in vCluster helps diagnose and resolve issues more effectively. By adding the `DEBUG` environment variable to the vCluster configuration, you increase log verbosity and gain deeper insights into the system’s behavior.

--- a/staging/How to Enable Debug Logging for vCluster.mdx
+++ b/staging/How to Enable Debug Logging for vCluster.mdx
@@ -1,14 +1,14 @@
-# Enabling Debug Logging in vCluster
+# Enabling debug logging in vCluster
 
 Debug logging can be useful for troubleshooting issues in vCluster. This guide explains how to enable debug logging by modifying the vCluster configuration.
 
 ## Steps to Enable Debug Logging
 
-### 1\. Edit the vCluster Configuration
+### 1. Edit the vCluster Configuration
 
 Open your vCluster configuration file (`vcluster.yaml`) or the Helm values file used during installation.
 
-### 2\. Add the Debug Flag
+### 2. Add the Debug Flag
 
 Modify the configuration to include the debug environment variable:
 
@@ -20,7 +20,7 @@ controlPlane:
       value: "true"
 ```
 
-### 3\. Apply the Configuration
+### 3. Apply the Configuration
 
 Run the following command to apply the updated configuration:
 

--- a/staging/enable-debug-logging.mdx
+++ b/staging/enable-debug-logging.mdx
@@ -1,4 +1,4 @@
-# Enabling debug logging in vCluster
+# Enable debug logging in vCluster
 
 Debug logging can be useful for troubleshooting issues in vCluster. This guide explains how to enable debug logging by modifying the vCluster configuration.
 
@@ -12,7 +12,7 @@ Open your vCluster configuration file (`vcluster.yaml`) or the Helm values file 
 
 Modify the configuration to include the debug environment variable:
 
-```
+```yaml
 controlPlane:
   statefulSet:
     env:
@@ -24,7 +24,7 @@ controlPlane:
 
 Run the following command to apply the updated configuration:
 
-```
+```yaml
 helm upgrade <vcluster-helm-release-name> loft/vcluster -n <vcluster-namespace> -f vcluster.yaml
 ```
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

