### PR TITLE
Check if you are connected to vCluster or host

### DIFF
--- a/staging/check_if_vcluster.mdx
+++ b/staging/check_if_vcluster.mdx
@@ -1,0 +1,62 @@
+---
+ title: How to programmatically check if you're connected to a vcluster or host cluster
+  sidebar_label: check vCluster connection 
+  description: How to programmatically check if the Kubernetes cluster you are connected to is vCluster
+  ---
+
+When working with Kubernetes clusters, it's sometimes necessary to determine programmatically whether you're connected to a vcluster (virtual cluster) or the host cluster. This article outlines several methods to achieve this.
+
+# Method 1: Check for vcluster node labels
+One approach is to retrieve the nodes and check for a vcluster node label:
+```
+kubectl get nodes --show-labels | grep vcluster
+```
+If this command returns results, you're likely connected to a vcluster. However, this method may not always be 100% reliable.
+
+# Method 2: Examine the current context
+For scripting purposes, you can check the current context:
+```
+kubectl config current-context
+```
+If the output contains "vcluster" (e.g., "vcluster_vcluster-xx5gk"), you're connected to a vcluster.
+
+# Method 3: Parse all contexts
+To get a more comprehensive view, you can list all contexts and search for "vcluster":
+```
+kubectl config get-contexts | grep vcluster
+```
+This will show all vcluster contexts available.
+
+# Implementing in a script
+
+Here's a simple bash script that combines these methods:
+```
+#!/bin/bash
+
+# Check current context
+current_context=$(kubectl config current-context)
+if [[ $current_context == *"vcluster"* ]]; then
+    echo "Connected to vcluster: $current_context"
+    exit 0
+fi
+
+# Check for vcluster node labels
+vcluster_nodes=$(kubectl get nodes --show-labels | grep vcluster)
+if [ ! -z "$vcluster_nodes" ]; then
+    echo "Connected to vcluster (detected via node labels)"
+    exit 0
+fi
+
+echo "Connected to host cluster"
+exit 1
+```
+
+This script first checks the current context name. If that doesn't indicate a vcluster, it then checks for vcluster node labels. If neither method detects a vcluster, it assumes you're connected to the host cluster.
+
+## Additional tools
+
+While not directly applicable for scripting, tools like kubectx can be helpful for manual context switching and management:
+- Install kubectl plugins using [Krew](https://krew.sigs.k8s.io/)
+- Use [kubectx](https://github.com/ahmetb/kubectx) for easier context switching
+
+These tools can be particularly useful when working with multiple clusters or contexts in a development environment.


### PR DESCRIPTION
A KB article on programmatic checking if you are connected to a vCluster or host cluster.

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

