### PR TITLE
fix: remove we from list

### DIFF
--- a/.github/styles/Google/We.yml
+++ b/.github/styles/Google/We.yml
@@ -4,7 +4,6 @@ link: 'https://developers.google.com/style/pronouns#personal-pronouns'
 level: warning
 ignorecase: true
 tokens:
-  - we
   - we'(?:ve|re)
   - ours?
   - us


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- We actually should be used to give a more friendly/ familial tone. GitLab docs and Google docs both use "We recommend..." We can keep the other rules, but I think using "You" and "We" should be okay.


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

