### PR TITLE
fix: update to include only 1.30 and higher

### DIFF
--- a/vcluster/deploy/upgrade/supported_versions.mdx
+++ b/vcluster/deploy/upgrade/supported_versions.mdx
@@ -31,20 +31,16 @@ Kubernetes versions that are no longer supported upstream can still be used but 
 <table>
   <tr>
     <th rowspan="2">Host Cluster Kubernetes Version</th>
-    <th colspan="5">vCluster Kubernetes Version</th>
+    <th colspan="3">vCluster Kubernetes Version</th>
   </tr>
   <tr>
     <th>v1.32</th>
     <th>v1.31</th>
     <th>v1.30</th>
-    <th>v1.29</th>
-    <th>v1.28</th>
   </tr>
   <tr>
     <td><b>v1.32</b></td>
     <td>✅</td>
-    <td>🆗</td>
-    <td>🆗</td>
     <td>🆗</td>
     <td>🆗</td>
   </tr>
@@ -53,35 +49,14 @@ Kubernetes versions that are no longer supported upstream can still be used but 
     <td>🆗</td>
     <td>✅</td>
     <td>🆗</td>
-    <td>🆗</td>
-    <td>🆗</td>
   </tr>
   <tr>
     <td><b>v1.30</b></td>
     <td>🆗</td>
     <td>🆗</td>
     <td>✅</td>
-    <td>🆗</td>
-    <td>🆗</td>
-  </tr>
-  <tr>
-    <td><b>v1.29</b></td>
-    <td>🆗</td>
-    <td>🆗</td>
-    <td>🆗</td>
-    <td>✅</td>
-    <td>🆗</td>
-  </tr>
-  <tr>
-    <td><b>v1.28</b></td>
-    <td>🆗</td>
-    <td>🆗</td>
-    <td>🆗</td>
-    <td>🆗</td>
-    <td>✅</td>
   </tr>
 </table>
-
 
 - ✅ **Tested and verified** – Officially tested and supported.
 - 🆗 **Likely compatible** – Expected to work, but not officially tested.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

- Update table to reflect support for 1.30 upwards.


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-511

