### PR TITLE
fix: add missing code and label for embedded CoredDNS

### DIFF
--- a/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
@@ -2,10 +2,14 @@
 title: CoreDNS
 sidebar_label: coredns
 sidebar_position: 3
+sidebar_class_name: pro
 description: Configure CoreDNS.
 ---
 
 import CoreDNS from '../../../../_partials/config/controlPlane/coredns.mdx'
+import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
+
+<ProAdmonition/>
 
 ## Separate CoreDNS
 

--- a/vcluster/configure/vcluster-yaml/networking/resolve-dns.mdx
+++ b/vcluster/configure/vcluster-yaml/networking/resolve-dns.mdx
@@ -14,11 +14,26 @@ This feature enables adding custom DNS rules to the virtual cluster to allow com
 
 ## Examples
 
+:::note 
+
+Enable embedded CoreDNS to ensure DNS resolution works inside the vcluster. Without this setting, DNS queries inside the vcluster, such as resolving services or external domains, fail. Ensure the following is added to `vcluster.yaml` or Helm values file:
+
+```yaml
+embedded:
+  coredns:
+    enabled: true
+```
+:::
+
 ### Map a hostname
 
 This is a URL-based mapping of one virtual cluster hostname to another hostname. A `wikipedia.com` DNS lookup would return a DNS response with answer as `en.wikipedia.org`.
 
 ```yaml
+controlplane:
+  coredns:
+    enabled: true
+    embedded: true 
 networking:
   resolveDNS:
     - hostname: wikipedia.com
@@ -31,6 +46,10 @@ networking:
 This is a URL-based mapping of one virtual cluster hostname to another hostname. A `test.svc.kubernetes` DNS lookup would return a DNS response with answer as `test.svc.cluster.local`.
 
 ```yaml
+controlplane:
+  coredns:
+    enabled: true
+    embedded: true 
 networking:
   resolveDNS:
     - hostname: *.svc.kubernetes
@@ -43,6 +62,10 @@ networking:
 This example maps the virtual cluster's `my-namespace/my-svc` resource to the host cluster's `dns-test/nginx-svc` resource. The DNS response is the `nginx-svc` IP in the host's `dns-test` namespace.
 
 ```yaml
+controlplane:
+  coredns:
+    enabled: true
+    embedded: true 
 networking:
   resolveDNS:
     - service: my-namespace/my-svc
@@ -56,6 +79,10 @@ This example maps a virtual cluster Service to another Service in a separate vir
 `my-ns-in-vcluster/my-svc-vcluster` maps to  `dns-test-in-vcluster-ns/test-in-vcluster-service` in a vCluster instance named `test-cluster` deployed in the host namespace `test-vcluster-ns`.
 
 ```yaml
+controlplane:
+  coredns:
+    enabled: true
+    embedded: true 
 networking:
   resolveDNS:
     - service: my-ns-in-vcluster/my-svc-vcluster
@@ -67,6 +94,10 @@ networking:
 
 Map all services under a virtual cluster namespace to a host namespace. This host namespace could also contain another vCluster instance, thereby mapping all vCluster services to another vCluster instance.
 ```yaml
+controlplane:
+  coredns:
+    enabled: true
+    embedded: true 
 networking:
   resolveDNS:
     - namespace: test-in-vcluster-ns

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/components/coredns.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/components/coredns.mdx
@@ -2,10 +2,14 @@
 title: CoreDNS
 sidebar_label: coredns
 sidebar_position: 3
+sidebar_class_name: pro
 description: Configure CoreDNS.
 ---
 
 import CoreDNS from '../../../../_partials/config/controlPlane/coredns.mdx'
+import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
+
+<ProAdmonition/>
 
 ## Separate CoreDNS
 
@@ -24,7 +28,7 @@ A normal vCluster deployment consists of two pods per vCluster instance:
 
 ## Integrated CoreDNS
 
-(Pro) The integrated CoreDNS feature lets you run CoreDNS as part of the syncer, which saves the overhead of an external CoreDNS pod. 
+The integrated CoreDNS feature lets you run CoreDNS as part of the syncer, which saves the overhead of an external CoreDNS pod. 
 
 - vCluster Pod
   - API server container

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/networking/resolve-dns.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/networking/resolve-dns.mdx
@@ -14,6 +14,19 @@ This feature enables adding custom DNS rules to the virtual cluster to allow com
 
 ## Examples
 
+:::note 
+
+Enable embedded CoreDNS to ensure DNS resolution works inside the vcluster. Without this setting, DNS queries inside the vcluster, such as resolving services or external domains, fail. Ensure the following is added to `vcluster.yaml` or Helm values file:
+
+```yaml
+embedded:
+  coredns:
+    enabled: true
+```
+:::
+
+## Examples
+
 ### Map a hostname
 
 This is a URL-based mapping of one virtual cluster hostname to another hostname. A `wikipedia.com` DNS lookup would return a DNS response with answer as `en.wikipedia.org`.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

- Update docs and add embedded CoreDNS to all code snippets
- Add enterprise label 


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-422

