### PR TITLE
feat: add follow-up label in linear to all issues created from prs

### DIFF
--- a/.github/workflows/create-linear-issue.yaml
+++ b/.github/workflows/create-linear-issue.yaml
@@ -19,6 +19,7 @@ jobs:
           linear-issue-description: ${{github.event.pull_request.body}}
           linear-attachment-url: ${{github.event.pull_request.html_url}}
           linear-attachment-title: ${{github.event.pull_request.title}}
+          linear-issue-label-ids: '918eb5e1-2297-44f0-b618-ca1659cbceb7' # This is label id for follow-up label
 
       - name: Create comment in PR with Linear Issue link
         uses: peter-evans/create-or-update-comment@v2


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Linear issues created from PRs will automatically have a `follow-up` label added to easier group them.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
N/A

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

