### PR TITLE
Create Resolving_rancher_ingress_conflicts.mdx

### DIFF
--- a/staging/Resolving_rancher_ingress_conflicts.mdx
+++ b/staging/Resolving_rancher_ingress_conflicts.mdx
@@ -1,0 +1,34 @@
+---
+ title: Resolving Ingress Update Conflicts When Using vCluster with Rancher
+  sidebar_label: resolve vCluster with Rrancher ingress conflicts
+  description: Resolving conflict in ingress when deploying Rancher in both vcluster and host cluster.
+  ---
+When deploying the Rancher agent in both vCluster and the host cluster, and using a single, shared ingress,  both agents will repeatedly update the ingress object, causing load on the DB and the API server.
+
+## Symptoms
+- Endless updates to ingress resources in the host cluster
+- A rapid growth of the API server database. The DB may reach several GB
+- Slowdown of the API server, causing simple commands like `kubectl get pods` to take several seconds
+
+## Cause
+This issue occurs due to a conflict between the rancher agent deployed in both vCluster and the host (outer) clusters. Both agents attempt to update annotations on the ingress, but they use different naming conventions, leading to a continuous update loop.
+
+## Solution
+This issue has been resolved in vCluster version 0.19.8. To fix the problem, upgrade your vCluster installation to this version or later.
+If your API server is slow, compact your etcd database to reduce its size. This is specific to your Kubernetes distro and implementation and is outside the scope of this document.
+
+## Steps to Upgrade using Helm
+If you installed vCluster using Helm, Run the following command:
+```
+helm upgrade <<mycluster>> loft/vcluster --reuse-values --version 0.19.8
+```
+ Replace "mycluster" with the name of your vCluster release if different.
+
+##Verification
+After upgrading, monitor your cluster to ensure that:
+- Ingress updates have stabilized
+- The kine database size growth has slowed or stopped
+- API server performance has returned to normal (The etcd database may need compacting before you see this)
+
+## Additional Information
+For more details about this fix and other changes in vCluster 0.19.8, refer to the [official release notes](https://github.com/loft-sh/vcluster/releases/tag/v0.19.8).


### PR DESCRIPTION
KB on resolving ingress conflics when deploying Rancher in vCluster and the host cluster. This was resolved in 0.19.8 and later

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

