### PR TITLE
fix: update policy profile doc

### DIFF
--- a/vcluster/configure/vcluster-yaml/policies/pod-security-standard.mdx
+++ b/vcluster/configure/vcluster-yaml/policies/pod-security-standard.mdx
@@ -20,7 +20,7 @@ policies:
   podSecurityStandard: <policy_profile>
 ```
 
-- Replace _`<policy_profile>`_ with `privileged`, `baseline`, or `restricted`. 
+- Replace `<policy_profile>` with `privileged`, `baseline`, or `restricted`. 
 
 See the [Kubernetes Pod Security profile details](https://kubernetes.io/docs/concepts/security/pod-security-standards/#profile-details) for more information. 
 

--- a/vcluster/configure/vcluster-yaml/policies/pod-security-standard.mdx
+++ b/vcluster/configure/vcluster-yaml/policies/pod-security-standard.mdx
@@ -7,18 +7,22 @@ description: Configure pod security standard.
 
 import PodSecurityStandard from '../../../_partials/config/policies/podSecurityStandard.mdx'
 
-This is disabled by default.
+:::note
+This feature is disabled by default.
+:::
 
-[Pod security standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) control pre-built validation of a Pod's capabilities. The security standards don't necessarily grant permissions to a Pod, but rather prevent a Pod from being created that requests more permissions than the standard. Typically this is done through the pods's `spec.securityContext` but can also cover things like host ports, volume types, and special annotations used for Linux AppArmor profiles.
+[Pod security standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) prevent Pods from starting if they request permissions beyond what's allowed. These standards check settings like `spec.securityContext`, host ports, volume types, and AppArmor annotations.
 
-Configure this feature to prevent priviledged pods breaking out of the virtual cluster. 
+Enable this feature to block privileged Pods from escaping the virtual cluster.
 
 ```yaml
 policies:
-  podSecurityStandard: POLICY_PROFILE
+  podSecurityStandard: <policy_profile>
 ```
 
-Replace _`POLICY_PROFILE`_ with `Privileged`, `Baseline`, or `Restricted`. See the Kubernetes docs for [profile details](https://kubernetes.io/docs/concepts/security/pod-security-standards/#profile-details).
+- Replace _`<policy_profile>`_ with `privileged`, `baseline`, or `restricted`. 
+
+See the [Kubernetes Pod Security profile details](https://kubernetes.io/docs/concepts/security/pod-security-standards/#profile-details) for more information. 
 
 ## Config reference
 

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/policies/pod-security-standard.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/policies/pod-security-standard.mdx
@@ -20,7 +20,7 @@ policies:
   podSecurityStandard: <policy_profile>
 ```
 
-- Replace _`<policy_profile>`_ with `privileged`, `baseline`, or `restricted`. 
+- Replace `<policy_profile>` with `privileged`, `baseline`, or `restricted`. 
 
 See the [Kubernetes Pod Security profile details](https://kubernetes.io/docs/concepts/security/pod-security-standards/#profile-details) for more information. 
 

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/policies/pod-security-standard.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/policies/pod-security-standard.mdx
@@ -7,18 +7,22 @@ description: Configure pod security standard.
 
 import PodSecurityStandard from '../../../_partials/config/policies/podSecurityStandard.mdx'
 
-This is disabled by default.
+:::note
+This feature is disabled by default.
+:::
 
-[Pod security standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) control pre-built validation of a Pod's capabilities. The security standards don't necessarily grant permissions to a Pod, but rather prevent a Pod from being created that requests more permissions than the standard. Typically this is done through the pods's `spec.securityContext` but can also cover things like host ports, volume types, and special annotations used for Linux AppArmor profiles.
+[Pod security standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) prevent Pods from starting if they request permissions beyond what's allowed. These standards check settings like `spec.securityContext`, host ports, volume types, and AppArmor annotations.
 
-Configure this feature to prevent priviledged pods breaking out of the virtual cluster. 
+Enable this feature to block privileged Pods from escaping the virtual cluster.
 
 ```yaml
 policies:
-  podSecurityStandard: POLICY_PROFILE
+  podSecurityStandard: <policy_profile>
 ```
 
-Replace _`POLICY_PROFILE`_ with `privileged`, `baseline`, or `restricted`. See the Kubernetes docs for [profile details](https://kubernetes.io/docs/concepts/security/pod-security-standards/#profile-details).
+- Replace _`<policy_profile>`_ with `privileged`, `baseline`, or `restricted`. 
+
+See the [Kubernetes Pod Security profile details](https://kubernetes.io/docs/concepts/security/pod-security-standards/#profile-details) for more information. 
 
 ## Config reference
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Make text on profile policy a little clearer
- make inputs lowercase


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Link to Preview](https://deploy-preview-559--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml/policies/pod-security-standard)


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-525

