### PR TITLE
fix: update incorrect config command

### DIFF
--- a/platform/api/_partials/resources/config/retrieve.mdx
+++ b/platform/api/_partials/resources/config/retrieve.mdx
@@ -2,51 +2,45 @@
 import Tabs from '@theme/Tabs'
 import TabItem from '@theme/TabItem'
 
-You can either use curl or kubectl to retrieve Configs.
+:::note
+Listing `Config` resources is not supported and returns a `MethodNotAllowed` error.
+:::
+
+The Loft platform uses a single `Config` resource named `loft-config`.
+
+Use the following commands to retrieve the configuration:
 
 <Tabs
-    defaultValue="kubectl"
-    values={[
-      {label: 'kubectl', value: 'kubectl'},
-      {label: 'curl', value: 'curl'},
-    ]}>
+  defaultValue="kubectl"
+  values={[
+    {label: 'kubectl', value: 'kubectl'},
+    {label: 'curl', value: 'curl'},
+  ]}>
+  
   <TabItem value="kubectl">
 
 
-### Retrieve a list of Configs
-Run the following command to list all Configs:
+### Retrieve the platform configuration
+
+Use the following command to get the `loft-config` resource from the cluster:
+
 ```bash
-kubectl get config.management.loft.sh  -o yaml
+kubectl get config.management.loft.sh loft-config -o yaml
 ```
-
-### Retrieve a single Config by name
-Run the following kubectl command to get Config `my-object`:
-```bash
-kubectl get config.management.loft.sh my-object  -o yaml
-```
-
-
   </TabItem>
   <TabItem value="curl">
 
+### Retrieve the platform configuration using curl
 
-### Retrieve a list of Configs
-Run the following curl command to list all Configs:
+Use this command to retrieve the `loft-config` resource:
+
 ```bash
-curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/config" \
+curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/config/loft-config" \
      -X GET --insecure \
      -H "Authorization: Bearer $ACCESS_KEY"
 ```
-
-### Get a single Config by name
-Run the following curl command to get Config `my-object`:
-```bash
-# Exchange my-object in the url below with the name of the Config
-curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/config/my-object" \
-     -X GET --insecure \
-     -H "Authorization: Bearer $ACCESS_KEY"
-```
-
+- Replace `$LOFT_DOMAIN` with the domain of where the platform or API server is hosted.
+- Replace `$ACCESS_KEY` with a token or access key used by the platform.
 
   </TabItem>
 </Tabs>

--- a/platform/api/_partials/resources/config/retrieve.mdx
+++ b/platform/api/_partials/resources/config/retrieve.mdx
@@ -18,29 +18,28 @@ Use the following commands to retrieve the configuration:
   ]}>
   
   <TabItem value="kubectl">
-
-
-### Retrieve the platform configuration
-
-Use the following command to get the `loft-config` resource from the cluster:
-
-```bash
-kubectl get config.management.loft.sh loft-config -o yaml
-```
+  
+  ### Retrieve the platform configuration
+  
+  Use the following command to get the `loft-config` resource from the cluster:
+  
+  ```bash
+  kubectl get config.management.loft.sh loft-config -o yaml
+  ```
   </TabItem>
   <TabItem value="curl">
-
-### Retrieve the platform configuration using curl
-
-Use this command to retrieve the `loft-config` resource:
-
-```bash
-curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/config/loft-config" \
-     -X GET --insecure \
-     -H "Authorization: Bearer $ACCESS_KEY"
-```
-- Replace `$LOFT_DOMAIN` with the domain of where the platform or API server is hosted.
-- Replace `$ACCESS_KEY` with a token or access key used by the platform.
-
+  
+  ### Retrieve the platform configuration using curl
+  
+  Use this command to retrieve the `loft-config` resource:
+  
+  ```bash
+  curl -s "https://$LOFT_DOMAIN/kubernetes/management/apis/management.loft.sh/v1/config/loft-config" \
+       -X GET --insecure \
+       -H "Authorization: Bearer $ACCESS_KEY"
+  ```
+    - Replace `$LOFT_DOMAIN` with the domain of where the platform or API server is hosted.
+    - Replace `$ACCESS_KEY` with a token or access key used by the platform.
+  
   </TabItem>
 </Tabs>

--- a/platform/api/resources/config.mdx
+++ b/platform/api/resources/config.mdx
@@ -29,12 +29,12 @@ status:
 
 ```
 
-## Config reference
-
-<Reference />
-
 ## Retrieve: Configs
 
 <Retrieve />
+
+## Config reference
+
+<Reference />
 
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Remove outdated command for platform configs


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Link to Preview](https://deploy-preview-560--vcluster-docs-site.netlify.app/docs/platform/api/resources/config?x0=1)


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-508

