### PR TITLE
refactor: add troublshooting for etcd nospace docs

### DIFF
--- a/vcluster/troubleshoot/_category_.json
+++ b/vcluster/troubleshoot/_category_.json
@@ -1,0 +1,5 @@
+{
+    "label": "Troubleshoot",
+    "position": "9",
+    "collapsible": true
+  }

--- a/vcluster/troubleshoot/_category_.json
+++ b/vcluster/troubleshoot/_category_.json
@@ -1,5 +1,5 @@
 {
     "label": "Troubleshoot",
-    "position": "7",
+    "position": "8",
     "collapsible": true
   }

--- a/vcluster/troubleshoot/_category_.json
+++ b/vcluster/troubleshoot/_category_.json
@@ -1,5 +1,5 @@
 {
     "label": "Troubleshoot",
-    "position": "9",
+    "position": "7",
     "collapsible": true
   }

--- a/vcluster/troubleshoot/etcd-compaction.mdx
+++ b/vcluster/troubleshoot/etcd-compaction.mdx
@@ -89,7 +89,7 @@ If you find a problematic object, pause syncing for it in your vCluster config.
    export ETCD_SRVNAME=<etcd-pod-name>
    ```
 
-3. Get the current revision number. Retrieve the current revision number of etcd using the following command:
+- Get the current revision number. Retrieve the current revision number of etcd using the following command:
 
    ```bash
    etcdctl endpoint status --write-out json \
@@ -99,7 +99,7 @@ If you find a problematic object, pause syncing for it in your vCluster config.
        --cert=/run/config/pki/etcd-peer.crt
    ```
 
-4. Compact the etcd database. Compact etcd to remove old data and free up disk space:
+- Compact the etcd database. Compact etcd to remove old data and free up disk space:
 
    ```bash
    etcdctl --command-timeout=600s compact <revision-number> \
@@ -110,7 +110,7 @@ If you find a problematic object, pause syncing for it in your vCluster config.
    ```
     Replace `<revision-number>` with the value retrieved from the previous command.
 
-5. Defragment etcd. Defragment etcd to optimize disk usage and improve performance:
+- Defragment etcd. Defragment etcd to optimize disk usage and improve performance:
 
    ```bash
    etcdctl --command-timeout=600s defrag \
@@ -120,7 +120,7 @@ If you find a problematic object, pause syncing for it in your vCluster config.
        --cert=/run/config/pki/etcd-peer.crt
    ```
 
-6. Repeat for all etcd pods in your cluster.
+- Repeat for all etcd pods in your cluster.
 
 </Step>
 

--- a/vcluster/troubleshoot/etcd-compaction.mdx
+++ b/vcluster/troubleshoot/etcd-compaction.mdx
@@ -59,17 +59,22 @@ The `NOSPACE` alarm occurs due to two common conditions:
 
 To resolve the issue, compact and defragment the etcd database to free up space. Then, reconfigure etcd with automatic compaction and increase its storage quota to prevent recurrence.
 
-### Step 1: Identify if there's a syncing conflict
+<Flow id="resolve-etcd-nospace-alarm">
 
-Check for objects that might be caught in a sync loop:
+<Step>
+
+Identify if there's a syncing conflict. Check for objects that might be caught in a sync loop:
 
 ```bash
 kubectl -n <namespace> logs <vcluster-pod> | grep -i "sync" | grep -i "error"
 ```
+</Step>
 
 If you find a problematic object, pause syncing for it in your vCluster config.
 
-### Step 2: Compact and defragment etcd
+<Step>
+
+**Compact and defragment etcd**
 
 1. Connect to each etcd pod:
 
@@ -115,7 +120,12 @@ If you find a problematic object, pause syncing for it in your vCluster config.
 
 6. Repeat for all etcd pods in your cluster.
 
-### Step 3: Verify disk usage reduction
+</Step>
+
+<Step>
+
+**Verify disk usage reduction**
+
 
 Check that the operation freed up space:
 
@@ -126,8 +136,11 @@ etcdctl endpoint status -w table \
     --key=/run/config/pki/etcd-peer.key \
     --cert=/run/config/pki/etcd-peer.crt
 ```
+</Step>
 
-### Step 4: Disarm the NOSPACE alarm
+<Step>
+
+**Disarm the NOSPACE alarm**
 
 Remove the alarm to restore normal operation:
 
@@ -139,11 +152,14 @@ etcdctl alarm disarm \
     --cert=/run/config/pki/etcd-peer.crt
 ```
 
+</Step>
+</Flow>
+
 ## Prevention
 
-Update your vCluster configuration to prevent future occurrences by implementing these recommended settings that enable automatic maintenance of your etcd database:
+Update your vCluster configuration to prevent future occurrences. Use the following recommended settings to enable automatic maintenance of your etcd database:
 
-```yaml
+```yaml title="vcluster.yaml"
 controlPlane:
   backingStore:
     etcd:
@@ -159,18 +175,20 @@ controlPlane:
             - '--quota-backend-bytes=8589934592'
 ```
 
-This configuration enables periodic compaction every 30 minutes, sets etcd quota to 8GB (adjust based on your needs), and uses deployed etcd instead of embedded for better control.
+This configuration enables periodic compaction every 30 minutes, sets etcd quota to 8GB, and uses deployed etcd instead of embedded for better control. You can edit parameters based on your needs.
 
 ## Verification
 
 After implementing the solution:
 
 1. Check that etcd pods are healthy:
+
    ```bash
    kubectl -n <namespace> get pods | grep etcd
    ```
 
 2. Verify that vCluster is functioning properly:
+
    ```bash
    kubectl -n <namespace> get pods
    kubectl -n <namespace> logs <vcluster-pod> | grep -i "alarm"
@@ -178,4 +196,10 @@ After implementing the solution:
 
 ## Best practices
 
-To maintain optimal etcd performance in your vCluster environment, always monitor etcd disk usage with appropriate metrics collection, implement regular automated compaction schedules appropriate to your workload patterns, and size your etcd storage quota based on actual usage plus a comfortable buffer. Remember that proper etcd maintenance is essential for vCluster stability, especially in production environments with high object counts or frequent configuration changes.
+To ensure optimal etcd performance in vCluster:  
+
+- **Monitor etcd disk usage**: Use metrics tools to track disk usage and set up alerts for high usage levels.  
+- **Enable automated compaction**: Configure compaction with `--auto-compaction-mode=periodic` and `--auto-compaction-retention=30m` to clean up old data.  
+- **Size etcd storage appropriately**: Set `--quota-backend-bytes` based on usage, with a buffer for growth.
+- **Defragment etcd regularly**: Optimize disk usage by defragmenting etcd periodically.  
+- **Resolve syncing conflicts**: Identify and fix syncing issues to prevent unnecessary data growth.  

--- a/vcluster/troubleshoot/etcd-compaction.mdx
+++ b/vcluster/troubleshoot/etcd-compaction.mdx
@@ -5,6 +5,8 @@ sidebar_position: 1
 description: Diagnose and resolve the etcd NOSPACE alarm in vCluster.  
 ---
 
+import Flow, { Step } from '@site/src/components/Flow';
+
 # Resolve etcd NOSPACE alarm in vCluster  
 
 ## Problem

--- a/vcluster/troubleshoot/etcd-compaction.mdx
+++ b/vcluster/troubleshoot/etcd-compaction.mdx
@@ -9,9 +9,7 @@ import Flow, { Step } from '@site/src/components/Flow';
 
 # Resolve etcd NOSPACE alarm in vCluster  
 
-## Problem
-
-The etcd `NOSPACE` alarm occurs when the etcd database in your vCluster runs out of disk space. This critical condition triggers health check failures that make your vCluster unusable and prevent any cluster actions. 
+The etcd `NOSPACE` alarm signals that the etcd database inside the vCluster has used its available disk space. When this occurs, etcd fails its health checks, which causes the control plane to become unresponsive. As a result, all cluster operations—such as deploying workloads, updating resources, or managing cluster components—are blocked, and the vCluster is unusable until the issue is resolved.
 
 ## Error message
 
@@ -76,7 +74,7 @@ If you find a problematic object, pause syncing for it in your vCluster config.
 
 <Step>
 
-**Compact and defragment etcd**
+**Compact and defragment etcd**.
 
 1. Connect to each etcd pod:
 
@@ -126,7 +124,7 @@ If you find a problematic object, pause syncing for it in your vCluster config.
 
 <Step>
 
-**Verify disk usage reduction**
+**Verify disk usage reduction**.
 
 
 Check that the operation freed up space:
@@ -142,7 +140,7 @@ etcdctl endpoint status -w table \
 
 <Step>
 
-**Disarm the NOSPACE alarm**
+**Disarm the NOSPACE alarm**.
 
 Remove the alarm to restore normal operation:
 
@@ -181,7 +179,7 @@ This configuration enables periodic compaction every 30 minutes, sets etcd quota
 
 ## Verification
 
-After implementing the solution:
+After completing the solution steps:
 
 1. Check that etcd pods are healthy:
 

--- a/vcluster/troubleshoot/etcd-compaction.mdx
+++ b/vcluster/troubleshoot/etcd-compaction.mdx
@@ -63,32 +63,33 @@ To resolve the issue, compact and defragment the etcd database to free up space.
 
 <Step>
 
-Identify if there's a syncing conflict. Check for objects that might be caught in a sync loop:
+**Identify if there's a syncing conflict**. 
 
-```bash
-kubectl -n <namespace> logs <vcluster-pod> | grep -i "sync" | grep -i "error"
-```
-</Step>
+Check for objects that might be caught in a sync loop:
 
+  ```bash
+  kubectl -n <namespace> logs <vcluster-pod> | grep -i "sync" | grep -i "error"
+  ```  
 If you find a problematic object, pause syncing for it in your vCluster config.
+</Step>
 
 <Step>
 
 **Compact and defragment etcd**.
 
-1. Connect to each etcd pod:
+- Connect to each etcd pod. Access the etcd pod using the following command:  
 
    ```bash
    kubectl -n <namespace> exec -it <etcd-pod-name> -- sh
    ```
 
-2. Set environment variable:
+- Set environment variables. Export the etcd service name as an environment variable:
 
    ```bash
    export ETCD_SRVNAME=<etcd-pod-name>
    ```
 
-3. Get current revision number:
+3. Get the current revision number. Retrieve the current revision number of etcd using the following command:
 
    ```bash
    etcdctl endpoint status --write-out json \
@@ -98,7 +99,7 @@ If you find a problematic object, pause syncing for it in your vCluster config.
        --cert=/run/config/pki/etcd-peer.crt
    ```
 
-4. Compact etcd database:
+4. Compact the etcd database. Compact etcd to remove old data and free up disk space:
 
    ```bash
    etcdctl --command-timeout=600s compact <revision-number> \
@@ -107,8 +108,9 @@ If you find a problematic object, pause syncing for it in your vCluster config.
        --key=/run/config/pki/etcd-peer.key \
        --cert=/run/config/pki/etcd-peer.crt
    ```
+    Replace `<revision-number>` with the value retrieved from the previous command.
 
-5. Defragment etcd:
+5. Defragment etcd. Defragment etcd to optimize disk usage and improve performance:
 
    ```bash
    etcdctl --command-timeout=600s defrag \

--- a/vcluster/troubleshoot/etcd-compaction.mdx
+++ b/vcluster/troubleshoot/etcd-compaction.mdx
@@ -1,6 +1,6 @@
 ---
 title: Resolve etcd NOSPACE alarm in vCluster  
-sidebar_label: etcd NOSPACE alarm  
+sidebar_label: etcd alarm - NOSPACE   
 sidebar_position: 1  
 description: Diagnose and resolve the etcd NOSPACE alarm in vCluster.  
 ---

--- a/vcluster/troubleshoot/etcd-compaction.mdx
+++ b/vcluster/troubleshoot/etcd-compaction.mdx
@@ -1,0 +1,181 @@
+---
+title: Resolve etcd NOSPACE alarm in vCluster  
+sidebar_label: etcd NOSPACE alarm  
+sidebar_position: 1  
+description: Diagnose and resolve the etcd NOSPACE alarm in vCluster.  
+---
+
+# Resolve etcd NOSPACE alarm in vCluster  
+
+## Problem
+
+The etcd `NOSPACE` alarm occurs when the etcd database in your vCluster runs out of disk space. This critical condition triggers health check failures that make your vCluster unusable and prevent any cluster actions. 
+
+## Error message
+
+You might find the following error in the logs of your etcd pods, if the etcd has run out of storage space: 
+
+```bash title="etcd NOSPACE alarm"
+etcdhttp/metrics.go:86 /health error ALARM NOSPACE status-code 503
+```
+
+<details id="etcd-nospace-alarm">
+<summary>Identifying an etcd `NOSPACE` alarm in vCluster</summary>
+
+When interacting with the affected vCluster using `kubectl`, API requests fail with timeout errors:
+
+```bash
+Error from server: etcdserver: request timed out
+```
+
+Additionally, the etcd health metrics endpoint returns a `503` status code and the following error:
+
+```text
+etcdhttp/metrics.go:86 /health error ALARM NOSPACE status-code 503
+```
+
+To verify the `NOSPACE` alarm, run the following command against the etcd instance:
+
+```bash
+etcdctl alarm list --endpoints=https://$ETCD_SRVNAME:2379 [...]
+```
+
+The output displays the triggered alarm:
+
+```text
+memberID:XXXXX alarm:NOSPACE
+```
+</details>
+
+## Causes
+
+The `NOSPACE` alarm occurs due to two common conditions:
+
+- **Excessive etcd data growth:** A large number of objects—such as Deployments, ConfigMaps, and Secrets—can fill etcd’s storage if regular compaction is not performed.
+
+- **Synchronization conflicts:** Conflicting objects between the vCluster and host cluster can trigger continuous sync loops. For example, a Custom Resource Definition (CRD) modified by the host cluster might sync back to the vCluster repeatedly. This behavior quickly fills etcd’s backend storage.
+
+## Solution
+
+To resolve the issue, compact and defragment the etcd database to free up space. Then, reconfigure etcd with automatic compaction and increase its storage quota to prevent recurrence.
+
+### Step 1: Identify if there's a syncing conflict
+
+Check for objects that might be caught in a sync loop:
+
+```bash
+kubectl -n <namespace> logs <vcluster-pod> | grep -i "sync" | grep -i "error"
+```
+
+If you find a problematic object, pause syncing for it in your vCluster config.
+
+### Step 2: Compact and defragment etcd
+
+1. Connect to each etcd pod:
+
+   ```bash
+   kubectl -n <namespace> exec -it <etcd-pod-name> -- sh
+   ```
+
+2. Set environment variable:
+
+   ```bash
+   export ETCD_SRVNAME=<etcd-pod-name>
+   ```
+
+3. Get current revision number:
+
+   ```bash
+   etcdctl endpoint status --write-out json \
+       --endpoints=https://$ETCD_SRVNAME:2379 \
+       --cacert=/run/config/pki/etcd-ca.crt \
+       --key=/run/config/pki/etcd-peer.key \
+       --cert=/run/config/pki/etcd-peer.crt
+   ```
+
+4. Compact etcd database:
+
+   ```bash
+   etcdctl --command-timeout=600s compact <revision-number> \
+       --endpoints=https://$ETCD_SRVNAME:2379 \
+       --cacert=/run/config/pki/etcd-ca.crt \
+       --key=/run/config/pki/etcd-peer.key \
+       --cert=/run/config/pki/etcd-peer.crt
+   ```
+
+5. Defragment etcd:
+
+   ```bash
+   etcdctl --command-timeout=600s defrag \
+       --endpoints=https://$ETCD_SRVNAME:2379 \
+       --cacert=/run/config/pki/etcd-ca.crt \
+       --key=/run/config/pki/etcd-peer.key \
+       --cert=/run/config/pki/etcd-peer.crt
+   ```
+
+6. Repeat for all etcd pods in your cluster.
+
+### Step 3: Verify disk usage reduction
+
+Check that the operation freed up space:
+
+```bash
+etcdctl endpoint status -w table \
+    --endpoints=https://$ETCD_SRVNAME:2379 \
+    --cacert=/run/config/pki/etcd-ca.crt \
+    --key=/run/config/pki/etcd-peer.key \
+    --cert=/run/config/pki/etcd-peer.crt
+```
+
+### Step 4: Disarm the NOSPACE alarm
+
+Remove the alarm to restore normal operation:
+
+```bash
+etcdctl alarm disarm \
+    --endpoints=https://$ETCD_SRVNAME:2379 \
+    --cacert=/run/config/pki/etcd-ca.crt \
+    --key=/run/config/pki/etcd-peer.key \
+    --cert=/run/config/pki/etcd-peer.crt
+```
+
+## Prevention
+
+Update your vCluster configuration to prevent future occurrences by implementing these recommended settings that enable automatic maintenance of your etcd database:
+
+```yaml
+controlPlane:
+  backingStore:
+    etcd:
+      embedded:
+        enabled: false
+      deploy:
+        enabled: true
+        statefulSet:
+          enabled: true
+          extraArgs:
+            - '--auto-compaction-mode=periodic'
+            - '--auto-compaction-retention=30m'
+            - '--quota-backend-bytes=8589934592'
+```
+
+This configuration enables periodic compaction every 30 minutes, sets etcd quota to 8GB (adjust based on your needs), and uses deployed etcd instead of embedded for better control.
+
+## Verification
+
+After implementing the solution:
+
+1. Check that etcd pods are healthy:
+   ```bash
+   kubectl -n <namespace> get pods | grep etcd
+   ```
+
+2. Verify that vCluster is functioning properly:
+   ```bash
+   kubectl -n <namespace> get pods
+   kubectl -n <namespace> logs <vcluster-pod> | grep -i "alarm"
+   ```
+
+## Best practices
+
+To maintain optimal etcd performance in your vCluster environment, always monitor etcd disk usage with appropriate metrics collection, implement regular automated compaction schedules appropriate to your workload patterns, and size your etcd storage quota based on actual usage plus a comfortable buffer. Remember that proper etcd maintenance is essential for vCluster stability, especially in production environments with high object counts or frequent configuration changes.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Follow up to [this PR](https://github.com/loft-sh/vcluster-docs/pull/519) to add compaction solution to docs


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

[Link to Preview](https://deploy-preview-548--vcluster-docs-site.netlify.app/docs/vcluster/next/troubleshoot/etcd-compaction?xetcd-nospace-alarm=1)


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-504

