### PR TITLE
fix: correct typos

### DIFF
--- a/vcluster/cli/vcluster_connect.md
+++ b/vcluster/cli/vcluster_connect.md
@@ -46,7 +46,7 @@ vcluster connect test -n test -- kubectl get ns
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_convert.md
+++ b/vcluster/cli/vcluster_convert.md
@@ -22,7 +22,7 @@ Convert virtual cluster config values
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_convert_config.md
+++ b/vcluster/cli/vcluster_convert_config.md
@@ -37,7 +37,7 @@ cat /my/k0s/values.yaml | vcluster convert config --distro k0s
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_create.md
+++ b/vcluster/cli/vcluster_create.md
@@ -64,7 +64,7 @@ vcluster create test --namespace test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_credits.md
+++ b/vcluster/cli/vcluster_credits.md
@@ -24,7 +24,7 @@ Saves licenses, copyright notices and source code, as required by a Go package's
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_debug.md
+++ b/vcluster/cli/vcluster_debug.md
@@ -22,7 +22,7 @@ Debug retrieves information from vCluster
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_debug_collect.md
+++ b/vcluster/cli/vcluster_debug_collect.md
@@ -39,7 +39,7 @@ vcluster debug collect
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_delete.md
+++ b/vcluster/cli/vcluster_delete.md
@@ -40,7 +40,7 @@ vcluster delete test --namespace test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_describe.md
+++ b/vcluster/cli/vcluster_describe.md
@@ -35,7 +35,7 @@ vcluster describe -o json test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_disconnect.md
+++ b/vcluster/cli/vcluster_disconnect.md
@@ -34,7 +34,7 @@ vcluster disconnect
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_get.md
+++ b/vcluster/cli/vcluster_get.md
@@ -23,7 +23,7 @@ Gets cluster related information
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster/cli/vcluster_get_service-cidr.md
+++ b/vcluster/cli/vcluster_get_service-cidr.md
@@ -33,7 +33,7 @@ vcluster get service-cidr
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster/cli/vcluster_import.md
+++ b/vcluster/cli/vcluster_import.md
@@ -36,7 +36,7 @@ vcluster import my-vcluster --cluster connected-cluster \
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster/cli/vcluster_list.md
+++ b/vcluster/cli/vcluster_list.md
@@ -35,7 +35,7 @@ vcluster list --namespace test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_login.md
+++ b/vcluster/cli/vcluster_login.md
@@ -36,7 +36,7 @@ vcluster platform login https://my-vcluster-platform.com --access-key myaccesske
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_logout.md
+++ b/vcluster/cli/vcluster_logout.md
@@ -31,7 +31,7 @@ vcluster logout
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_pause.md
+++ b/vcluster/cli/vcluster_pause.md
@@ -40,7 +40,7 @@ vcluster pause test --namespace test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform.md
+++ b/vcluster/cli/vcluster_platform.md
@@ -22,7 +22,7 @@ vCluster platform subcommands
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_access-key.md
+++ b/vcluster/cli/vcluster_platform_access-key.md
@@ -36,7 +36,7 @@ vcluster platform token
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_add.md
+++ b/vcluster/cli/vcluster_platform_add.md
@@ -22,7 +22,7 @@ Adds a cluster to vCluster platform
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_add_cluster.md
+++ b/vcluster/cli/vcluster_platform_add_cluster.md
@@ -41,7 +41,7 @@ vcluster platform add cluster my-cluster
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_add_vcluster.md
+++ b/vcluster/cli/vcluster_platform_add_vcluster.md
@@ -43,7 +43,7 @@ vcluster platform add vcluster --project my-project --all
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_backup.md
+++ b/vcluster/cli/vcluster_platform_backup.md
@@ -22,7 +22,7 @@ Backup subcommands
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_backup_management.md
+++ b/vcluster/cli/vcluster_platform_backup_management.md
@@ -35,7 +35,7 @@ vcluster platform backup management
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_connect.md
+++ b/vcluster/cli/vcluster_platform_connect.md
@@ -25,7 +25,7 @@ Activates a kube context for the given cluster / management / namespace / vclust
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_connect_cluster.md
+++ b/vcluster/cli/vcluster_platform_connect_cluster.md
@@ -34,7 +34,7 @@ vcluster platform connect cluster mycluster
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_connect_management.md
+++ b/vcluster/cli/vcluster_platform_connect_management.md
@@ -33,7 +33,7 @@ vcluster platform connect management
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_connect_namespace.md
+++ b/vcluster/cli/vcluster_platform_connect_namespace.md
@@ -39,7 +39,7 @@ vcluster platform connect namespace myspace --project myproject
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_connect_vcluster.md
+++ b/vcluster/cli/vcluster_platform_connect_vcluster.md
@@ -45,7 +45,7 @@ vcluster platform connect vcluster test -n test -- kubectl get ns
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_create.md
+++ b/vcluster/cli/vcluster_platform_create.md
@@ -22,7 +22,7 @@ Creates vCluster platform resources
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_create_namespace.md
+++ b/vcluster/cli/vcluster_platform_create_namespace.md
@@ -56,7 +56,7 @@ vcluster platform create namespace myspace --project myproject --team myteam
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_create_vcluster.md
+++ b/vcluster/cli/vcluster_platform_create_vcluster.md
@@ -59,7 +59,7 @@ vcluster platform create vcluster test --namespace test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_delete.md
+++ b/vcluster/cli/vcluster_platform_delete.md
@@ -22,7 +22,7 @@ Deletes vCluster platform resources
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_delete_namespace.md
+++ b/vcluster/cli/vcluster_platform_delete_namespace.md
@@ -37,7 +37,7 @@ vcluster platform delete namespace myspace --project myproject
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_delete_vcluster.md
+++ b/vcluster/cli/vcluster_platform_delete_vcluster.md
@@ -34,7 +34,7 @@ vcluster platform delete vcluster --namespace test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_destroy.md
+++ b/vcluster/cli/vcluster_platform_destroy.md
@@ -50,7 +50,7 @@ VirtualClusterInstances managed with driver helm will be deleted, but the underl
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_get.md
+++ b/vcluster/cli/vcluster_platform_get.md
@@ -22,7 +22,7 @@ Retrieves and display informations
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_get_cluster-access-key.md
+++ b/vcluster/cli/vcluster_platform_get_cluster-access-key.md
@@ -33,7 +33,7 @@ vcluster platform get cluster-access-key [CLUSTER_NAME]
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_get_cluster.md
+++ b/vcluster/cli/vcluster_platform_get_cluster.md
@@ -34,4 +34,4 @@ vcluster platform get cluster [flags]
 
 
 ## Flags
-## Global & Inherited Flags
+## Global and inherited flags

--- a/vcluster/cli/vcluster_platform_get_current-user.md
+++ b/vcluster/cli/vcluster_platform_get_current-user.md
@@ -33,7 +33,7 @@ vcluster platform get current-user
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_get_secret.md
+++ b/vcluster/cli/vcluster_platform_get_secret.md
@@ -37,7 +37,7 @@ vcluster platform get secret test-secret.key --project myproject
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_list.md
+++ b/vcluster/cli/vcluster_platform_list.md
@@ -22,7 +22,7 @@ Lists configuration
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_list_clusters.md
+++ b/vcluster/cli/vcluster_platform_list_clusters.md
@@ -32,7 +32,7 @@ vcluster platform list clusters
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_list_namespaces.md
+++ b/vcluster/cli/vcluster_platform_list_namespaces.md
@@ -31,7 +31,7 @@ vcluster platform list namespaces
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_list_projects.md
+++ b/vcluster/cli/vcluster_platform_list_projects.md
@@ -32,7 +32,7 @@ vcluster platform list projects
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_list_secrets.md
+++ b/vcluster/cli/vcluster_platform_list_secrets.md
@@ -36,7 +36,7 @@ vcluster platform list secrets
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_list_teams.md
+++ b/vcluster/cli/vcluster_platform_list_teams.md
@@ -32,7 +32,7 @@ vcluster platform list teams
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_list_vclusters.md
+++ b/vcluster/cli/vcluster_platform_list_vclusters.md
@@ -33,7 +33,7 @@ vcluster platform list vclusters
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_login.md
+++ b/vcluster/cli/vcluster_platform_login.md
@@ -36,7 +36,7 @@ vcluster platform login https://my-vcluster-platform.com --access-key myaccesske
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_logout.md
+++ b/vcluster/cli/vcluster_platform_logout.md
@@ -31,7 +31,7 @@ vcluster platform logout
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_reset.md
+++ b/vcluster/cli/vcluster_platform_reset.md
@@ -22,7 +22,7 @@ Reset configuration
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_reset_password.md
+++ b/vcluster/cli/vcluster_platform_reset_password.md
@@ -37,7 +37,7 @@ vcluster platform reset password --user admin
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_set.md
+++ b/vcluster/cli/vcluster_platform_set.md
@@ -22,7 +22,7 @@ Set configuration
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_set_secret.md
+++ b/vcluster/cli/vcluster_platform_set_secret.md
@@ -36,7 +36,7 @@ vcluster platform set secret test-secret.key value --project myproject
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_share.md
+++ b/vcluster/cli/vcluster_platform_share.md
@@ -22,7 +22,7 @@ Shares a virtual cluster / namespace with another vCluster platform user or team
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_share_namespace.md
+++ b/vcluster/cli/vcluster_platform_share_namespace.md
@@ -39,7 +39,7 @@ vcluster platform share namespace myspace --project myproject --user admin
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_share_vcluster.md
+++ b/vcluster/cli/vcluster_platform_share_vcluster.md
@@ -38,7 +38,7 @@ vcluster platform share vcluster myvcluster --project myproject --user admin
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_sleep.md
+++ b/vcluster/cli/vcluster_platform_sleep.md
@@ -25,7 +25,7 @@ Put a virtual cluster / namespace to sleep.
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_sleep_namespace.md
+++ b/vcluster/cli/vcluster_platform_sleep_namespace.md
@@ -35,7 +35,7 @@ vcluster platform sleep namespace myspace --project myproject
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_sleep_vcluster.md
+++ b/vcluster/cli/vcluster_platform_sleep_vcluster.md
@@ -39,7 +39,7 @@ vcluster platform sleep vcluster test --namespace test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_start.md
+++ b/vcluster/cli/vcluster_platform_start.md
@@ -56,7 +56,7 @@ before running this command:
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_wakeup.md
+++ b/vcluster/cli/vcluster_platform_wakeup.md
@@ -25,7 +25,7 @@ Wake up a virtual cluster / namespace.
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_wakeup_namespace.md
+++ b/vcluster/cli/vcluster_platform_wakeup_namespace.md
@@ -34,7 +34,7 @@ vcluster platform wakeup namespace myspace --project myproject
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_platform_wakeup_vcluster.md
+++ b/vcluster/cli/vcluster_platform_wakeup_vcluster.md
@@ -34,7 +34,7 @@ vcluster platform wakeup vcluster test --namespace test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_pro.md
+++ b/vcluster/cli/vcluster_pro.md
@@ -27,7 +27,7 @@ vCluster.Pro subcommands
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster/cli/vcluster_pro_connect.md
+++ b/vcluster/cli/vcluster_pro_connect.md
@@ -27,7 +27,7 @@ Connects a cluster to vCluster.Pro
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster/cli/vcluster_pro_connect_cluster.md
+++ b/vcluster/cli/vcluster_pro_connect_cluster.md
@@ -41,7 +41,7 @@ vcluster pro connect cluster my-cluster
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --debug               Prints the stack trace if an error occurs

--- a/vcluster/cli/vcluster_pro_generate.md
+++ b/vcluster/cli/vcluster_pro_generate.md
@@ -27,7 +27,7 @@ Generate configuration
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster/cli/vcluster_pro_generate_admin-kube-config.md
+++ b/vcluster/cli/vcluster_pro_generate_admin-kube-config.md
@@ -40,7 +40,7 @@ vcluster pro generate admin-kube-config
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster/cli/vcluster_pro_login.md
+++ b/vcluster/cli/vcluster_pro_login.md
@@ -37,4 +37,4 @@ vcluster pro login [flags]
 
 
 ## Flags
-## Global & Inherited Flags
+## Global and inherited flags

--- a/vcluster/cli/vcluster_pro_reset.md
+++ b/vcluster/cli/vcluster_pro_reset.md
@@ -27,7 +27,7 @@ Reset configuration
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster/cli/vcluster_pro_reset_password.md
+++ b/vcluster/cli/vcluster_pro_reset_password.md
@@ -41,7 +41,7 @@ vcluster pro reset password --user admin
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster/cli/vcluster_pro_start.md
+++ b/vcluster/cli/vcluster_pro_start.md
@@ -61,7 +61,7 @@ before running this command:
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --debug               Prints the stack trace if an error occurs

--- a/vcluster/cli/vcluster_pro_token.md
+++ b/vcluster/cli/vcluster_pro_token.md
@@ -41,7 +41,7 @@ vcluster pro token
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster/cli/vcluster_restore.md
+++ b/vcluster/cli/vcluster_restore.md
@@ -41,7 +41,7 @@ vcluster restore my-vcluster container:///data/my-local-snapshot.tar.gz
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_resume.md
+++ b/vcluster/cli/vcluster_resume.md
@@ -35,7 +35,7 @@ vcluster resume test --namespace test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_set.md
+++ b/vcluster/cli/vcluster_set.md
@@ -22,7 +22,7 @@ Set configuration
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_set_secret.md
+++ b/vcluster/cli/vcluster_set_secret.md
@@ -36,7 +36,7 @@ vcluster platform set secret test-secret.key value --project myproject
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_snapshot.md
+++ b/vcluster/cli/vcluster_snapshot.md
@@ -42,7 +42,7 @@ vcluster snapshot my-vcluster container:///data/my-local-snapshot.tar.gz
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_telemetry.md
+++ b/vcluster/cli/vcluster_telemetry.md
@@ -27,7 +27,7 @@ docs: https://www.vcluster.com/docs/advanced-topics/telemetry
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_telemetry_disable.md
+++ b/vcluster/cli/vcluster_telemetry_disable.md
@@ -32,7 +32,7 @@ docs: https://www.vcluster.com/docs/advanced-topics/telemetry
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_telemetry_enable.md
+++ b/vcluster/cli/vcluster_telemetry_enable.md
@@ -32,7 +32,7 @@ docs: https://www.vcluster.com/docs/advanced-topics/telemetry
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_ui.md
+++ b/vcluster/cli/vcluster_ui.md
@@ -31,7 +31,7 @@ vcluster ui
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_upgrade.md
+++ b/vcluster/cli/vcluster_upgrade.md
@@ -29,7 +29,7 @@ Upgrades the vcluster CLI to the newest version
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_use.md
+++ b/vcluster/cli/vcluster_use.md
@@ -22,7 +22,7 @@ vCluster use subcommand
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_use_driver.md
+++ b/vcluster/cli/vcluster_use_driver.md
@@ -28,7 +28,7 @@ Either use "helm" or "platform" as the deployment method for managing virtual cl
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/cli/vcluster_version.md
+++ b/vcluster/cli/vcluster_version.md
@@ -24,7 +24,7 @@ All software has versions. This is Vcluster's.
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/k0s.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/k0s.mdx
@@ -28,7 +28,7 @@ controlPlane:
 After deploying your vCluster, changing the Kubernetes distribution of vCluster is not supported.
 :::
 
-## Compatiblity matrix
+## Compatibility matrix
 
 <K0sCompat/>
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/k3s.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/k3s.mdx
@@ -24,7 +24,7 @@ After deploying your vCluster, changing the Kubernetes distribution of vCluster 
 :::
 
 
-## Compatiblity matrix
+## Compatibility matrix
 
 <K3sCompat/>
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
@@ -17,7 +17,7 @@ By default, vCluster uses an embedded SQLite as the [backing store](../backing-s
 After deploying your vCluster, changing the Kubernetes distribution of vCluster is not supported.
 :::
 
-## Compatiblity matrix
+## Compatibility matrix
 
 <K8sCompat/>
 

--- a/vcluster/configure/vcluster-yaml/control-plane/other/advanced/README.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/other/advanced/README.mdx
@@ -2,7 +2,7 @@
 title: Advanced
 sidebar_label: advanced
 sidebar_position: 5
-description: Configue vCluster control plane advanced options.
+description: Configure vCluster control plane advanced options.
 ---
 
 import ControlPlaneAdvanced from '../../../../../_partials/config/controlPlane/advanced.mdx'

--- a/vcluster/configure/vcluster-yaml/experimental/generic-sync.mdx
+++ b/vcluster/configure/vcluster-yaml/experimental/generic-sync.mdx
@@ -45,7 +45,7 @@ Use the top-level `export` field to declare which virtual resources you want to 
 
 Use `patches` to define how to modify synced resources before the resource's creation or update in the host cluster.
 
-Use `reversePatches` to declare how changes to synced host cluster resource propogate back to the original resource in the virtual cluster.
+Use `reversePatches` to declare how changes to synced host cluster resource propagate back to the original resource in the virtual cluster.
 
 Use `selector` to limit which resources to sync from the virtual cluster. The virtual resource is synced when it matches one or more selectors, or when the `selector` field is empty.
 
@@ -77,7 +77,7 @@ Use the top-level `import` field to declare which host resources to sync to the 
 
 Use `patches` to define how to modify certain synced resource fields before the resource's creation or update in the virtual cluster. See [patches reference]  for details.
 
-Use `reversePatches` to declare how changes to synced virtual cluster resource propogate back to the original resource in the host cluster.
+Use `reversePatches` to declare how changes to synced virtual cluster resource propagate back to the original resource in the host cluster.
 
 Use `selector` to limit which resources to sync from the host cluster. The host resource is synced when it matches, or when the `selector` is empty.
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/nodes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/nodes.mdx
@@ -36,7 +36,7 @@ import SyncNodes from '../../../../_partials/config/sync/fromHost/nodes.mdx'
 
 By default, this is disabled.
 
-vCluster syncs psuedo nodes from the host cluster where there are virtual cluster pods running. Pseudo nodes only have real values for the CPU, architecture, and operating system, while everything else is randomly generated. A single pseudo node can either represent a single real node on the host cluster, or it can represent multiple real nodes. If there are no more pods on a node, vCluster deletes the pseudo node.
+vCluster syncs pseudo nodes from the host cluster where there are virtual cluster pods running. Pseudo nodes only have real values for the CPU, architecture, and operating system, while everything else is randomly generated. A single pseudo node can either represent a single real node on the host cluster, or it can represent multiple real nodes. If there are no more pods on a node, vCluster deletes the pseudo node.
 
 However, when you need to access specific node information, you can choose to sync real nodes from the host cluster to the virtual cluster. This requires a cluster role.
 

--- a/vcluster/reference/migrations/loft-cli-vcluster-cli-migration.mdx
+++ b/vcluster/reference/migrations/loft-cli-vcluster-cli-migration.mdx
@@ -11,7 +11,7 @@ Most commands should work exactly as before. Any commands that have been changed
 ## Global --config flag
 
 Previously, **loft** CLI read its config file from `~/.loft/config.json` if nothing was specified under `--config`. **vCluster** CLI now assumes the config to be per default in `~/.vcluster/config.json`.
-Futhermore, the config format in **vCluster** CLI changed in a way that the loft platform (now vCluster platform) related configuration goes into a special section under the key `platform`.
+Furthermore, the config format in **vCluster** CLI changed in a way that the loft platform (now vCluster platform) related configuration goes into a special section under the key `platform`.
 If you want you can convert your already existing loft configuration via the following (prerequisite: jq >= 1.7 installed):
 
 ```bash

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_connect.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_connect.md
@@ -46,7 +46,7 @@ vcluster connect test -n test -- kubectl get ns
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_convert.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_convert.md
@@ -22,7 +22,7 @@ Convert virtual cluster config values
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_convert_config.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_convert_config.md
@@ -37,7 +37,7 @@ cat /my/k0s/values.yaml | vcluster convert config --distro k0s
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_create.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_create.md
@@ -64,7 +64,7 @@ vcluster create test --namespace test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_credits.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_credits.md
@@ -24,7 +24,7 @@ Saves licenses, copyright notices and source code, as required by a Go package's
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_debug.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_debug.md
@@ -22,7 +22,7 @@ Debug retrieves information from vCluster
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_debug_collect.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_debug_collect.md
@@ -39,7 +39,7 @@ vcluster debug collect
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_delete.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_delete.md
@@ -40,7 +40,7 @@ vcluster delete test --namespace test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_describe.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_describe.md
@@ -35,7 +35,7 @@ vcluster describe -o json test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_disconnect.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_disconnect.md
@@ -34,7 +34,7 @@ vcluster disconnect
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_get.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_get.md
@@ -23,7 +23,7 @@ Gets cluster related information
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_get_service-cidr.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_get_service-cidr.md
@@ -33,7 +33,7 @@ vcluster get service-cidr
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_import.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_import.md
@@ -36,7 +36,7 @@ vcluster import my-vcluster --cluster connected-cluster \
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_list.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_list.md
@@ -35,7 +35,7 @@ vcluster list --namespace test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_login.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_login.md
@@ -36,7 +36,7 @@ vcluster platform login https://my-vcluster-platform.com --access-key myaccesske
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_logout.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_logout.md
@@ -31,7 +31,7 @@ vcluster logout
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pause.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pause.md
@@ -40,7 +40,7 @@ vcluster pause test --namespace test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform.md
@@ -22,7 +22,7 @@ vCluster platform subcommands
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_access-key.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_access-key.md
@@ -36,7 +36,7 @@ vcluster platform token
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_add.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_add.md
@@ -22,7 +22,7 @@ Adds a cluster to vCluster platform
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_add_cluster.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_add_cluster.md
@@ -41,7 +41,7 @@ vcluster platform add cluster my-cluster
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_add_vcluster.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_add_vcluster.md
@@ -43,7 +43,7 @@ vcluster platform add vcluster --project my-project --all
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_backup.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_backup.md
@@ -22,7 +22,7 @@ Backup subcommands
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_backup_management.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_backup_management.md
@@ -35,7 +35,7 @@ vcluster platform backup management
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_connect.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_connect.md
@@ -25,7 +25,7 @@ Activates a kube context for the given cluster / management / namespace / vclust
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_connect_cluster.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_connect_cluster.md
@@ -34,7 +34,7 @@ vcluster platform connect cluster mycluster
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_connect_management.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_connect_management.md
@@ -33,7 +33,7 @@ vcluster platform connect management
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_connect_namespace.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_connect_namespace.md
@@ -39,7 +39,7 @@ vcluster platform connect namespace myspace --project myproject
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_connect_vcluster.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_connect_vcluster.md
@@ -45,7 +45,7 @@ vcluster platform connect vcluster test -n test -- kubectl get ns
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_create.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_create.md
@@ -22,7 +22,7 @@ Creates vCluster platform resources
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_create_namespace.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_create_namespace.md
@@ -56,7 +56,7 @@ vcluster platform create namespace myspace --project myproject --team myteam
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_create_vcluster.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_create_vcluster.md
@@ -60,7 +60,7 @@ vcluster platform create vcluster test --namespace test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_delete.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_delete.md
@@ -22,7 +22,7 @@ Deletes vCluster platform resources
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_delete_namespace.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_delete_namespace.md
@@ -37,7 +37,7 @@ vcluster platform delete namespace myspace --project myproject
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_delete_vcluster.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_delete_vcluster.md
@@ -34,7 +34,7 @@ vcluster platform delete vcluster --namespace test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_destroy.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_destroy.md
@@ -50,7 +50,7 @@ VirtualClusterInstances managed with driver helm will be deleted, but the underl
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_get.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_get.md
@@ -22,7 +22,7 @@ Retrieves and display informations
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_get_cluster-access-key.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_get_cluster-access-key.md
@@ -33,7 +33,7 @@ vcluster platform get cluster-access-key [CLUSTER_NAME]
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_get_cluster.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_get_cluster.md
@@ -34,4 +34,4 @@ vcluster platform get cluster [flags]
 
 
 ## Flags
-## Global & Inherited Flags
+## Global and inherited flags

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_get_current-user.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_get_current-user.md
@@ -33,7 +33,7 @@ vcluster platform get current-user
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_get_secret.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_get_secret.md
@@ -37,7 +37,7 @@ vcluster platform get secret test-secret.key --project myproject
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_list.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_list.md
@@ -22,7 +22,7 @@ Lists configuration
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_list_clusters.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_list_clusters.md
@@ -32,7 +32,7 @@ vcluster platform list clusters
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_list_namespaces.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_list_namespaces.md
@@ -31,7 +31,7 @@ vcluster platform list namespaces
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_list_projects.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_list_projects.md
@@ -32,7 +32,7 @@ vcluster platform list projects
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_list_secrets.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_list_secrets.md
@@ -36,7 +36,7 @@ vcluster platform list secrets
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_list_teams.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_list_teams.md
@@ -32,7 +32,7 @@ vcluster platform list teams
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_list_vclusters.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_list_vclusters.md
@@ -33,7 +33,7 @@ vcluster platform list vclusters
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_login.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_login.md
@@ -36,7 +36,7 @@ vcluster platform login https://my-vcluster-platform.com --access-key myaccesske
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_logout.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_logout.md
@@ -31,7 +31,7 @@ vcluster platform logout
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_reset.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_reset.md
@@ -22,7 +22,7 @@ Reset configuration
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_reset_password.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_reset_password.md
@@ -37,7 +37,7 @@ vcluster platform reset password --user admin
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_set.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_set.md
@@ -22,7 +22,7 @@ Set configuration
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_set_secret.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_set_secret.md
@@ -36,7 +36,7 @@ vcluster platform set secret test-secret.key value --project myproject
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_share.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_share.md
@@ -22,7 +22,7 @@ Shares a virtual cluster / namespace with another vCluster platform user or team
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_share_namespace.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_share_namespace.md
@@ -39,7 +39,7 @@ vcluster platform share namespace myspace --project myproject --user admin
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_share_vcluster.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_share_vcluster.md
@@ -38,7 +38,7 @@ vcluster platform share vcluster myvcluster --project myproject --user admin
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_sleep.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_sleep.md
@@ -25,7 +25,7 @@ Put a virtual cluster / namespace to sleep.
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_sleep_namespace.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_sleep_namespace.md
@@ -35,7 +35,7 @@ vcluster platform sleep namespace myspace --project myproject
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_sleep_vcluster.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_sleep_vcluster.md
@@ -39,7 +39,7 @@ vcluster platform sleep vcluster test --namespace test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_start.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_start.md
@@ -56,7 +56,7 @@ before running this command:
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_wakeup.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_wakeup.md
@@ -25,7 +25,7 @@ Wake up a virtual cluster / namespace.
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_wakeup_namespace.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_wakeup_namespace.md
@@ -34,7 +34,7 @@ vcluster platform wakeup namespace myspace --project myproject
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_wakeup_vcluster.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_platform_wakeup_vcluster.md
@@ -34,7 +34,7 @@ vcluster platform wakeup vcluster test --namespace test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro.md
@@ -27,7 +27,7 @@ vCluster.Pro subcommands
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro_connect.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro_connect.md
@@ -27,7 +27,7 @@ Connects a cluster to vCluster.Pro
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro_connect_cluster.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro_connect_cluster.md
@@ -41,7 +41,7 @@ vcluster pro connect cluster my-cluster
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --debug               Prints the stack trace if an error occurs

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro_generate.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro_generate.md
@@ -27,7 +27,7 @@ Generate configuration
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro_generate_admin-kube-config.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro_generate_admin-kube-config.md
@@ -40,7 +40,7 @@ vcluster pro generate admin-kube-config
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro_login.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro_login.md
@@ -37,4 +37,4 @@ vcluster pro login [flags]
 
 
 ## Flags
-## Global & Inherited Flags
+## Global and inherited flags

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro_reset.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro_reset.md
@@ -27,7 +27,7 @@ Reset configuration
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro_reset_password.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro_reset_password.md
@@ -41,7 +41,7 @@ vcluster pro reset password --user admin
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro_start.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro_start.md
@@ -61,7 +61,7 @@ before running this command:
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --debug               Prints the stack trace if an error occurs

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro_token.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_pro_token.md
@@ -41,7 +41,7 @@ vcluster pro token
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --context string      The kubernetes config context to use

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_resume.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_resume.md
@@ -35,7 +35,7 @@ vcluster resume test --namespace test
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_set.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_set.md
@@ -22,7 +22,7 @@ Set configuration
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_set_secret.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_set_secret.md
@@ -36,7 +36,7 @@ vcluster platform set secret test-secret.key value --project myproject
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_telemetry.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_telemetry.md
@@ -27,7 +27,7 @@ docs: https://www.vcluster.com/docs/advanced-topics/telemetry
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_telemetry_disable.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_telemetry_disable.md
@@ -32,7 +32,7 @@ docs: https://www.vcluster.com/docs/advanced-topics/telemetry
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_telemetry_enable.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_telemetry_enable.md
@@ -32,7 +32,7 @@ docs: https://www.vcluster.com/docs/advanced-topics/telemetry
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_ui.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_ui.md
@@ -31,7 +31,7 @@ vcluster ui
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_upgrade.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_upgrade.md
@@ -29,7 +29,7 @@ Upgrades the vcluster CLI to the newest version
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_use.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_use.md
@@ -22,7 +22,7 @@ vCluster use subcommand
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_use_driver.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_use_driver.md
@@ -28,7 +28,7 @@ Either use "helm" or "platform" as the deployment method for managing virtual cl
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/cli/vcluster_version.md
+++ b/vcluster_versioned_docs/version-0.24.0/cli/vcluster_version.md
@@ -24,7 +24,7 @@ All software has versions. This is Vcluster's.
 ```
 
 
-## Global & Inherited Flags
+## Global and inherited flags
 
 ```
       --config string       The vcluster CLI config to use (will be created if it does not exist) (default "~/.vcluster/config.json")

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/components/distro/k0s.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/components/distro/k0s.mdx
@@ -28,7 +28,7 @@ controlPlane:
 After deploying your vCluster, changing the Kubernetes distribution of vCluster is not supported.
 :::
 
-## Compatiblity matrix
+## Compatibility matrix
 
 <K0sCompat/>
 

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/components/distro/k3s.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/components/distro/k3s.mdx
@@ -24,7 +24,7 @@ After deploying your vCluster, changing the Kubernetes distribution of vCluster 
 :::
 
 
-## Compatiblity matrix
+## Compatibility matrix
 
 <K3sCompat/>
 

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
@@ -17,7 +17,7 @@ By default, vCluster uses an embedded SQLite as the [backing store](../backing-s
 After deploying your vCluster, changing the Kubernetes distribution of vCluster is not supported.
 :::
 
-## Compatiblity matrix
+## Compatibility matrix
 
 <K8sCompat/>
 

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/other/advanced/README.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/other/advanced/README.mdx
@@ -2,7 +2,7 @@
 title: Advanced
 sidebar_label: advanced
 sidebar_position: 5
-description: Configue vCluster control plane advanced options.
+description: Configure vCluster control plane advanced options.
 ---
 
 import ControlPlaneAdvanced from '../../../../../_partials/config/controlPlane/advanced.mdx'

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/experimental/generic-sync.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/experimental/generic-sync.mdx
@@ -45,7 +45,7 @@ Use the top-level `export` field to declare which virtual resources you want to 
 
 Use `patches` to define how to modify synced resources before the resource's creation or update in the host cluster.
 
-Use `reversePatches` to declare how changes to synced host cluster resource propogate back to the original resource in the virtual cluster.
+Use `reversePatches` to declare how changes to synced host cluster resource propagate back to the original resource in the virtual cluster.
 
 Use `selector` to limit which resources to sync from the virtual cluster. The virtual resource is synced when it matches one or more selectors, or when the `selector` field is empty.
 
@@ -77,7 +77,7 @@ Use the top-level `import` field to declare which host resources to sync to the 
 
 Use `patches` to define how to modify certain synced resource fields before the resource's creation or update in the virtual cluster. See [patches reference]  for details.
 
-Use `reversePatches` to declare how changes to synced virtual cluster resource propogate back to the original resource in the host cluster.
+Use `reversePatches` to declare how changes to synced virtual cluster resource propagate back to the original resource in the host cluster.
 
 Use `selector` to limit which resources to sync from the host cluster. The host resource is synced when it matches, or when the `selector` is empty.
 

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/sync/from-host/nodes.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/sync/from-host/nodes.mdx
@@ -36,7 +36,7 @@ import SyncNodes from '../../../../_partials/config/sync/fromHost/nodes.mdx'
 
 By default, this is disabled.
 
-vCluster syncs psuedo nodes from the host cluster where there are virtual cluster pods running. Pseudo nodes only have real values for the CPU, architecture, and operating system, while everything else is randomly generated. A single pseudo node can either represent a single real node on the host cluster, or it can represent multiple real nodes. If there are no more pods on a node, vCluster deletes the pseudo node.
+vCluster syncs pseudo nodes from the host cluster where there are virtual cluster pods running. Pseudo nodes only have real values for the CPU, architecture, and operating system, while everything else is randomly generated. A single pseudo node can either represent a single real node on the host cluster, or it can represent multiple real nodes. If there are no more pods on a node, vCluster deletes the pseudo node.
 
 However, when you need to access specific node information, you can choose to sync real nodes from the host cluster to the virtual cluster. This requires a cluster role.
 

--- a/vcluster_versioned_docs/version-0.24.0/reference/migrations/loft-cli-vcluster-cli-migration.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/reference/migrations/loft-cli-vcluster-cli-migration.mdx
@@ -11,7 +11,7 @@ Most commands should work exactly as before. Any commands that have been changed
 ## Global --config flag
 
 Previously, **loft** CLI read its config file from `~/.loft/config.json` if nothing was specified under `--config`. **vCluster** CLI now assumes the config to be per default in `~/.vcluster/config.json`.
-Futhermore, the config format in **vCluster** CLI changed in a way that the loft platform (now vCluster platform) related configuration goes into a special section under the key `platform`.
+Furthermore, the config format in **vCluster** CLI changed in a way that the loft platform (now vCluster platform) related configuration goes into a special section under the key `platform`.
 If you want you can convert your already existing loft configuration via the following (prerequisite: jq >= 1.7 installed):
 
 ```bash


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Correct typos highlighted in `0.24.0` release

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-517

