### PR TITLE
feat: clarify end of life terminology in supported versions

### DIFF
--- a/docs/_partials/support_terminology.mdx
+++ b/docs/_partials/support_terminology.mdx
@@ -1,0 +1,4 @@
+:::info support terminology
+- **EOS (End of Support)**: The date when active support ends for a version. After this date, the version receives only critical security updates.
+- **EOL (End of Life)**: The date when all support, including security updates, ends for a version.
+:::

--- a/docs/_partials/support_terminology.mdx
+++ b/docs/_partials/support_terminology.mdx
@@ -1,4 +1,4 @@
-:::info support terminology
-- **EOS (End of Support)**: The date when active support ends for a version. After this date, the version receives only critical security updates.
-- **EOL (End of Life)**: The date when all support, including security updates, ends for a version.
+:::info Support terminology
+- **End of Support (EOS)**: The date when active support for a version ends. After this date, the version only receives critical security updates.
+- **End of Life (EOL)**: The date when all support, including security updates, ends for a version.
 :::

--- a/docs/_partials/vcluster_supported_versions.mdx
+++ b/docs/_partials/vcluster_supported_versions.mdx
@@ -1,3 +1,5 @@
+import SupportTerminology from '@site/docs/_partials/support_terminology.mdx';
+
 Due to vCluster's rapid development, each minor version receives active support for 3 months after its release. After this period, it transitions to maintenance support for another 3 months, during which only security fixes are applied.
 
 Versions not listed under active or maintenance support are no longer supported.
@@ -13,4 +15,6 @@ Versions not listed under active or maintenance support are no longer supported.
 | v0.20 | August 14, 2024 | November 14, 2024 | February 14, 2025 |
 | v0.19 | February 12, 2024 | April 1, 2025* | July 1, 2025 |
 
-\* **Extended Support:** Due to the number of breaking changes from v0.19 to v0.20, the active support period for v0.19 has been extended. Review the [migration guide](/vcluster/reference/migrations/0-20-migration) to upgrade your v0.19 virtual clusters to v0.20.
+\* **Extended Support:** due to the number of breaking changes from v0.19 to v0.20, the active support period for v0.19 has been extended. Review the [migration guide](/vcluster/reference/migrations/0-20-migration) to upgrade your v0.19 virtual clusters to v0.20.
+
+<SupportTerminology />

--- a/docs/_partials/vcluster_supported_versions.mdx
+++ b/docs/_partials/vcluster_supported_versions.mdx
@@ -15,6 +15,6 @@ Versions not listed under active or maintenance support are no longer supported.
 | v0.20 | August 14, 2024 | November 14, 2024 | February 14, 2025 |
 | v0.19 | February 12, 2024 | April 1, 2025* | July 1, 2025 |
 
-\* **Extended Support:** due to the number of breaking changes from v0.19 to v0.20, the active support period for v0.19 has been extended. Review the [migration guide](/vcluster/reference/migrations/0-20-migration) to upgrade your v0.19 virtual clusters to v0.20.
+\* **Extended support**: Due to the number of breaking changes from v0.19 to v0.20, the active support period for v0.19 has been extended. Review the [migration guide](/vcluster/reference/migrations/0-20-migration) to upgrade your v0.19 virtual clusters to v0.20.
 
 <SupportTerminology />

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -126,12 +126,12 @@ const config = {
             badge: true,
           },
           "0.22.0": {
-            label: "v0.22",
-            banner: "none",
+            label: "v0.22 (EOS)",
+            banner: "unmaintained",
             badge: true,
           },
           "0.21.0": {
-            label: "v0.21 (EOL)",
+            label: "v0.21 (EOS)",
             banner: "unmaintained",
             badge: true,
           },

--- a/platform/install/supported_versions.mdx
+++ b/platform/install/supported_versions.mdx
@@ -12,8 +12,7 @@ The following defines the platform's lifecycle policy for releases and maintenan
 The platform aims to release on a regular cadence and follow [semantic versioning](https://semver.org/). We encourage users to run the latest stable release
 to stay up to date on features and security patches.
 
-Due to the rapid development of the platform, each minor version is actively supported for 3 months after it's been released. At the end of
-active support, it moves to into maintenance support for 3 months. During active support, any updates on the active development branch can
+Due to the rapid development of the platform, each minor version is actively supported for 3 months after it's been released. At the end of active support, the version moves into maintenance support. During active support, any updates on the active development branch can
 be backported upon request. During maintenance support, backporting is limited only to security updates.
 
 Any previous versions which are not on this list are no longer in any support window.

--- a/platform/install/supported_versions.mdx
+++ b/platform/install/supported_versions.mdx
@@ -4,6 +4,8 @@ sidebar_label: Releases and Maintenance
 sidebar_position: 5
 keywords: [support matrix, supported versions, lifecycle]
 ---
+import SupportTerminology from '@site/docs/_partials/support_terminology.mdx';
+
 
 The following defines the platform's lifecycle policy for releases and maintenance.
 
@@ -11,7 +13,7 @@ The platform aims to release on a regular cadence and follow [semantic versionin
 to stay up to date on features and security patches.
 
 Due to the rapid development of the platform, each minor version is actively supported for 3 months after it's been released. At the end of
-active support, it moves to into maintenance support for 3 months. During active support, any updates on the active development branch can 
+active support, it moves to into maintenance support for 3 months. During active support, any updates on the active development branch can
 be backported upon request. During maintenance support, backporting is limited only to security updates.
 
 Any previous versions which are not on this list are no longer in any support window.
@@ -26,3 +28,5 @@ Any previous versions which are not on this list are no longer in any support wi
 | v3.4| February 29, 2024 | April 1, 2025* | July 1, 2025 |
 
 \* Due to the number of breaking changes from vCluster v0.19 to v0.20 and Platform v3.4 to v4.0, v3.4 has an extended active support end date. Review the [migration guide](../reference/migrations/4-0-migration.mdx) to upgrade your v3.4 to v4.0 Platform.
+
+<SupportTerminology />


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- adding non-versioned partial with definitions of end-of-life support abbreviations.
- partial is reused between vcluster and platform.
- adjusting the eol/eos settings in dropdown and main label.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
- [Platform supported versions](https://deploy-preview-541--vcluster-docs-site.netlify.app/docs/platform/install/supported_versions)
- [vCluster releases](https://deploy-preview-541--vcluster-docs-site.netlify.app/docs/vcluster/deploy/upgrade/supported_versions)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-518

