### PR TITLE
fix: wrong default password when create platform using helm

### DIFF
--- a/platform/install/helm.mdx
+++ b/platform/install/helm.mdx
@@ -97,7 +97,7 @@ There are a set of fields in the `values.yaml` that are recommended to explicitl
 
 - `config.loftHost` - Sets a publicly resolvable hostname.
 - `admin.username` - Sets the username of an administrator user. By default, the username is `admin`.
-- `admin.password` - Sets the password of an administrator user. By default, the username is `password`.
+- `admin.password` - Sets the password of an administrator user. By default, the username is `my-password`.
 
 ```yaml title="Recommended values.yaml and config section."
 admin:


### PR DESCRIPTION
Fix wrong default password as it: https://github.com/loft-sh/loft-enterprise/blob/main/chart/values.yaml#L8

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Wrong default password fix
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

