### PR TITLE
chore: update non-versioned partials references

### DIFF
--- a/vcluster/configure/vcluster-yaml/sleep-mode.mdx
+++ b/vcluster/configure/vcluster-yaml/sleep-mode.mdx
@@ -9,7 +9,7 @@ import ProAdmonition from '../../_partials/admonitions/pro-admonition.mdx'
 import SleepMode from '../../_partials/config/sleepMode.mdx'
 import SleepModeDeploymentExample from '../../../vcluster/_fragments/sleepmode-deployment-example.mdx'
 import SleepModeIngressExample from '../../../vcluster/_fragments/sleepmode-ingress-example.mdx'
-import BasePrerequisites from '../../../docs/_partials/base-prerequisites.mdx';
+import BasePrerequisites from '@site/docs/_partials/base-prerequisites.mdx';
 import InstallCli from '../../_partials/deploy/install-cli.mdx';
 
 <ProAdmonition />

--- a/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
@@ -8,7 +8,7 @@ description: Configuration for ...
 import EnableSwitch from '../../../../_partials/config/sync/fromHost/configMaps.mdx'
 import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 import FromHostConfigMapExample from '../../../../_fragments/sync-from-host-configmap-example.mdx'
-import BasePrerequisites from '../../../../../docs/_partials/base-prerequisites.mdx'
+import BasePrerequisites from '@site/docs/_partials/base-prerequisites.mdx'
 
 By default, this is turned off.
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
@@ -8,7 +8,7 @@ description: Configuration for ...
 import EnableSwitch from '../../../../_partials/config/sync/fromHost/secrets.mdx'
 import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 import FromHostSecretExample from '../../../../_fragments/sync-from-host-secret-example.mdx'
-import BasePrerequisites from '../../../../../docs/_partials/base-prerequisites.mdx'
+import BasePrerequisites from '@site/docs/_partials/base-prerequisites.mdx'
 
 By default, this is turned off.
 

--- a/vcluster/deploy/environment/aks.mdx
+++ b/vcluster/deploy/environment/aks.mdx
@@ -8,7 +8,7 @@ description: Learn how to deploy vCluster on Azure Kubernetes Service (AKS), inc
 
 import InstallCli from '../../_partials/deploy/install-cli.mdx';
 
-import ManagedK8sInstallVcluster from '../../../docs/_partials/managed_k8s_install_vcluster.mdx';
+import ManagedK8sInstallVcluster from '@site/docs/_partials/managed_k8s_install_vcluster.mdx';
 
 
 <!-- vale off -->

--- a/vcluster/deploy/environment/eks.mdx
+++ b/vcluster/deploy/environment/eks.mdx
@@ -12,7 +12,7 @@ import ProAdmonition from '../../_partials/admonitions/pro-admonition.mdx';
 
 import InstallCli from '../../_partials/deploy/install-cli.mdx';
 
-import KubeconfigUpdate from '../../../docs/_partials/kubeconfig_update.mdx';
+import KubeconfigUpdate from '@site/docs/_partials/kubeconfig_update.mdx';
 
 <!-- vale off -->
 # Deploy vCluster on EKS

--- a/vcluster/deploy/environment/gke.mdx
+++ b/vcluster/deploy/environment/gke.mdx
@@ -9,8 +9,8 @@ description: Learn how to deploy vCluster on Google Kubernetes Engine (GKE), inc
 import BasePrerequisites from '../../../platform/_partials/install/base-prerequisites.mdx';
 import Mark from "@site/src/components/Mark";
 import InstallCli from '../../_partials/deploy/install-cli.mdx';
-import KubeconfigUpdate from '../../../docs/_partials/kubeconfig_update.mdx';
-import ManagedK8sInstallVcluster from '../../../docs/_partials/managed_k8s_install_vcluster.mdx';
+import KubeconfigUpdate from '@site/docs/_partials/kubeconfig_update.mdx';
+import ManagedK8sInstallVcluster from '@site/docs/_partials/managed_k8s_install_vcluster.mdx';
 
 import ProAdmonition from '../../_partials/admonitions/pro-admonition.mdx';
 

--- a/vcluster/deploy/upgrade/supported_versions.mdx
+++ b/vcluster/deploy/upgrade/supported_versions.mdx
@@ -5,7 +5,7 @@ sidebar_position: 1
 keywords: [support matrix, supported versions, lifecycle]
 ---
 
-import SupportedVersions from '../../../docs/_partials/vcluster_supported_versions.mdx';
+import SupportedVersions from '@site/docs/_partials/vcluster_supported_versions.mdx';
 
 The following defines vCluster's lifecycle policy for releases and maintenance.
 

--- a/vcluster/manage/sleep-wakeup.mdx
+++ b/vcluster/manage/sleep-wakeup.mdx
@@ -3,7 +3,7 @@ title: Sleep & Wakeup vCluster
 sidebar_label: Sleep & Wakeup
 sidebar_position: 4
 ---
-import BasePrerequisites from '../../docs/_partials/base-prerequisites.mdx';
+import BasePrerequisites from '@site/docs/_partials/base-prerequisites.mdx';
 import InstallCli from '../_partials/deploy/install-cli.mdx';
 
 The sleep mode **temporarily scales down** a virtual cluster and deletes all its created workloads on the host cluster. This approach helps **save computing resources** used by virtual cluster workloads in the host cluster. For example, sleeping development clusters during non-working hours can significantly reduce infrastructure costs.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Update import paths for docs/_partials references

  For example:
```diff
- import BasePrerequisites from '../../../docs/_partials/base-prerequisites.mdx';
+ import BasePrerequisites from '@site/docs/_partials/base-prerequisites.mdx';
```

This change is important for when we cut a new docs release, as these references will no longer
break when the file structure changes. The @site prefix ensures that the imports remain stable
across versions and directory restructuring.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-556--vcluster-docs-site.netlify.app/docs/

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-527

