### PR TITLE
feat: add GPU pricing to Cost Control docs

### DIFF
--- a/platform/configure/cost-control.mdx
+++ b/platform/configure/cost-control.mdx
@@ -16,7 +16,7 @@ virtual clusters the platform deploys and manages [Prometheus](https://prometheu
 [OpenCost](https://www.opencost.io/) on each connected cluster. Prometheus uses a time series database that requires
 persistent volume storage to retain metrics over time. The platform-managed
 Prometheus is configured to collect the minimum metrics required for the cost
-control dashboard. OpenCost provides CPU and Memory allocation metrics for the
+control dashboard. OpenCost provides CPU, GPU, and Memory allocation metrics for the
 deployed workloads.
 
 In addition to the Prometheus instance on the connected cluster, the cluster
@@ -69,6 +69,10 @@ config:
         timePeriod: Monthly
       # Average Memory cost
       averageRAMPricePerNode:
+        price: 31
+        timePeriod: Monthly
+      # Average GPU cost
+      averageGPUPricePerNode:
         price: 31
         timePeriod: Monthly
       # Monthly or Yearly cost for Hosted Control Planes


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
**Update**: Setting this to draft until https://github.com/loft-sh/loft-enterprise/pull/4019 has been finalized.

Adds the GPU section to Cost Control docs.

Should be merged after all relevant vCluster platform PRs have been merged.
## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENG-6247

