### PR TITLE
fix: mark 0.23 as stable until 0.24 release is announced

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -110,18 +110,18 @@ const config = {
         editUrl: ({ versionDocsDirPath, docPath }) =>
           `https://github.com/loft-sh/vcluster-docs/edit/main/${versionDocsDirPath}/${docPath}`,
         editCurrentVersion: true,
-        lastVersion: "0.24.0",
+        lastVersion: "0.23.0",
         versions: {
           current: {
             label: "main 🚧",
           },
           "0.24.0": {
-            label: "v0.24 Stable",
+            label: "v0.24",
             banner: "none",
             badge: true,
           },
           "0.23.0": {
-            label: "v0.23",
+            label: "v0.23 Stable",
             banner: "none",
             badge: true,
           },


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Revert this PR once release is announced.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-519

