### PR TITLE
feat: missing port 1053 added to docs

### DIFF
--- a/platform/administer/clusters/advanced/networking.mdx
+++ b/platform/administer/clusters/advanced/networking.mdx
@@ -6,7 +6,7 @@ description: Learn which ports must be open to enable communication on the platf
 
 The platform uses specific network ports to enable communication between Kubernetes clusters, the platform API, and external services. These ports support API requests, webhook execution, and cost monitoring.
 
-If these ports are blocked by firewall rules, some platform features—such as role-based access control (RBAC) enforcement, cost monitoring, or webhook validation—might fail. Ensure these ports are open to prevent connectivity issues.
+If these ports are blocked by firewall rules, some platform features such as role-based access control (RBAC) enforcement, cost monitoring, or webhook validation might fail. Ensure these ports are open to prevent connectivity issues.
 
 ## Required open ports
 
@@ -28,13 +28,13 @@ In private GKE clusters, Kubernetes control plane and worker nodes might reside 
 
 vCluster runs a CoreDNS component inside each virtual cluster to handle internal DNS queries. To avoid conflicts with the host cluster's DNS, CoreDNS in vCluster listens on port `1053` instead of the default port `53`.
 
-If this port is blocked, DNS queries from virtual cluster pods may fail—especially when the querying pod and CoreDNS pod run on different nodes. This issue commonly affects EKS clusters created with Terraform, which set up separate security groups for the control plane and worker nodes. By default, the node security group does not allow inbound traffic on port `1053`.
+If this port is blocked, DNS queries from virtual cluster pods might not work, especially when the querying pod and the CoreDNS pod are on different nodes. This issue commonly affects EKS clusters created with Terraform, which set up separate security groups for the control plane and worker nodes. By default, the node security group does not allow inbound traffic on port `1053`.
 
 To enable proper DNS resolution within virtual clusters, allow inbound traffic on port `1053` between nodes.
 
 | Port   | Description          | Purpose                                                                 |
 |--------|----------------------|-------------------------------------------------------------------------|
-| `1053` | CoreDNS for vCluster | Enables internal DNS resolution across nodes in virtual clusters       |
+| `1053` | CoreDNS for vCluster | Enables internal DNS resolution across nodes in virtual clusters        |
 
 :::note
 If you're using EKS with Terraform, check the default node security group and manually allow inbound traffic on TCP and UDP port `1053`. This ensures DNS queries between pods and CoreDNS can succeed even when scheduled on different nodes.

--- a/platform/administer/clusters/advanced/networking.mdx
+++ b/platform/administer/clusters/advanced/networking.mdx
@@ -24,6 +24,23 @@ Kubernetes must connect to the platform’s API extensions and webhooks to proce
 In private GKE clusters, Kubernetes control plane and worker nodes might reside in separate subnetworks. You might need to explicitly allow traffic on these ports using a firewall rule.
 :::
 
+### Enable DNS resolution in virtual clusters
+
+vCluster runs a CoreDNS component inside each virtual cluster to handle internal DNS queries. To avoid conflicts with the host cluster's DNS, CoreDNS in vCluster listens on port `1053` instead of the default port `53`.
+
+If this port is blocked, DNS queries from virtual cluster pods may fail—especially when the querying pod and CoreDNS pod run on different nodes. This issue commonly affects EKS clusters created with Terraform, which set up separate security groups for the control plane and worker nodes. By default, the node security group does not allow inbound traffic on port `1053`.
+
+To enable proper DNS resolution within virtual clusters, allow inbound traffic on port `1053` between nodes.
+
+| Port   | Description          | Purpose                                                                 |
+|--------|----------------------|-------------------------------------------------------------------------|
+| `1053` | CoreDNS for vCluster | Enables internal DNS resolution across nodes in virtual clusters       |
+
+:::note
+If you're using EKS with Terraform, check the default node security group and manually allow inbound traffic on TCP and UDP port `1053`. This ensures DNS queries between pods and CoreDNS can succeed even when scheduled on different nodes.
+:::
+
+
 ### Connect the platform to Prometheus
 
 The platform retrieves cost metrics from Prometheus running inside connected clusters. The platform's cost control dashboard uses these metrics to provide insights into resource usage.  
@@ -37,7 +54,6 @@ To collect this data, the local cluster agent acts as a proxy between the platfo
 :::note
 If your environment has strict firewall rules or network policies, you might need to explicitly allow traffic over `TCP 9090` between the platform and Prometheus.
 :::
-
 
 ## Firewall rules configuration
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
@@ -31,7 +31,7 @@ vCluster's CoreDNS service listens on port `1053` instead of the default DNS por
 
 If you're running vCluster on EKS or another cloud provider with strict network policies, you must allow traffic on port `1053` between nodes to avoid DNS resolution issues.
 
-For more deails, see the [Networking documentation](/platform/networking#enable-dns-resolution-in-virtual-clusters).
+For more deails, see the [Networking documentation](/platform/administer/clusters/advanced/networking).
 :::
 
 ## Integrated CoreDNS

--- a/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/coredns.mdx
@@ -26,6 +26,14 @@ A normal vCluster deployment consists of two pods per vCluster instance:
   - Syncer container
 - CoreDNS Pod
 
+:::note CoreDNS listens on port 1053
+vCluster's CoreDNS service listens on port `1053` instead of the default DNS port `53` to avoid conflicts with DNS on the host cluster.
+
+If you're running vCluster on EKS or another cloud provider with strict network policies, you must allow traffic on port `1053` between nodes to avoid DNS resolution issues.
+
+For more deails, see the [Networking documentation](/platform/networking#enable-dns-resolution-in-virtual-clusters).
+:::
+
 ## Integrated CoreDNS
 
 (Pro) The integrated CoreDNS feature lets you run CoreDNS as part of the syncer, which saves the overhead of an external CoreDNS pod. 

--- a/vcluster/deploy/environment/eks.mdx
+++ b/vcluster/deploy/environment/eks.mdx
@@ -136,7 +136,7 @@ vcluster create my-vcluster --namespace team-x
 
 <KubeconfigUpdate />
 
-### Verify the Installation
+### Verify the installation
 
 Check if `vCluster` pods are running:
 
@@ -155,6 +155,18 @@ This configuration ensures that:
 - Service accounts are properly synced between virtual and host clusters
 - Persistent volume claims are handled correctly
 - The `gp3` storage class created earlier is used
+
+### Allow internal DNS resolution
+
+By default, vCluster runs a CoreDNS component inside the virtual cluster. This component listens on port `1053` instead of the standard DNS port `53` to avoid conflicts with the host cluster DNS.
+
+On EKS, if the CoreDNS pod and other virtual cluster pods are scheduled on different nodes, DNS resolution may fail. This happens because AWS creates separate security groups for the EKS control plane and worker nodes, and the default node security group does not allow inbound traffic on port `1053`.
+
+To resolve this, manually update the EKS node security group to allow inbound TCP and UDP traffic on port `1053` between nodes.
+
+:::tip
+This step is especially important for EKS clusters created using Terraform or other automation tools that apply restrictive network settings by default.
+:::
 
 ## Next steps
 

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/components/coredns.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/components/coredns.mdx
@@ -31,7 +31,7 @@ vCluster's CoreDNS service listens on port `1053` instead of the default DNS por
 
 If you're running vCluster on EKS or another cloud provider with strict network policies, you must allow traffic on port `1053` between nodes to avoid DNS resolution issues.
 
-For more deails, see the [Networking documentation](/platform/networking#enable-dns-resolution-in-virtual-clusters).
+For more deails, see the [Networking documentation](/platform/administer/clusters/advanced/networking).
 :::
 
 ## Integrated CoreDNS

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/components/coredns.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/control-plane/components/coredns.mdx
@@ -26,6 +26,14 @@ A normal vCluster deployment consists of two pods per vCluster instance:
   - Syncer container
 - CoreDNS Pod
 
+:::note CoreDNS listens on port 1053
+vCluster's CoreDNS service listens on port `1053` instead of the default DNS port `53` to avoid conflicts with DNS on the host cluster.
+
+If you're running vCluster on EKS or another cloud provider with strict network policies, you must allow traffic on port `1053` between nodes to avoid DNS resolution issues.
+
+For more deails, see the [Networking documentation](/platform/networking#enable-dns-resolution-in-virtual-clusters).
+:::
+
 ## Integrated CoreDNS
 
 The integrated CoreDNS feature lets you run CoreDNS as part of the syncer, which saves the overhead of an external CoreDNS pod. 

--- a/vcluster_versioned_docs/version-0.24.0/deploy/environment/eks.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/deploy/environment/eks.mdx
@@ -156,6 +156,18 @@ This configuration ensures that:
 - Persistent volume claims are handled correctly
 - The `gp3` storage class created earlier is used
 
+### Allow internal DNS resolution
+
+By default, vCluster runs a CoreDNS component inside the virtual cluster. This component listens on port `1053` instead of the standard DNS port `53` to avoid conflicts with the host cluster DNS.
+
+On EKS, if the CoreDNS pod and other virtual cluster pods are scheduled on different nodes, DNS resolution may fail. This happens because AWS creates separate security groups for the EKS control plane and worker nodes, and the default node security group does not allow inbound traffic on port `1053`.
+
+To resolve this, manually update the EKS node security group to allow inbound TCP and UDP traffic on port `1053` between nodes.
+
+:::tip
+This step is especially important for EKS clusters created using Terraform or other automation tools that apply restrictive network settings by default.
+:::
+
 ## Next steps
 
 Now that you have `vCluster` running on EKS, consider:


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Update pages to mention port `1053` should be open

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-451

