### PR TITLE
Clarifies how reference patches work

### DIFF
--- a/vcluster/_fragments/patches.mdx
+++ b/vcluster/_fragments/patches.mdx
@@ -34,7 +34,10 @@ There is also a variable called `context` besides `value` that can be used to ac
 
 ### Reference patches
 
-A reference patch can be used to have a specific field of one resource point to a different resource that should get rewritten. vCluster automatically imports the referenced resource to the virtual cluster if it can find it in the host cluster. For example:
+A reference patch is used to sync resources based on a reference existing on the object. Meaning if a specific field of the resource being operated on references another, you can set that field in a reference patch, and the resource it refers to will be synced automatically by vCluster if found.
+
+In the following example, if the object being configured has an annotation named "my-secret-ref", whose value is the name of a Secret object, the Secret will be synced and it's name translated accordingly:
+
 <CodeBlock language="yaml">
 {`sync:
   toHost:
@@ -46,8 +49,6 @@ A reference patch can be used to have a specific field of one resource point to 
           apiVersion: v1
           kind: Secret`}
 </CodeBlock>
-
-With this yaml, vCluster translates the path `metadata.annotations["my-secret-ref"]` as it points to a secret. If the secret is created in the host cluster, vCluster automatically imports it into the virtual cluster.
 
 :::info Multi-Namespace-Mode
 With multi-namespace-mode you only need to rewrite references that include a namespace. You can use the `namespacePath` option to specify the path of the namespace of the reference.


### PR DESCRIPTION
Since this fragments is used in several cases in the docs I made it object agnostic, and also from/to host agnostic. 