### PR TITLE
feat(ci): remove markdown comments from PR body

### DIFF
--- a/.github/workflows/create-linear-issue.yaml
+++ b/.github/workflows/create-linear-issue.yaml
@@ -9,6 +9,23 @@ jobs:
     if: ${{ github.event.label.name == 'follow-up' }}
     runs-on: ubuntu-latest
     steps:
+      - name: Clean PR description
+        id: clean_description
+        run: |
+          # Get PR body and temporarily replace newlines for processing
+          PR_BODY=$(echo '${{ github.event.pull_request.body }}' | tr '\n' '\r')
+          
+          # Remove all markdown comments (anything between <!-- and -->)
+          CLEAN_BODY=$(echo "$PR_BODY" | perl -pe 's/<!--.*?-->//g')
+          
+          # Restore newlines and escape for GitHub Actions
+          CLEAN_BODY=$(echo "$CLEAN_BODY" | tr '\r' '\n')
+          
+          # Set the output variable with cleaned description
+          echo "description<<EOF" >> $GITHUB_OUTPUT
+          echo "$CLEAN_BODY" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Create the Linear Issue
         id: createIssue
         uses: ctriolo/action-create-linear-issue@v0.7
@@ -16,7 +33,7 @@ jobs:
           linear-api-key: ${{secrets.LINEAR_API_KEY}}
           linear-team-key: "DOC"
           linear-issue-title: "follow-up: ${{github.event.pull_request.title}}"
-          linear-issue-description: ${{github.event.pull_request.body}}
+          linear-issue-description: ${{ steps.clean_description.outputs.description }}
           linear-attachment-url: ${{github.event.pull_request.html_url}}
           linear-attachment-title: ${{github.event.pull_request.title}}
           linear-issue-label-ids: '918eb5e1-2297-44f0-b618-ca1659cbceb7' # This is label id for follow-up label
@@ -27,5 +44,3 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             ${{ steps.createIssue.outputs.linear-issue-url }}
-
-


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Remove markdown comments from PR body for better readability in the linear issue.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

