### PR TITLE
feat(ci): create a follow-up linear issue on a PR

### DIFF
--- a/.github/workflows/create-linear-issue.yaml
+++ b/.github/workflows/create-linear-issue.yaml
@@ -1,0 +1,30 @@
+name: Create follow up linear issue
+
+on:
+  pull_request:
+    types:
+      - labeled
+jobs:
+  create-linear-issue-on-pull-request:
+    if: ${{ github.event.label.name == 'follow-up' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create the Linear Issue
+        id: createIssue
+        uses: ctriolo/action-create-linear-issue@v1
+        with:
+          linear-api-key: ${{secrets.LINEAR_API_KEY}}
+          linear-team-key: "DOC"
+          linear-issue-title: ${{github.event.pull_request.title}}
+          linear-issue-description: ${{github.event.pull_request.body}}
+          linear-attachment-url: ${{github.event.pull_request.html_url}}
+          linear-attachment-title: ${{github.event.pull_request.title}}
+
+      - name: Create comment in PR with Linear Issue link
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            ${{ steps.createIssue.outputs.linear-issue-url }}"
+
+


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
N/A

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

