### PR TITLE
fix: updates to image doc for clarity

### DIFF
--- a/vcluster/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
@@ -27,32 +27,26 @@ Use the `highAvailability` settings to run multiple replicas of the vCluster con
 You can configure how and where virtual cluster pods are scheduled within the Kubernetes cluster. Configure the scheduling field with the following options to control pod placement in the cluster:
 
 - `nodeSelector` ::  
-  Match specific node labels to guide the scheduler toward preferred nodes.  
-  Examples include:  
+  Match specific node labels to guide the scheduler toward preferred nodes. Examples include:  
   - Targeting nodes in a specific region  
   - Selecting nodes with a specific architecture or machine class
 
 - `affinity` ::  
   Set rules to control how pods are scheduled in relation to other pods.  
-  - Use `anti-affinity` to keep virtual cluster pods on separate nodes. This increases resiliency if a node is scaled down or replaced.  
-  - Use `affinity` to group related pods together and reduce network latency for critical services.
+  - Use anti-affinity (repel the pod) to keep virtual cluster pods on separate nodes. A common technique is to make virtual cluster pods repel each other so that they are not scheduled on the same nodes.This increases resiliency if a node is scaled down or replaced.  
+  - Use affinity (attract the pod) to group related pods together and reduce network latency for critical services.
 
 - `tolerations` ::  
-  Allow pods to run on nodes with specific taints. Use this to schedule virtual cluster pods on nodes that would otherwise reject them.  
-  A common pattern is to taint nodes for non-virtual-cluster workloads and configure virtual cluster pods to tolerate the taint. This keeps virtual clusters separate from critical workloads.  
-  See [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information.
+  Allow pods to run on nodes with specific taints. Use this to schedule virtual cluster pods on nodes that would otherwise reject them. A common pattern is to taint nodes for non-virtual-cluster workloads and configure virtual cluster pods to tolerate the taint. This keeps virtual clusters separate from critical workloads. See [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information.
 
 - `priorityClassName` ::  
-  Set the pod’s priority to control scheduling order and preemption.  
-  See the [Pod Priority and Preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) documentation for details.
+  Set the pod’s priority to control scheduling order and preemption. See the [Pod Priority and Preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) documentation for details.
 
 - `podManagementPolicy` ::  
-  Control how StatefulSets create and delete pods.  
-  See [Pod Management Policies](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies) for details.
+  Control how StatefulSets create and delete pods. See [Pod Management Policies](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies) for details.
 
 - `topologySpreadConstraints` ::  
-  Spread pods evenly across zones, nodes, or other topology domains.  
-  See [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) and the [comparison with `podAffinity` and `podAntiAffinity`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#comparison-with-podaffinity-podantiaffinity) for more information.
+  Spread pods evenly across zones, nodes, or other topology domains. See [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) and the [comparison with `podAffinity` and `podAntiAffinity`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#comparison-with-podaffinity-podantiaffinity) for more information.
 
 ## Reuse an existing PersistenceVolumeClaim
 

--- a/vcluster/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
@@ -48,7 +48,9 @@ You can configure how and where virtual cluster pods are scheduled within the Ku
 - `topologySpreadConstraints` ::  
   Spread pods evenly across zones, nodes, or other topology domains. See [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) and the [comparison with `podAffinity` and `podAntiAffinity`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#comparison-with-podaffinity-podantiaffinity) for more information.
 
+<!-- vale off -->
 ## Reuse an existing PersistenceVolumeClaim
+<!-- vale on -->
 
 You can pre-provision a `PersistenceVolumeClaim`, and then configure vCluster to use it.
 

--- a/vcluster/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
@@ -26,33 +26,33 @@ Use the `highAvailability` settings to run multiple replicas of the vCluster con
 
 You can configure how and where virtual cluster pods are scheduled within the Kubernetes cluster. Configure the scheduling field with the following options to control pod placement in the cluster:
 
-- `nodeSelector` ::  
+- **`nodeSelector`**  
   Match specific node labels to guide the scheduler toward preferred nodes. Examples include:  
   - Targeting nodes in a specific region  
   - Selecting nodes with a specific architecture or machine class
 
-- `affinity` ::  
+- **`affinity`** 
   Set rules to control how pods are scheduled in relation to other pods.  
   - Use anti-affinity (repel the pod) to keep virtual cluster pods on separate nodes. A common technique is to make virtual cluster pods repel each other so that they are not scheduled on the same nodes.This increases resiliency if a node is scaled down or replaced.  
   - Use affinity (attract the pod) to group related pods together and reduce network latency for critical services.
 
-- `tolerations` ::  
+- **`tolerations`**  
   Allow pods to run on nodes with specific taints. Use this to schedule virtual cluster pods on nodes that would otherwise reject them. A common pattern is to taint nodes for non-virtual-cluster workloads and configure virtual cluster pods to tolerate the taint. This keeps virtual clusters separate from critical workloads. See [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information.
 
-- `priorityClassName` ::  
+- **`priorityClassName`**  
   Set the pod’s priority to control scheduling order and preemption. See the [Pod Priority and Preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) documentation for details.
 
-- `podManagementPolicy` ::  
+- **`podManagementPolicy`**
   Control how StatefulSets create and delete pods. See [Pod Management Policies](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies) for details.
 
-- `topologySpreadConstraints` ::  
+- **`topologySpreadConstraints`**
   Spread pods evenly across zones, nodes, or other topology domains. See [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) and the [comparison with `podAffinity` and `podAntiAffinity`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#comparison-with-podaffinity-podantiaffinity) for more information.
 
 <!-- vale off -->
 ## Reuse an existing PersistenceVolumeClaim
+<!-- vale on -->
 
 You can pre-provision a `PersistenceVolumeClaim`, and then configure vCluster to use it.
-<!-- vale on -->
 
 To do this, set the existing claim name in the chart values `controlPlane.statefulSet.persistence.dataVolume` under `persistenceVolumeClaim.claimName`:
 

--- a/vcluster/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
@@ -7,32 +7,58 @@ description: Configuration for ...
 
 import ControlPlaneStatefulSet from '../../../../_partials/config/controlPlane/statefulSet.mdx'
 
-The vCluster control plane is deployed as a StatefulSet, since vCluster requires a PersistentVolume resource to store data across restarts. When you configure `statefulSet.persistence.volumeClaim.enabled: false` or you don't configure `statefulSet.persistence.volumeClaimTemplates`,  vCluster is deployed as a `Deployment`.
+The vCluster control plane typically runs as a `StatefulSet` to ensure data persists across restarts. This setup uses a `PersistentVolume` for state storage. However, if you set `statefulSet.persistence.volumeClaim.enabled: false` or omit the `statefulSet.persistence.volumeClaimTemplates` configuration, vCluster defaults to deploying the control plane as a `Deployment`, which does not retain state across restarts.
 
-## High availability
+## Configure high availability
 
-- The `highAvailability` settings let you run more than one pod for the vCluster control plane, with one running as the leader.
-- If the leader crashes, is unhealthy, or restarts, more pods take over leadership, depending on the number of replicas.
-- Adjusting the leaseDuration / renewDeadline / retryPeriod changes the leader election behavior (how often a leader is renewed & retries when it cannot be renewed)
+Use the `highAvailability` settings to run multiple replicas of the vCluster control plane. One pod acts as the leader, while the others remain on standby:
 
-## Scheduling
+- If the leader pod crashes, becomes unhealthy, or restarts, another pod automatically takes over leadership.
 
-`scheduling` configures various scheduler behavior for different purposes. Examples of each follow:
-- `nodeSelector`: Matches labels on nodes to make the scheduler "prefer" scheduling the virtual cluster pods on certain nodes. Do this to:
-  - Target nodes in a region.
-  - Target a specific architecture or machine class.
-- `affinity`: Value can be affinity (attract the pod) or anti-affinity (repel the pod).
-  - Use anti-affinity to spread pods away from each other. A common technique is to make virtual cluster pods repel each other so that they are not scheduled on the same nodes. This increases resiliency in the event a node is scaled down or replaced by a cloud provider.
-  - Use affinity to group certain pods together to reduce network latency for critical services
-- `tolerations`: Another method of influencing where the scheduler places pods. A common use is to "taint" nodes for non-virtual-cluster workloads and make virtual cluster workloads "tolerate" the taint. This results in separating critical apps from the more ephemeral vCluster instances.
-- `priorityClassName`: See [Pod Priority and Preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/).
-- `podManagementPolicy`: See [Pod Management Policies](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies).
-- `topologySpreadConstraints`: See [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/).
-  - Similar to podAffinity & podAntiAffinity in some ways. See [Comparison with podAffinity and podAntiAffinity](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#comparison-with-podaffinity-podantiaffinity).
+- The number of available replicas determines how quickly a new leader can be elected.
 
-## Re-using existing PersistenceVolumeClaim
-It is possible to pre-provision a PersistenceVolumeClaim, and then configure vCluster to use it.
-To do that, set existing claim name in the chart values `controlPlane.statefulSet.persistence.dataVolume` under `persistenceVolumeClaim.claimName`.
+- You can fine-tune the leader election process using the following settings:
+  - `leaseDuration`: Maximum time a leader can hold leadership without renewal.
+  - `renewDeadline`: Time a pod waits to renew its leadership before it gives up.
+  - `retryPeriod`: Interval between retries when attempting to acquire or renew leadership.
+
+## Schedule virtual cluster pods
+
+You can configure how and where virtual cluster pods are scheduled within the Kubernetes cluster. Configure the scheduling field with the following options to control pod placement in the cluster:
+
+- `nodeSelector` ::  
+  Match specific node labels to guide the scheduler toward preferred nodes.  
+  Examples include:  
+  - Targeting nodes in a specific region  
+  - Selecting nodes with a specific architecture or machine class
+
+- `affinity` ::  
+  Set rules to control how pods are scheduled in relation to other pods.  
+  - Use `anti-affinity` to keep virtual cluster pods on separate nodes. This increases resiliency if a node is scaled down or replaced.  
+  - Use `affinity` to group related pods together and reduce network latency for critical services.
+
+- `tolerations` ::  
+  Allow pods to run on nodes with specific taints. Use this to schedule virtual cluster pods on nodes that would otherwise reject them.  
+  A common pattern is to taint nodes for non-virtual-cluster workloads and configure virtual cluster pods to tolerate the taint. This keeps virtual clusters separate from critical workloads.  
+  See [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information.
+
+- `priorityClassName` ::  
+  Set the pod’s priority to control scheduling order and preemption.  
+  See the [Pod Priority and Preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) documentation for details.
+
+- `podManagementPolicy` ::  
+  Control how StatefulSets create and delete pods.  
+  See [Pod Management Policies](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies) for details.
+
+- `topologySpreadConstraints` ::  
+  Spread pods evenly across zones, nodes, or other topology domains.  
+  See [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) and the [comparison with `podAffinity` and `podAntiAffinity`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#comparison-with-podaffinity-podantiaffinity) for more information.
+
+## Reuse an existing PersistenceVolumeClaim
+
+You can pre-provision a `PersistenceVolumeClaim`, and then configure vCluster to use it.
+
+To do this, set the existing claim name in the chart values `controlPlane.statefulSet.persistence.dataVolume` under `persistenceVolumeClaim.claimName`:
 
 ```yaml
 controlPlane:
@@ -48,9 +74,9 @@ controlPlane:
 
 There are currently 3 vCluster image builds you can use in `statefulSet.image.repository`: 
 
-- loft-sh/vcluster-pro: The default image for the Helm chart, this image works for all use-cases.
-- loft-sh/vcluster-oss: A purely open-source build of vCluster
-- loft-sh/vcluster: Deprecated. Use `loft-sh/vcluster-oss` as a replacement.
+- `loft-sh/vcluster-pro`: The default image for the Helm chart. This image works for all use cases.
+- `loft-sh/vcluster-oss`: An open source build of vCluster
+- `loft-sh/vcluster`: Deprecated. Use `loft-sh/vcluster-oss` instead.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
@@ -50,9 +50,9 @@ You can configure how and where virtual cluster pods are scheduled within the Ku
 
 <!-- vale off -->
 ## Reuse an existing PersistenceVolumeClaim
-<!-- vale on -->
 
 You can pre-provision a `PersistenceVolumeClaim`, and then configure vCluster to use it.
+<!-- vale on -->
 
 To do this, set the existing claim name in the chart values `controlPlane.statefulSet.persistence.dataVolume` under `persistenceVolumeClaim.claimName`:
 

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
@@ -27,32 +27,26 @@ Use the `highAvailability` settings to run multiple replicas of the vCluster con
 You can configure how and where virtual cluster pods are scheduled within the Kubernetes cluster. Configure the scheduling field with the following options to control pod placement in the cluster:
 
 - `nodeSelector` ::  
-  Match specific node labels to guide the scheduler toward preferred nodes.  
-  Examples include:  
+  Match specific node labels to guide the scheduler toward preferred nodes. Examples include:  
   - Targeting nodes in a specific region  
   - Selecting nodes with a specific architecture or machine class
 
 - `affinity` ::  
   Set rules to control how pods are scheduled in relation to other pods.  
-  - Use `anti-affinity` to keep virtual cluster pods on separate nodes. This increases resiliency if a node is scaled down or replaced.  
-  - Use `affinity` to group related pods together and reduce network latency for critical services.
+  - Use anti-affinity (repel the pod) to keep virtual cluster pods on separate nodes. A common technique is to make virtual cluster pods repel each other so that they are not scheduled on the same nodes.This increases resiliency if a node is scaled down or replaced.  
+  - Use affinity (attract the pod) to group related pods together and reduce network latency for critical services.
 
 - `tolerations` ::  
-  Allow pods to run on nodes with specific taints. Use this to schedule virtual cluster pods on nodes that would otherwise reject them.  
-  A common pattern is to taint nodes for non-virtual-cluster workloads and configure virtual cluster pods to tolerate the taint. This keeps virtual clusters separate from critical workloads.  
-  See [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information.
+  Allow pods to run on nodes with specific taints. Use this to schedule virtual cluster pods on nodes that would otherwise reject them. A common pattern is to taint nodes for non-virtual-cluster workloads and configure virtual cluster pods to tolerate the taint. This keeps virtual clusters separate from critical workloads. See [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information.
 
 - `priorityClassName` ::  
-  Set the pod’s priority to control scheduling order and preemption.  
-  See the [Pod Priority and Preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) documentation for details.
+  Set the pod’s priority to control scheduling order and preemption. See the [Pod Priority and Preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) documentation for details.
 
 - `podManagementPolicy` ::  
-  Control how StatefulSets create and delete pods.  
-  See [Pod Management Policies](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies) for details.
+  Control how StatefulSets create and delete pods. See [Pod Management Policies](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies) for details.
 
 - `topologySpreadConstraints` ::  
-  Spread pods evenly across zones, nodes, or other topology domains.  
-  See [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) and the [comparison with `podAffinity` and `podAntiAffinity`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#comparison-with-podaffinity-podantiaffinity) for more information.
+  Spread pods evenly across zones, nodes, or other topology domains. See [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) and the [comparison with `podAffinity` and `podAntiAffinity`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#comparison-with-podaffinity-podantiaffinity) for more information.
 
 ## Reuse an existing PersistenceVolumeClaim
 

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
@@ -26,26 +26,26 @@ Use the `highAvailability` settings to run multiple replicas of the vCluster con
 
 You can configure how and where virtual cluster pods are scheduled within the Kubernetes cluster. Configure the scheduling field with the following options to control pod placement in the cluster:
 
-- `nodeSelector` ::  
+- **`nodeSelector`**
   Match specific node labels to guide the scheduler toward preferred nodes. Examples include:  
   - Targeting nodes in a specific region  
   - Selecting nodes with a specific architecture or machine class
 
-- `affinity` ::  
+- **`affinity`**  
   Set rules to control how pods are scheduled in relation to other pods.  
   - Use anti-affinity (repel the pod) to keep virtual cluster pods on separate nodes. A common technique is to make virtual cluster pods repel each other so that they are not scheduled on the same nodes.This increases resiliency if a node is scaled down or replaced.  
   - Use affinity (attract the pod) to group related pods together and reduce network latency for critical services.
 
-- `tolerations` ::  
+- **`tolerations`**  
   Allow pods to run on nodes with specific taints. Use this to schedule virtual cluster pods on nodes that would otherwise reject them. A common pattern is to taint nodes for non-virtual-cluster workloads and configure virtual cluster pods to tolerate the taint. This keeps virtual clusters separate from critical workloads. See [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information.
 
-- `priorityClassName` ::  
+- **`priorityClassName`**  
   Set the pod’s priority to control scheduling order and preemption. See the [Pod Priority and Preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) documentation for details.
 
-- `podManagementPolicy` ::  
+- **`podManagementPolicy`**  
   Control how StatefulSets create and delete pods. See [Pod Management Policies](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies) for details.
 
-- `topologySpreadConstraints` ::  
+- **`topologySpreadConstraints`**  
   Spread pods evenly across zones, nodes, or other topology domains. See [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) and the [comparison with `podAffinity` and `podAntiAffinity`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#comparison-with-podaffinity-podantiaffinity) for more information.
 
 <!-- vale off -->

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
@@ -7,32 +7,58 @@ description: Configuration for ...
 
 import ControlPlaneStatefulSet from '../../../../_partials/config/controlPlane/statefulSet.mdx'
 
-The vCluster control plane is deployed as a StatefulSet, since vCluster requires a PersistentVolume resource to store data across restarts. When you configure `statefulSet.persistence.volumeClaim.enabled: false` or you don't configure `statefulSet.persistence.volumeClaimTemplates`,  vCluster is deployed as a `Deployment`.
+The vCluster control plane typically runs as a `StatefulSet` to ensure data persists across restarts. This setup uses a `PersistentVolume` for state storage. However, if you set `statefulSet.persistence.volumeClaim.enabled: false` or omit the `statefulSet.persistence.volumeClaimTemplates` configuration, vCluster defaults to deploying the control plane as a `Deployment`, which does not retain state across restarts.
 
-## High availability
+## Configure high availability
 
-- The `highAvailability` settings let you run more than one pod for the vCluster control plane, with one running as the leader.
-- If the leader crashes, is unhealthy, or restarts, more pods take over leadership, depending on the number of replicas.
-- Adjusting the leaseDuration / renewDeadline / retryPeriod changes the leader election behavior (how often a leader is renewed & retries when it cannot be renewed)
+Use the `highAvailability` settings to run multiple replicas of the vCluster control plane. One pod acts as the leader, while the others remain on standby:
 
-## Scheduling
+- If the leader pod crashes, becomes unhealthy, or restarts, another pod automatically takes over leadership.
 
-`scheduling` configures various scheduler behavior for different purposes. Examples of each follow:
-- `nodeSelector`: Matches labels on nodes to make the scheduler "prefer" scheduling the virtual cluster pods on certain nodes. Do this to:
-  - Target nodes in a region.
-  - Target a specific architecture or machine class.
-- `affinity`: Value can be affinity (attract the pod) or anti-affinity (repel the pod).
-  - Use anti-affinity to spread pods away from each other. A common technique is to make virtual cluster pods repel each other so that they are not scheduled on the same nodes. This increases resiliency in the event a node is scaled down or replaced by a cloud provider.
-  - Use affinity to group certain pods together to reduce network latency for critical services
-- `tolerations`: Another method of influencing where the scheduler places pods. A common use is to "taint" nodes for non-virtual-cluster workloads and make virtual cluster workloads "tolerate" the taint. This results in separating critical apps from the more ephemeral vCluster instances.
-- `priorityClassName`: See [Pod Priority and Preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/).
-- `podManagementPolicy`: See [Pod Management Policies](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies).
-- `topologySpreadConstraints`: See [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/).
-  - Similar to podAffinity & podAntiAffinity in some ways. See [Comparison with podAffinity and podAntiAffinity](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#comparison-with-podaffinity-podantiaffinity).
+- The number of available replicas determines how quickly a new leader can be elected.
 
-## Re-using existing PersistenceVolumeClaim
-It is possible to pre-provision a PersistenceVolumeClaim, and then configure vCluster to use it.
-To do that, set existing claim name in the chart values `controlPlane.statefulSet.persistence.dataVolume` under `persistenceVolumeClaim.claimName`.
+- You can fine-tune the leader election process using the following settings:
+  - `leaseDuration`: Maximum time a leader can hold leadership without renewal.
+  - `renewDeadline`: Time a pod waits to renew its leadership before it gives up.
+  - `retryPeriod`: Interval between retries when attempting to acquire or renew leadership.
+
+## Schedule virtual cluster pods
+
+You can configure how and where virtual cluster pods are scheduled within the Kubernetes cluster. Configure the scheduling field with the following options to control pod placement in the cluster:
+
+- `nodeSelector` ::  
+  Match specific node labels to guide the scheduler toward preferred nodes.  
+  Examples include:  
+  - Targeting nodes in a specific region  
+  - Selecting nodes with a specific architecture or machine class
+
+- `affinity` ::  
+  Set rules to control how pods are scheduled in relation to other pods.  
+  - Use `anti-affinity` to keep virtual cluster pods on separate nodes. This increases resiliency if a node is scaled down or replaced.  
+  - Use `affinity` to group related pods together and reduce network latency for critical services.
+
+- `tolerations` ::  
+  Allow pods to run on nodes with specific taints. Use this to schedule virtual cluster pods on nodes that would otherwise reject them.  
+  A common pattern is to taint nodes for non-virtual-cluster workloads and configure virtual cluster pods to tolerate the taint. This keeps virtual clusters separate from critical workloads.  
+  See [Taints and Tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for more information.
+
+- `priorityClassName` ::  
+  Set the pod’s priority to control scheduling order and preemption.  
+  See the [Pod Priority and Preemption](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) documentation for details.
+
+- `podManagementPolicy` ::  
+  Control how StatefulSets create and delete pods.  
+  See [Pod Management Policies](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-management-policies) for details.
+
+- `topologySpreadConstraints` ::  
+  Spread pods evenly across zones, nodes, or other topology domains.  
+  See [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) and the [comparison with `podAffinity` and `podAntiAffinity`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#comparison-with-podaffinity-podantiaffinity) for more information.
+
+## Reuse an existing PersistenceVolumeClaim
+
+You can pre-provision a `PersistenceVolumeClaim`, and then configure vCluster to use it.
+
+To do this, set the existing claim name in the chart values `controlPlane.statefulSet.persistence.dataVolume` under `persistenceVolumeClaim.claimName`:
 
 ```yaml
 controlPlane:
@@ -48,9 +74,9 @@ controlPlane:
 
 There are currently 3 vCluster image builds you can use in `statefulSet.image.repository`: 
 
-- loft-sh/vcluster-pro: The default image for the Helm chart, this image works for all use-cases.
-- loft-sh/vcluster-oss: A purely open-source build of vCluster
-- loft-sh/vcluster: Deprecated. Use `loft-sh/vcluster-oss` as a replacement.
+- `loft-sh/vcluster-pro`: The default image for the Helm chart. This image works for all use cases.
+- `loft-sh/vcluster-oss`: An open source build of vCluster
+- `loft-sh/vcluster`: Deprecated. Use `loft-sh/vcluster-oss` instead.
 
 ## Config reference
 

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/deployment/statefulset.mdx
@@ -48,7 +48,9 @@ You can configure how and where virtual cluster pods are scheduled within the Ku
 - `topologySpreadConstraints` ::  
   Spread pods evenly across zones, nodes, or other topology domains. See [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) and the [comparison with `podAffinity` and `podAntiAffinity`](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#comparison-with-podaffinity-podantiaffinity) for more information.
 
+<!-- vale off -->
 ## Reuse an existing PersistenceVolumeClaim
+<!-- vale off -->
 
 You can pre-provision a `PersistenceVolumeClaim`, and then configure vCluster to use it.
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Minor updates to comply with style guide

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Link to Preview](https://deploy-preview-571--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml/control-plane/deployment/statefulset)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-514

