### PR TITLE
Create override_alpine_sidecar.mdx

### DIFF
--- a/staging/override_alpine_sidecar.mdx
+++ b/staging/override_alpine_sidecar.mdx
@@ -1,0 +1,52 @@
+---
+ title: Overriding the Alpine Sidecar Image and Adding Image Pull Secrets in vcluster
+  sidebar_label: Overriding Alpine Sidecar Image 
+  description: Setting a different sidecar in vCluster
+  ---
+
+# Overriding the Alpine Sidecar Image
+
+vcluster uses an Alpine sidecar container to manage host entries in the virtual cluster's /etc/hosts file. By default, it pulls the Alpine image from DockerHub. However, you can override this default image with your own Alpine or similar image.
+### For vcluster 0.20 and above
+In the vcluster.yaml configuration file, add the following under the `sync.toHost.pods.rewriteHosts.initContainer` section:
+```
+sync:
+  toHost:
+    pods:
+      rewriteHosts:
+        initContainer:
+          image: "your-alpine-or-similar-img"
+```
+
+### For vcluster 0.19 and below
+
+Add the following under the `syncer.extraArgs` section in vcluster.yaml:
+```
+syncer:
+  extraArgs:
+    - '--override-hosts-container-image="your-alpine-or-similar-img"'        
+```
+## Adding Image Pull Secrets
+
+If your Alpine or custom image is hosted in a private registry that requires authentication, you can configure vcluster to use an existing image pull secret.
+
+### For vcluster 0.20 and above
+
+Add the following under the `controlPlane.advanced.workloadServiceAccount` section in vcluster.yaml:
+```
+controlPlane:
+  advanced:
+    workloadServiceAccount:
+      imagePullSecrets:
+        name: secret-name-in-vcluster-ns
+```
+### For vcluster 0.19 and below
+
+Add the following under the `serviceAccount.imagePullSecrets` section in vcluster.yaml:
+```
+serviceAccount:
+  imagePullSecrets:
+    - name: secret-name-in-vcluster-ns
+```
+
+Replace `secret-name-in-vcluster-ns` with the name of the image pull secret in the vcluster namespace.


### PR DESCRIPTION
KB page on changing Alpine sidecar in vCluster

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

