### PR TITLE
(re)factor: update ports documentation

### DIFF
--- a/platform/_partials/install/install-next-steps.mdx
+++ b/platform/_partials/install/install-next-steps.mdx
@@ -1,6 +1,6 @@
 After logging into the UI, you'll be able to start creating virtual clusters immediately. You're automatically part of a [project](../../understand/what-are-projects.mdx) called `Default Project`.
 
-Click on "New Virtual Cluster" and "Create" to spin one up to try out.
+Click **New Virtual Cluste** and **Create** to spin one up to try out.
 
 :::tip
 Find more information about creating virtual clusters in the [create virtual

--- a/platform/_partials/install/install-next-steps.mdx
+++ b/platform/_partials/install/install-next-steps.mdx
@@ -1,6 +1,6 @@
 After logging into the UI, you'll be able to start creating virtual clusters immediately. You're automatically part of a [project](../../understand/what-are-projects.mdx) called `Default Project`.
 
-Click **New Virtual Cluste** and **Create** to spin one up to try out.
+Click **New Virtual Cluster** and **Create** to spin one up to try out.
 
 :::tip
 Find more information about creating virtual clusters in the [create virtual
@@ -9,8 +9,8 @@ clusters](/platform/use-platform/virtual-clusters/create/create-no-template) sec
 
 Otherwise, read more about some primary concepts:
 
-* [Projects](../../understand/what-are-projects.mdx) - How resources can be grouped together into different projects
-* [Virtual Clusters](../../understand/what-are-virtual-clusters.mdx) - How to create and manage virtual clusters
-* [Templates](../../understand/what-are-templates.mdx) - How to use templates to control what type of resources that can be made
-* [Host Clusters](../../understand/what-are-clusters.mdx) - How to add more host clusters to the platform
-* [Sleep & Wakeup](/vcluster/manage/sleep-wakeup) - How to temporarily scale down unused virtual clusters and bring them back up
+* [Projects](../../understand/what-are-projects.mdx) - How resources can be grouped together into different projects.
+* [Virtual clusters](../../understand/what-are-virtual-clusters.mdx) - How to create and manage virtual clusters.
+* [Templates](../../understand/what-are-templates.mdx) - How to use templates to control what type of resources that can be made.
+* [Host clusters](../../understand/what-are-clusters.mdx) - How to add more host clusters to the platform.
+* [Sleep and wakeup](/vcluster/manage/sleep-wakeup) - How to temporarily scale down unused virtual clusters and bring them back up.

--- a/platform/_partials/install/open-ports.mdx
+++ b/platform/_partials/install/open-ports.mdx
@@ -9,4 +9,4 @@
     - `9444` – Management API for platform administration (`v1.management.loft.sh`)  
     - `9090` – Prometheus metrics proxy for cost monitoring  
 
-    For more information, see [Networking](../../administer/clusters/advanced/networking) to learn about port and firewall rules.
+    For more information, see [Networking](/docs/platform/administer/clusters/advanced/networking) to learn about port and firewall rules.

--- a/platform/_partials/install/open-ports.mdx
+++ b/platform/_partials/install/open-ports.mdx
@@ -1,0 +1,12 @@
+- Ensure that the required network ports are open.
+
+    :::info  
+    The platform requires open ports for API extensions, webhooks, and cost monitoring. In private GKE clusters, ensure firewall rules allow traffic from the Kubernetes master to platform components.  
+    :::
+
+    - `8443` – API service extension for cluster communication (`v1.cluster.loft.sh`)  
+    - `9443` – Webhook validation and enforcement (`loft webhook`)  
+    - `9444` – Management API for platform administration (`v1.management.loft.sh`)  
+    - `9090` – Prometheus metrics proxy for cost monitoring  
+
+    For more information, see [Networking](../../administer/clusters/advanced/networking) to learn about port and firewall rules.

--- a/platform/administer/clusters/advanced/monitoring.mdx
+++ b/platform/administer/clusters/advanced/monitoring.mdx
@@ -1,12 +1,4 @@
----
-title: Cluster Monitoring
-sidebar_label: Monitoring
-description: Monitor your cluster with Prometheus and view Grafana dashboards in the Platform UI.
----
-
-vCluster Platform provides direct integration with Prometheus. With the recommended app kube-prometheus-stack, a complete monitoring setup can be enabled in your cluster with a single click.
-To leverage the prometheus integration, you'd have to install the kube-prometheus-stack application from within the platform.
-
+x
 
 ## 1. Install kube-prometheus-stack
 

--- a/platform/administer/clusters/advanced/monitoring.mdx
+++ b/platform/administer/clusters/advanced/monitoring.mdx
@@ -1,8 +1,16 @@
-x
+---
+title: Cluster Monitoring
+sidebar_label: Monitoring
+description: Monitor your cluster with Prometheus and view Grafana dashboards in the platform UI.
+---
 
-## 1. Install kube-prometheus-stack
+vCluster Platform provides direct integration with Prometheus. With the recommended app `kube-prometheus-stack, a complete monitoring setup can be enabled in your cluster with a single click.
 
-Navigate to `Clusters -> CLUSTER -> Overview` and click on the recommended app `kube-prometheus-stack`.
+To use the prometheus integration, you must install the `kube-prometheus-stack` application from within the platform.
+
+## Install `kube-prometheus-stack`
+
+Navigate to **Clusters** -> **CLUSTER** -> **Overview** and click the recommended app `kube-prometheus-stack`.
 
 <figure class="frame">
   <img
@@ -17,6 +25,6 @@ Navigate to `Clusters -> CLUSTER -> Overview` and click on the recommended app `
 
 ```
 
-After pressing _Install_, please be patient until the kube-prometheus-stack is installed.
+After selecting **Install**, wait until the `kube-prometheus-stack` is installed.
 
-Congratulations, you now have a fully fledged monitoring setup with vCluster Platform & Prometheus.
+Congratulations, you now have a complete monitoring system with vCluster Platform and Prometheus!

--- a/platform/administer/clusters/advanced/monitoring.mdx
+++ b/platform/administer/clusters/advanced/monitoring.mdx
@@ -21,10 +21,10 @@ Navigate to **Clusters** -> **CLUSTER** -> **Overview** and click the recommende
 </figure>
 
 ```yaml
-# Required values by vCluster Platform
+# Required values by the platform
 
 ```
 
 After selecting **Install**, wait until the `kube-prometheus-stack` is installed.
 
-Congratulations, you now have a complete monitoring system with vCluster Platform and Prometheus!
+Congratulations, you now have a complete monitoring system with the platform and Prometheus.

--- a/platform/administer/clusters/advanced/monitoring.mdx
+++ b/platform/administer/clusters/advanced/monitoring.mdx
@@ -1,5 +1,5 @@
 ---
-title: Cluster Monitoring
+title: Cluster monitoring
 sidebar_label: Monitoring
 description: Monitor your cluster with Prometheus and view Grafana dashboards in the platform UI.
 ---

--- a/platform/administer/clusters/advanced/networking.mdx
+++ b/platform/administer/clusters/advanced/networking.mdx
@@ -1,0 +1,63 @@
+---
+title: Networking
+sidebar_label: Networking 
+description: 
+---
+
+vCluster Platform requires specific network ports to be open for communication between Kubernetes clusters, the platform API, and external services. These ports handle API requests, webhook execution, and cost monitoring. If they are blocked by firewall rules, certain features may fail.
+
+## Required open ports  
+
+### Connecting Kubernetes to vCluster Platform  
+
+Kubernetes must be able to communicate with vCluster platform’s API extensions and webhooks.
+
+| Port  | Purpose |  
+|-----------|------------|  
+| `8443`  | API service extension (`v1.cluster.loft.sh`) |  
+| `9443`  | Webhook validation (`loft webhook`) |  
+| `9444`  | Management API (`v1.management.loft.sh`) |  
+
+
+NOTE: In private GKE clusters, Kubernetes control plane and worker nodes might reside in separate subnetworks. You might need a firewall rule to allow traffic on these ports.
+
+### Connect vCluster to Prometheus 
+
+vCluster Platform connects to Prometheus in connected clusters to retrieve cost metrics. If cost metrics are missing, confirm that the vCluster platform can reach Prometheus over `TCP 9090`.
+
+| Port  | Purpose |  
+|-----------|------------|  
+| `9090`  | Prometheus cost control dashboard metrics |  
+
+
+## Firewall rules configuration  
+
+If your firewall blocks these ports, you can create rules to allow required traffic.
+
+### Allow Kubernetes to connect to the platform  
+
+```sh
+gcloud compute firewall-rules create allow-k8s-api-to-vcluster-platform \
+  --allow tcp:8443,tcp:9443,tcp:9444 \
+  --source-ranges=<KUBERNETES_API_IP_RANGE> \
+  --target-tags=vcluster-platform
+```
+    - Replace `<KUBERNETES_API_IP_RANGE>` with the actual Kubernetes API IP range.
+
+
+### Allow the platform to connect to Prometheus
+
+```sh
+gcloud compute firewall-rules create allow-vcluster-platform-to-prometheus \
+  --allow tcp:9090 \
+  --source-ranges=<VCLUSTER_PLATFORM_IP> \
+  --target-tags=prometheus
+```
+    - Replace `<VCLUSTER_PLATFORM_IP>` with the platform instance’s IP.
+
+
+## Troubleshooting connectivity issues
+
+TBD
+
+

--- a/platform/administer/clusters/advanced/networking.mdx
+++ b/platform/administer/clusters/advanced/networking.mdx
@@ -4,13 +4,13 @@ sidebar_label: Networking
 description: vCluster requires specific network ports to to be open for communication
 ---
 
-vCluster Platform uses specific network ports to enable communication between Kubernetes clusters, the platform API, and external services. These ports support API requests, webhook execution, and cost monitoring.
+vCluster platform uses specific network ports to enable communication between Kubernetes clusters, the platform API, and external services. These ports support API requests, webhook execution, and cost monitoring.
 
 IMPORTANT: If these ports are blocked by firewall rules, some platform features—such as role-based access control (RBAC) enforcement, cost monitoring, or webhook validation—might fail.
 
 ## Required open ports
 
-### Connecting Kubernetes to vCluster Platform
+### Connecting Kubernetes to vCluster platform
 
 Kubernetes must connect to the platform’s API extensions and webhooks to process requests, enforce policies, and perform management operations. The following ports must be open:
 

--- a/platform/administer/clusters/advanced/networking.mdx
+++ b/platform/administer/clusters/advanced/networking.mdx
@@ -1,45 +1,52 @@
 ---
-title: Networking
-sidebar_label: Networking 
-description: vCluster requires specific network ports to to be open for communication
+title: Networking  
+sidebar_label: Networking  
+description: Learn which ports must be open to enable communication on the platform.  
 ---
 
-vCluster platform uses specific network ports to enable communication between Kubernetes clusters, the platform API, and external services. These ports support API requests, webhook execution, and cost monitoring.
+The platform uses specific network ports to enable communication between Kubernetes clusters, the platform API, and external services. These ports support API requests, webhook execution, and cost monitoring.
 
-IMPORTANT: If these ports are blocked by firewall rules, some platform features—such as role-based access control (RBAC) enforcement, cost monitoring, or webhook validation—might fail.
+If these ports are blocked by firewall rules, some platform features—such as role-based access control (RBAC) enforcement, cost monitoring, or webhook validation—might fail. Ensure these ports are open to prevent connectivity issues.
 
 ## Required open ports
 
-### Connecting Kubernetes to vCluster platform
+### Connect Kubernetes to the platform
 
-Kubernetes must connect to the platform’s API extensions and webhooks to process requests, enforce policies, and perform management operations. The following ports must be open:
+Kubernetes must connect to the platform’s API extensions and webhooks to process requests, enforce policies, and perform management operations. The following ports must be open to allow for communication:
 
-| Port | Purpose |
-|------|---------|
-| `8443` | API service extension (`v1.cluster.loft.sh`) – Enables Kubernetes API integration with vCluster Platform. |
-| `9443` | Webhook validation (`loft webhook`) – Validates requests and enforces policies. |
-| `9444` | Management API (`v1.management.loft.sh`) – Handles platform-wide administration and cluster management. |
+| Port   | Description | Purpose                               |
+|--------|-------------|---------------------------------------|
+| `8443` | API service extension (`v1.cluster.loft.sh`)| Enables Kubernetes API integration with the platform |
+| `9443` | Webhook validation (`loft webhook`)| Validates requests and enforces policies |
+| `9444` | Management API (`v1.management.loft.sh`)| Handles platform-wide administration and cluster management |
 
-NOTE: In private GKE clusters, Kubernetes control plane and worker nodes may reside in separate subnetworks. You may need to explicitly allow traffic on these ports using a firewall rule.
+:::note
+In private GKE clusters, Kubernetes control plane and worker nodes might reside in separate subnetworks. You might need to explicitly allow traffic on these ports using a firewall rule.
+:::
 
-### Connecting platform to Prometheus
+### Connect the platform to Prometheus
 
 The platform retrieves cost metrics from Prometheus running inside connected clusters. The platform's cost control dashboard uses these metrics to provide insights into resource usage.  
 
-To collect this data, the local cluster agent acts as a proxy between vCluster Platform and Prometheus. This requires an open connection over `TCP port 9090`. If cost metrics are missing or unavailable, verify that the platform can reach Prometheus on this port.
+To collect this data, the local cluster agent acts as a proxy between the platform and Prometheus. This requires an open connection over `TCP port 9090`. If cost metrics are missing or unavailable, verify that the platform can reach Prometheus on this port.
 
+| Port   | Description | Purpose                           |
+|--------|-------------|---------------------------------------|
+| `9090` | Cost control dashboard metrics | Enables cost monitoring and visualization |
 
-| Port | Purpose |
-|------|---------|
-| `9090` | Prometheus cost control dashboard metrics – Enables cost monitoring and visualization. |
+:::note
+If your environment has strict firewall rules or network policies, you might need to explicitly allow traffic over `TCP 9090` between the platform and Prometheus.
+:::
 
-NOTE: If your environment has strict firewall rules or network policies, you might need to explicitly allow traffic over `TCP 9090` between the platform and Prometheus.
+<!--
+
+// I do not think this works for vCluster, but we should mention what to do if a firewall blocks the ports (becasue we mention firewall above!). Should we include tabs on the different ways to do this? Is that necessary? Also I would like to add a verification step to verify firewall rules/configurations if so. 
 
 ## Firewall rules configuration
 
-If your firewall blocks these ports, you need to create rules to allow required traffic.
+If your firewall blocks ports, you must create rules to allow required traffic. You can configure access using network security settings such as VPC firewall rules or AWS Security Groups.
 
-### Allow Kubernetes to connect to the Platform
+### Allow Kubernetes to connect to the platform
 
 Run the following command to allow Kubernetes to communicate with the platform:
 
@@ -49,3 +56,41 @@ gcloud compute firewall-rules create allow-k8s-api-to-vcluster-platform \
   --source-ranges=<KUBERNETES_API_IP_RANGE> \
   --target-tags=vcluster-platform
 ```
+
+- Replace `<KUBERNETES_API_IP_RANGE>` with the actual IP range of the Kubernetes API server.
+
+:::note
+In private GKE clusters, the Kubernetes control plane and nodes are not in the same subnetwork. Without this rule, Kubernetes cannot communicate with platform components.
+:::
+
+### Allow the platform to connect to Prometheus
+
+vCluster Platform collects cost metrics from Prometheus running inside connected clusters. To enable this, the local cluster agent proxies requests to Prometheus over `TCP port 9090`. If the platform cannot access Prometheus, cost monitoring might fail.  
+
+Run the following command to allow the platform to communicate with Prometheus:  
+
+```sh
+gcloud compute firewall-rules create allow-vcluster-platform-to-prometheus \
+  --allow tcp:9090 \
+  --source-ranges=<VCLUSTER_PLATFORM_IP> \
+  --target-tags=prometheus
+```
+
+- Replace `<VCLUSTER_PLATFORM_IP>` with the IP address of the platform instance.
+
+
+### Verify firewall rules
+
+After setting up firewall rules, test the connection between the platform and Prometheus:
+
+```sh
+nc -zv <PROMETHEUS_IP> 9090
+```
+
+If successful, the output confirm with the following message:
+
+```sh
+Connection to <PROMETHEUS_IP> 9090 port [tcp/http] succeeded!
+```
+
+-->

--- a/platform/administer/clusters/advanced/networking.mdx
+++ b/platform/administer/clusters/advanced/networking.mdx
@@ -40,7 +40,7 @@ If your environment has strict firewall rules or network policies, you might nee
 
 <!--
 
-// I do not think this works for vCluster, but we should mention what to do if a firewall blocks the ports (becasue we mention firewall above!). Should we include tabs on the different ways to do this? Is that necessary? Also I would like to add a verification step to verify firewall rules/configurations if so. 
+// I do not think this works for vCluster, but we should mention what to do if a firewall blocks the ports (because we mention firewall above!). Should we include tabs on the different ways to do this? Is that necessary? Also I would like to add a verification step to verify firewall rules/configurations if so. 
 
 ## Firewall rules configuration
 

--- a/platform/administer/clusters/advanced/networking.mdx
+++ b/platform/administer/clusters/advanced/networking.mdx
@@ -38,9 +38,6 @@ To collect this data, the local cluster agent acts as a proxy between the platfo
 If your environment has strict firewall rules or network policies, you might need to explicitly allow traffic over `TCP 9090` between the platform and Prometheus.
 :::
 
-<!--
-
-// I do not think this works for vCluster, but we should mention what to do if a firewall blocks the ports (because we mention firewall above!). Should we include tabs on the different ways to do this? Is that necessary? Also I would like to add a verification step to verify firewall rules/configurations if so. 
 
 ## Firewall rules configuration
 
@@ -92,5 +89,3 @@ If successful, the output confirm with the following message:
 ```sh
 Connection to <PROMETHEUS_IP> 9090 port [tcp/http] succeeded!
 ```
-
--->

--- a/platform/administer/clusters/advanced/networking.mdx
+++ b/platform/administer/clusters/advanced/networking.mdx
@@ -1,40 +1,47 @@
 ---
 title: Networking
 sidebar_label: Networking 
-description: 
+description: vCluster requires specific network ports to to be open for communication
 ---
 
-vCluster Platform requires specific network ports to be open for communication between Kubernetes clusters, the platform API, and external services. These ports handle API requests, webhook execution, and cost monitoring. If they are blocked by firewall rules, certain features may fail.
+vCluster Platform uses specific network ports to enable communication between Kubernetes clusters, the platform API, and external services. These ports support API requests, webhook execution, and cost monitoring.
 
-## Required open ports  
+IMPORTANT: If these ports are blocked by firewall rules, some platform features—such as role-based access control (RBAC) enforcement, cost monitoring, or webhook validation—might fail.
 
-### Connecting Kubernetes to vCluster Platform  
+## Required open ports
 
-Kubernetes must be able to communicate with vCluster platform’s API extensions and webhooks.
+### Connecting Kubernetes to vCluster Platform
 
-| Port  | Purpose |  
-|-----------|------------|  
-| `8443`  | API service extension (`v1.cluster.loft.sh`) |  
-| `9443`  | Webhook validation (`loft webhook`) |  
-| `9444`  | Management API (`v1.management.loft.sh`) |  
+Kubernetes must connect to the platform’s API extensions and webhooks to process requests, enforce policies, and perform management operations. The following ports must be open:
+
+| Port | Purpose |
+|------|---------|
+| `8443` | API service extension (`v1.cluster.loft.sh`) – Enables Kubernetes API integration with vCluster Platform. |
+| `9443` | Webhook validation (`loft webhook`) – Validates requests and enforces policies. |
+| `9444` | Management API (`v1.management.loft.sh`) – Handles platform-wide administration and cluster management. |
+
+NOTE: In private GKE clusters, Kubernetes control plane and worker nodes may reside in separate subnetworks. You may need to explicitly allow traffic on these ports using a firewall rule.
+
+### Connecting platform to Prometheus
+
+The platform retrieves cost metrics from Prometheus running inside connected clusters. The platform's cost control dashboard uses these metrics to provide insights into resource usage.  
+
+To collect this data, the local cluster agent acts as a proxy between vCluster Platform and Prometheus. This requires an open connection over `TCP port 9090`. If cost metrics are missing or unavailable, verify that the platform can reach Prometheus on this port.
 
 
-NOTE: In private GKE clusters, Kubernetes control plane and worker nodes might reside in separate subnetworks. You might need a firewall rule to allow traffic on these ports.
+| Port | Purpose |
+|------|---------|
+| `9090` | Prometheus cost control dashboard metrics – Enables cost monitoring and visualization. |
 
-### Connect vCluster to Prometheus 
+NOTE: If your environment has strict firewall rules or network policies, you might need to explicitly allow traffic over `TCP 9090` between the platform and Prometheus.
 
-vCluster Platform connects to Prometheus in connected clusters to retrieve cost metrics. If cost metrics are missing, confirm that the vCluster platform can reach Prometheus over `TCP 9090`.
+## Firewall rules configuration
 
-| Port  | Purpose |  
-|-----------|------------|  
-| `9090`  | Prometheus cost control dashboard metrics |  
+If your firewall blocks these ports, you need to create rules to allow required traffic.
 
+### Allow Kubernetes to connect to the Platform
 
-## Firewall rules configuration  
-
-If your firewall blocks these ports, you can create rules to allow required traffic.
-
-### Allow Kubernetes to connect to the platform  
+Run the following command to allow Kubernetes to communicate with the platform:
 
 ```sh
 gcloud compute firewall-rules create allow-k8s-api-to-vcluster-platform \
@@ -42,22 +49,3 @@ gcloud compute firewall-rules create allow-k8s-api-to-vcluster-platform \
   --source-ranges=<KUBERNETES_API_IP_RANGE> \
   --target-tags=vcluster-platform
 ```
-    - Replace `<KUBERNETES_API_IP_RANGE>` with the actual Kubernetes API IP range.
-
-
-### Allow the platform to connect to Prometheus
-
-```sh
-gcloud compute firewall-rules create allow-vcluster-platform-to-prometheus \
-  --allow tcp:9090 \
-  --source-ranges=<VCLUSTER_PLATFORM_IP> \
-  --target-tags=prometheus
-```
-    - Replace `<VCLUSTER_PLATFORM_IP>` with the platform instance’s IP.
-
-
-## Troubleshooting connectivity issues
-
-TBD
-
-

--- a/platform/administer/clusters/connect-cluster.mdx
+++ b/platform/administer/clusters/connect-cluster.mdx
@@ -44,7 +44,7 @@ sure to check the `CLI` tab for working with the command.
 
   If your kubectl context is not set to the cluster with running platform, it's
   possible to login to the platform using the CLI and access key.
-  If you haven't already, you need to [create access key](/platform/api/authentication#create-access-key) to be able to login to the platform.
+  If you haven't already, you need to [create access key](/docs/platform/api/authentication#create-an-access-key) to be able to login to the platform.
 
   ```bash title="Login to the platform using access key"
   vcluster platform login [platform-url] --access-key [access-key]

--- a/platform/install/advanced/air-gapped.mdx
+++ b/platform/install/advanced/air-gapped.mdx
@@ -41,7 +41,7 @@ accessible to your cluster.
 
 ### Supported Kubernetes versions
 
-- A running air-gapped Kubernetes cluster with one of the [supported versions](../../../vcluster/deploy/upgrade/supported_versions.mdx#kubernetes-compatibility-matrix)
+- A running air-gapped Kubernetes cluster with one of the [supported versions](/docs/vcluster/deploy/upgrade/supported_versions#kubernetes-compatibility-matrix)
 
 :::note
 Although the platform might work with other versions, using the supported versions is recommended to avoid potential issues.

--- a/platform/install/advanced/air-gapped.mdx
+++ b/platform/install/advanced/air-gapped.mdx
@@ -41,7 +41,7 @@ accessible to your cluster.
 
 ### Supported Kubernetes versions
 
-- A running air-gapped Kubernetes cluster with one of the [supported versions](../../../deploy/upgrade/supported_versions.mdx#kubernetes-compatibility-matrix)
+- A running air-gapped Kubernetes cluster with one of the [supported versions](../../../vcluster/deploy/upgrade/supported_versions.mdx#kubernetes-compatibility-matrix)
 
 :::note
 Although the platform might work with other versions, using the supported versions is recommended to avoid potential issues.

--- a/platform/install/advanced/air-gapped.mdx
+++ b/platform/install/advanced/air-gapped.mdx
@@ -2,7 +2,7 @@
 title: Deploy in Air-Gapped Environments
 sidebar_label: Using Air-Gapped Installation
 sidebar_position: 1
-description: Learn how to install vCluster Platform in air-gapped, offline, or VPC environments with restricted network connectivity.
+description: Learn how to install vCluster platform in air-gapped, offline, or VPC environments with restricted network connectivity.
 ---
 
 import Flow, { Step } from "@site/src/components/Flow";
@@ -11,10 +11,9 @@ import PartialAdminUpgrade from "../../_partials/install/upgrade.mdx";
 import Mark from "@site/src/components/Mark";
 
 import BasePrerequisites from '../../_partials/install/base-prerequisites.mdx';
-
 import LoginAfterHelmInstall from '../../_partials/install/login-after-helm-install.mdx';
-
 import InstallNextSteps from '../../_partials/install/install-next-steps.mdx';
+import NetworkPorts from '../../_partials/install/open-ports.mdx';
 
 
 If your cluster is air-gapped, within a VPC, or has restricted network connectivity, you may encounter issues validating the platform license and pulling required container images.
@@ -33,6 +32,7 @@ accessible to your cluster.
 <BasePrerequisites />
 
 -  A private Docker registry accessible to both the installer computer and the air-gapped Kubernetes cluster
+
 ### Optional prerequisites
 
 - On the installation computer:
@@ -41,10 +41,10 @@ accessible to your cluster.
 
 ### Supported Kubernetes versions
 
-- A running air-gapped Kubernetes cluster with one of the supported versions: `v1.30.x`, `v1.31.x`, or `v1.32.x`
+- A running air-gapped Kubernetes cluster with one of the [supported versions](../../../deploy/upgrade/supported_versions.mdx#kubernetes-compatibility-matrix)
 
 :::note
-Although the platform may work with other versions, using the supported versions is recommended to avoid potential issues.
+Although the platform might work with other versions, using the supported versions is recommended to avoid potential issues.
 :::
 
 ### Resource requirements
@@ -57,24 +57,15 @@ Although the platform may work with other versions, using the supported versions
   - Limits
     - memory: `4Gi`
     - cpu: `2`
+  
+<NetworkPorts />
 
-- Open network ports:
-  :::info
-  The platform installs webhooks and API server extensions into the cluster. The Kubernetes master needs to communicate with the platform pods. For example, in private GKE clusters, the Kubernetes master and nodes are not in the same subnetwork and cannot communicate directly on every port. Ensure a firewall rule allows incoming traffic from the Kubernetes master network to the following TCP ports:
-  :::
-  - `8443` (platform agent API service extension - `v1.cluster.loft.sh`)
-  - `9443` (platform agent webhook & loft webhook)
-  - `9444` (platform API service extension - `v1.management.loft.sh`)
-  :::info
-  The platform's cost control dashboard federates metrics from each connected cluster. In order to scrape these metrics, it utilizes the local cluster agent to proxy to the cluster's Prometheus pods. The agent requires connectivity over TCP port `9090` to access the Prometheus pods.
-  :::
-  - `9090` (cost control dashboard Prometheus pods)
 
 ## Deployment
 
-### Offline Images
+### Offline images
 
-For clusters unable to pull images from Docker Hub, you need to push the platform images to your private registry. Each platform release includes a `loft-images.txt` file that lists the necessary images.
+For clusters unable to pull images from Docker Hub, you must push the platform images to your private registry. Each platform release includes a `loft-images.txt` file that lists the necessary images.
 
 :::warning
 When using virtual clusters in air-gapped environments, the
@@ -165,9 +156,10 @@ env:
 ```
 
 :::info
-Apply this configuration during the initial installation process or when upgrading the platform. Include it in your `vcluster-platform.yaml` file or pass it as a value to the Helm install/upgrade command.
+Apply this configuration during the initial installation process or when upgrading the platform. Include it in your `vcluster-platform.yaml` file or pass it as a value to the Helm install or upgrade command.
 :::
-## Login
+
+## Log in
 
 <LoginAfterHelmInstall />
 

--- a/platform/install/gitops.mdx
+++ b/platform/install/gitops.mdx
@@ -9,7 +9,7 @@ import ListHelmVersions from "../_partials/install/list-helm-versions.mdx";
 import BasePrerequisites from '../_partials/install/base-prerequisites.mdx';
 import LoginAfterHelmInstall from '../_partials/install/login-after-helm-install.mdx';
 import InstallNextSteps from '../_partials/install/install-next-steps.mdx';
-import NetworkPorts from '../../_partials/install/open-ports.mdx';
+import NetworkPorts from '../_partials/install/open-ports.mdx';
 
 
 The platform can be deployed using [GitOps](https://argoproj.github.io/cd/), just as you would for deploying applications in your Kubernetes clusters. This guide provides a quick overview of deploying the platform with GitOps. Since the platform is similar to other applications, standard GitOps practices are equally applicable.

--- a/platform/install/gitops.mdx
+++ b/platform/install/gitops.mdx
@@ -229,7 +229,7 @@ Managing connected clusters via GitOps offers several advantages:
 
 ### Cluster resources
 
-  If you would like to manage the platform _and_ its agents via your GitOps tooling, you likely also want to manage the connected cluster configurations that live inside the platform.
+  If you would like to manage the platform _and_ its agents via your GitOps tooling, you likely also want to manage the connected cluster configurations that live inside the platform. For information about networking requirements, see [Networking](/docs/platform/administer/clusters/advanced/networking).
 
   These configuration elements inform the platform of:
 

--- a/platform/install/gitops.mdx
+++ b/platform/install/gitops.mdx
@@ -6,12 +6,10 @@ description: Learn how to deploy vCluster Platform in a GitOps style using ArgoC
 ---
 
 import ListHelmVersions from "../_partials/install/list-helm-versions.mdx";
-
 import BasePrerequisites from '../_partials/install/base-prerequisites.mdx';
-
 import LoginAfterHelmInstall from '../_partials/install/login-after-helm-install.mdx';
-
 import InstallNextSteps from '../_partials/install/install-next-steps.mdx';
+import NetworkPorts from '../../_partials/install/open-ports.mdx';
 
 
 The platform can be deployed using [GitOps](https://argoproj.github.io/cd/), just as you would for deploying applications in your Kubernetes clusters. This guide provides a quick overview of deploying the platform with GitOps. Since the platform is similar to other applications, standard GitOps practices are equally applicable.
@@ -27,6 +25,10 @@ This guide details deploying the platform using GitOps practices, specifically w
 ### ArgoCD
 
 ArgoCD needs to be installed and configured on the host cluster. Follow the [Argo CD Installation Guide](https://argo-cd.readthedocs.io/en/stable/getting_started/) to install it.
+
+### Resource requirements
+
+<NetworkPorts />
 
 
 ## Deployment

--- a/platform/install/helm.mdx
+++ b/platform/install/helm.mdx
@@ -12,6 +12,7 @@ import InstallNextSteps from "../_partials/install/install-next-steps.mdx";
 import ListHelmVersions from "../_partials/install/list-helm-versions.mdx";
 
 import BasePrerequisites from "../_partials/install/base-prerequisites.mdx";
+import NetworkPorts from '../../_partials/install/open-ports.mdx';
 
 The platform can be deployed directly using Helm commands. Managing the platform deployment with Helm directly can be a great way to "GitOps" your platform
 deployment, by using ArgoCD or other GitOps tools to manage the platform deployment. This section outlines the basics of deploying and managing the platform with
@@ -21,6 +22,11 @@ in a GitOps fashion as well.
 ## Prerequisites
 
 <BasePrerequisites />
+
+### Resource requirements
+
+<NetworkPorts />
+
 
 ## Deployment
 

--- a/platform/install/helm.mdx
+++ b/platform/install/helm.mdx
@@ -12,7 +12,7 @@ import InstallNextSteps from "../_partials/install/install-next-steps.mdx";
 import ListHelmVersions from "../_partials/install/list-helm-versions.mdx";
 
 import BasePrerequisites from "../_partials/install/base-prerequisites.mdx";
-import NetworkPorts from '../../_partials/install/open-ports.mdx';
+import NetworkPorts from '../_partials/install/open-ports.mdx';
 
 The platform can be deployed directly using Helm commands. Managing the platform deployment with Helm directly can be a great way to "GitOps" your platform
 deployment, by using ArgoCD or other GitOps tools to manage the platform deployment. This section outlines the basics of deploying and managing the platform with

--- a/platform/install/helm.mdx
+++ b/platform/install/helm.mdx
@@ -27,6 +27,8 @@ in a GitOps fashion as well.
 
 <NetworkPorts />
 
+For more detailed information about networking requirements, see [Networking](/docs/platform/administer/clusters/advanced/networking).
+
 
 ## Deployment
 

--- a/platform/install/quick-start-guide.mdx
+++ b/platform/install/quick-start-guide.mdx
@@ -36,6 +36,8 @@ After installation, verify the successful installation of the vCluster CLI by ru
 
 <NetworkPorts />
 
+For more detailed information about networking requirements, see [Networking](/docs/platform/administer/clusters/advanced/networking).
+
 
 ## Deployment
 

--- a/platform/install/quick-start-guide.mdx
+++ b/platform/install/quick-start-guide.mdx
@@ -11,6 +11,7 @@ import InstallNextSteps from "../_partials/install/install-next-steps.mdx";
 import ListHelmVersions from '../_partials/install/list-helm-versions.mdx';
 
 import BasePrerequisites from '../_partials/install/base-prerequisites.mdx';
+import NetworkPorts from '../../_partials/install/open-ports.mdx';
 
 
 The `vCluster CLI` is the preferred method for deploying the platform to a Kubernetes cluster.
@@ -30,6 +31,10 @@ Use one of the following commands to download the vCluster CLI binary from GitHu
 :::tip
 After installation, verify the successful installation of the vCluster CLI by running `vcluster version` in your terminal. This command should display the installed version of the vCluster CLI.
 :::
+
+### Resource requirements
+
+<NetworkPorts />
 
 
 ## Deployment

--- a/platform/install/quick-start-guide.mdx
+++ b/platform/install/quick-start-guide.mdx
@@ -11,7 +11,7 @@ import InstallNextSteps from "../_partials/install/install-next-steps.mdx";
 import ListHelmVersions from '../_partials/install/list-helm-versions.mdx';
 
 import BasePrerequisites from '../_partials/install/base-prerequisites.mdx';
-import NetworkPorts from '../../_partials/install/open-ports.mdx';
+import NetworkPorts from '../_partials/install/open-ports.mdx';
 
 
 The `vCluster CLI` is the preferred method for deploying the platform to a Kubernetes cluster.

--- a/vcluster/configure/vcluster-yaml/export-kube-config.mdx
+++ b/vcluster/configure/vcluster-yaml/export-kube-config.mdx
@@ -59,7 +59,7 @@ for the default secret `vc-NAME` and do not affect the additional secrets that y
 
 The default secret and the secret specified with the deprecated `exportKubeConfig.secret` field are customized with
 the same set of fields (`exportKubeConfig.context`, `exportKubeConfig.server`, etc), so setting these fields customizes
-both the default and the deprecated secret in the same way. More details in the [migration section below](#migrate-customized-deprecated-secret-to-new-additional-secrets).
+both the default and the deprecated secret in the same way. More details in the [migration section below](#migrate-custom-deprecated).
 
 :::
 
@@ -136,7 +136,7 @@ exportKubeConfig:
   - name: my-secret
 ```
 
-#### Migrate a customized deprecated secret to new additional secrets
+#### Migrate a customized deprecated secret to new additional secrets {#migrate-custom-deprecated}
 
 The secret defined using the deprecated `exportKubeConfig.secret` field is customized using the same configuration fields (such as `exportKubeConfig.context`, `exportKubeConfig.server`) as the default kubeconfig secret.
 

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/export-kube-config.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/export-kube-config.mdx
@@ -59,7 +59,7 @@ for the default secret `vc-NAME` and do not affect the additional secrets that y
 
 The default secret and the secret specified with the deprecated `exportKubeConfig.secret` field are customized with
 the same set of fields (`exportKubeConfig.context`, `exportKubeConfig.server`, etc), so setting these fields customizes
-both the default and the deprecated secret in the same way. More details in the [migration section below](#migrate-customized-deprecated-secret-to-new-additional-secrets).
+both the default and the deprecated secret in the same way. More details in the [migration section below](#migrate-custom-deprecated).
 
 :::
 
@@ -136,7 +136,7 @@ exportKubeConfig:
   - name: my-secret
 ```
 
-#### Migrate a customized deprecated secret to new additional secrets
+#### Migrate a customized deprecated secret to new additional secrets {#migrate-custom-deprecated}
 
 The secret defined using the deprecated `exportKubeConfig.secret` field is customized using the same configuration fields (such as `exportKubeConfig.context`, `exportKubeConfig.server`) as the default kubeconfig secret.
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Add clarity to open ports docs. 
- Add a networking section and also put content in troubleshooting section. 
> NOTE: I attempted to add some firewall information to this doc, but I'm not sure if it's correct. While we mention firewall considerations, we don't provide specific details, which is less than ideal for users. I've added some content but commented it out because I'm uncertain about its accuracy. Could you please review both the PR source and the rendered preview? I'm looking for clarity and information for the firewall section as well, as it would be beneficial to make this available to users.


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
- [Link to Preview - Troubleshooting](https://deploy-preview-508--vcluster-docs-site.netlify.app/docs/platform/administer/clusters/advanced/networking)
- [Link to Preview - Install Partials](https://deploy-preview-508--vcluster-docs-site.netlify.app/docs/platform/install/quick-start-guide)
- [Link to Preview - Networking](https://deploy-preview-508--vcluster-docs-site.netlify.app/docs/platform/administer/clusters/advanced/networking)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-462
Closes DOC-451
Closes DOC-505