### PR TITLE
chore(vale): lower level on headings id rule to suggestion

### DIFF
--- a/.github/styles/Loft/headings-ids.yml
+++ b/.github/styles/Loft/headings-ids.yml
@@ -1,6 +1,6 @@
 extends: existence
 message: "Headings must have an associated ID. Add an ID like {#heading-id}."
-level: warning
+level: suggestion
 scope: heading
 raw:
   - '\A(?!.*\{#[\w-]+\}).*$'


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
This is too noisy on changes.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
N/A

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-533

