### PR TITLE
fix: improve platform migration doc

### DIFF
--- a/platform/administer/upgrade-migrate/migrate-to-hostcluster.mdx
+++ b/platform/administer/upgrade-migrate/migrate-to-hostcluster.mdx
@@ -57,6 +57,7 @@ Not addressing these considerations before migration can lead to DNS misconfigur
 - Plan for 15–30 minutes of downtime during the migration process. Communicate this downtime to end users in advance.
 - Use the same platform version for both the source and destination installations. Migration does not support version changes.
 
+<!-- vale off -->
 ## Migration steps {#migration-steps}
 
 <Flow id="migration procedure">
@@ -183,3 +184,4 @@ Optional: Restart `ArgoCD` sync if previously stopped.
 Send end-of-downtime communication to end users.
 </Step>
 </Flow>
+<!-- vale on -->

--- a/platform/administer/upgrade-migrate/migrate-to-hostcluster.mdx
+++ b/platform/administer/upgrade-migrate/migrate-to-hostcluster.mdx
@@ -29,16 +29,16 @@ The platform must run on a dedicated Kubernetes cluster. It must have its own ex
 
 Review the following factors before migrating. These scenarios require a different migration approach.
 
-- Loft router configurations::
-  If the platform uses the Loft router (`<something.loft.host>`), special DNS handling is required. The DNS records must be updated to reflect the new cluster. Failure to update DNS settings can cause routing issues and service downtime.
+- **Loft router configurations**  
+  If the platform uses the Loft router (`<example.loft.host>`), special DNS handling is required. The DNS records must be updated to reflect the new cluster. Failure to update DNS settings can cause routing issues and service downtime.
 
-- Automated deployment tools::
+- **Automated deployment tools**  
   If the platform is managed by an automated deployment tool such as `ArgoCD`, migration must be coordinated with GitOps workflows. Changes to cluster configuration must be reflected in the repository before deployment. Skipping this step can lead to drift between the declared and actual state of the platform.
 
-- Virtual cluster dependencies::
+- **Virtual cluster dependencies**  
   If the platform has virtual cluster instances running on the same Kubernetes host cluster, these instances do not migrate automatically. They require a separate migration process after the platform has been moved. Migrating only the platform without considering virtual clusters can cause service disruptions and dependency issues.
 
-- Virtual cluster agent on the destination cluster::
+- **Virtual cluster agent on the destination cluster**  
   If the destination Kubernetes cluster has a virtual cluster agent, it must be decommissioned before migration. The agent can interfere with the new platform installation, potentially leading to scheduling conflicts and unexpected behavior.
 
 Not addressing these considerations before migration can lead to DNS misconfigurations, deployment failures, and conflicts with existing workloads.
@@ -51,11 +51,11 @@ Not addressing these considerations before migration can lead to DNS misconfigur
 
 ### Platform specific prerequisites {#platform-specific-prerequisites}
 
-- Storage space for backup (approximately 1GB).
-- Access to DNS management for the platform's domain.
-- Only one platform instance can exist per Kubernetes cluster. Do not install the platform twice in the same Kubernetes host cluster.
-- The migration process requires 15-30 minutes of downtime. Communicate this downtime to end users.
-- The source and destination installations must use the same platform version. Version changes during migration are not supported.
+- Ensure at least 1 GB of available storage space for the backup.
+- Confirm that you have access to DNS management for the platform's domain.
+- Only one platform instance can run in a single Kubernetes cluster. Do not install the platform more than once in the same host cluster.
+- Plan for 15–30 minutes of downtime during the migration process. Communicate this downtime to end users in advance.
+- Use the same platform version for both the source and destination installations. Migration does not support version changes.
 
 ## Migration steps {#migration-steps}
 
@@ -63,7 +63,7 @@ Not addressing these considerations before migration can lead to DNS misconfigur
 
 ### Install the platform in the new cluster {#install-platform-new-cluster}
 <Step>
-Configuration::
+Use the following configuration settings to complete the installation in the new cluster:
 
 - Use the Helm values from the original installation, making adjustments to values like `ingressClass` or `storageClass` as necessary.
 - If your project namespaces use the `loft-p-` prefix, set `projectNamespacePrefix: loft-p-` in your configuration.

--- a/platform/administer/upgrade-migrate/migrate-to-hostcluster.mdx
+++ b/platform/administer/upgrade-migrate/migrate-to-hostcluster.mdx
@@ -8,7 +8,7 @@ description: Learn how to migrate vCluster platform from one Kubernetes cluster 
 import Flow, { Step } from '@site/src/components/Flow'
 import BasePrerequisites from '../../_partials/install/base-prerequisites.mdx';
 
-This guide explains how to migrate the platform to a different Kubernetes cluster, which may be necessary during cluster decommissioning or cloud platform migration.
+This guide explains how to migrate the platform to a different Kubernetes cluster, which might be necessary during cluster decommissioning or cloud platform migration.
 
 ## When to migrate {#when-to-migrate}
 
@@ -24,21 +24,21 @@ Migrating the platform to a new Kubernetes cluster is necessary in certain cases
 ### Migration considerations {#migration-considerations}
 
 :::warning
-The platform must run on a dedicated Kubernetes cluster. It must have its own external access (via ingress or LoadBalancer) and DNS record before migration. Ensure these conditions are met before proceeding.
+The platform must run on a dedicated Kubernetes cluster. It must have its own external access (using ingress or LoadBalancer) and DNS record before migration. Ensure these conditions are met before proceeding.
 :::
 
 Review the following factors before migrating. These scenarios require a different migration approach.
 
-- Loft router configurations
+- Loft router configurations::
   If the platform uses the Loft router (`<something.loft.host>`), special DNS handling is required. The DNS records must be updated to reflect the new cluster. Failure to update DNS settings can cause routing issues and service downtime.
 
-- Automated deployment tools
+- Automated deployment tools::
   If the platform is managed by an automated deployment tool such as `ArgoCD`, migration must be coordinated with GitOps workflows. Changes to cluster configuration must be reflected in the repository before deployment. Skipping this step can lead to drift between the declared and actual state of the platform.
 
-- Virtual cluster dependencies
+- Virtual cluster dependencies::
   If the platform has virtual cluster instances running on the same Kubernetes host cluster, these instances do not migrate automatically. They require a separate migration process after the platform has been moved. Migrating only the platform without considering virtual clusters can cause service disruptions and dependency issues.
 
-- Virtual cluster agent on the destination cluster
+- Virtual cluster agent on the destination cluster::
   If the destination Kubernetes cluster has a virtual cluster agent, it must be decommissioned before migration. The agent can interfere with the new platform installation, potentially leading to scheduling conflicts and unexpected behavior.
 
 Not addressing these considerations before migration can lead to DNS misconfigurations, deployment failures, and conflicts with existing workloads.
@@ -63,16 +63,15 @@ Not addressing these considerations before migration can lead to DNS misconfigur
 
 ### Install the platform in the new cluster {#install-platform-new-cluster}
 <Step>
-Configuration
+Configuration::
 
-- Use the Helm values from the original installation, making adjustments to values like `ingressClass` or `storageClass` as necessary
-- If your project namespaces have the "loft-p-" prefix, set `projectNamespacePrefix: loft-p-` in your configuration
+- Use the Helm values from the original installation, making adjustments to values like `ingressClass` or `storageClass` as necessary.
+- If your project namespaces use the `loft-p-` prefix, set `projectNamespacePrefix: loft-p-` in your configuration.
 </Step>
 
 <Step>
-Installation
 
-Install the platform in the new cluster following the [quick start guide](/platform/install/quick-start-guide).
+Install the platform in the new cluster by following the [quick start guide](/platform/install/quick-start-guide).
 
 :::info Using a temporary hostname during installation
 When using cloud-managed ingress, use a temporary hostname to prevent conflicts with the running platform instance.
@@ -82,15 +81,15 @@ When using cloud-managed ingress, use a temporary hostname to prevent conflicts 
 ### Prepare for migration {#prepare-for-migration}
 
 <Step>
-Send downtime communication to end users
+Send downtime communication to end users.
 </Step>
 
 <Step>
-Optional: stop `ArgoCD` sync of any virtual clusters
+Optional: Stop `ArgoCD` sync of any virtual clusters.
 </Step>
 
 <Step>
-[Perform a backup of the source platform](/platform/administer/backup-restore/backup-restore-platform)
+[Perform a backup of the source platform](/platform/administer/backup-restore/backup-restore-platform).
 </Step>
 
 ### Execute migration {#execute-migration}
@@ -104,7 +103,7 @@ kubectl scale deployment loft --replicas=0 -n vcluster-platform
 </Step>
 
 <Step>
-[Restore the backup to the new installation](/platform/administer/backup-restore/backup-restore-platform#restoring-vcluster-platform-from-backup)
+[Restore the backup to the new installation](/platform/administer/backup-restore/backup-restore-platform#restoring-vcluster-platform-from-backup).
 </Step>
 
 <Step>
@@ -139,13 +138,13 @@ kubectl scale deployment loft --replicas=1 -n vcluster-platform
 
 </Step>
 <Step>
-Update the hostname in the platform configuration as described in the [configuration guide](/platform/configure/config#changing-the-lofthost-variable)
+Update the hostname in the platform configuration as described in the [configuration guide](/platform/configure/config#changing-the-lofthost-variable).
 </Step>
 <Step>
-Update the DNS record to point to the new cluster if needed
+Update the DNS record to point to the new cluster, if needed.
 </Step>
 <Step>
-If the original cluster is going to be used as a connected cluster: connect it to the new platform installation
+When using the original cluster as a connected cluster, connect it to the new platform installation.
 </Step>
 
 </Flow>
@@ -154,14 +153,14 @@ If the original cluster is going to be used as a connected cluster: connect it t
 <Flow id="post-migration validation">
 <Step>
 Log in to the platform UI and verify object presence:
-   - Check for all expected projects
-   - Verify user access and permissions
-   - Confirm virtual cluster listings
+   - Check for all expected projects.
+   - Verify user access and permissions.
+   - Confirm virtual cluster listings.
 </Step>
 <Step>
 Verify license status in the platform UI:
-   - Navigate to Settings → License
-   - Confirm license is active and correct
+   - Navigate to **Settings** → **License**.
+   - Confirm license is active and correct.
 </Step>
 <Step>
 Restart platform agents on connected clusters:
@@ -172,15 +171,15 @@ kubectl rollout restart deployment loft -n vcluster-platform
 </Step>
 <Step>
 Validate the core capabilities of the platform:
-   - Single Sign-on: test login with all configured providers
-   - Log access: verify log retrieval from multiple virtual clusters
-   - Virtual cluster creation: create a test cluster
-   - Sleep mode: test sleep/wake feature
+  - Single sign-on: Test logging in with all configured providers.
+  - Log access: Verify log retrieval from multiple virtual clusters.
+  - Virtual cluster creation: Create a test cluster.
+  - Sleep mode: Test the sleep/wake feature.
 </Step>
 <Step>
-Optional: restart `ArgoCD` sync if previously stopped
+Optional: Restart `ArgoCD` sync if previously stopped.
 </Step>
 <Step>
-Send end-of-downtime communication to end users
+Send end-of-downtime communication to end users.
 </Step>
 </Flow>

--- a/platform/administer/upgrade-migrate/migrate-to-hostcluster.mdx
+++ b/platform/administer/upgrade-migrate/migrate-to-hostcluster.mdx
@@ -10,58 +10,58 @@ import BasePrerequisites from '../../_partials/install/base-prerequisites.mdx';
 
 This guide explains how to migrate the platform to a different Kubernetes cluster, which may be necessary during cluster decommissioning or cloud platform migration.
 
-## When to migrate
+## When to migrate {#when-to-migrate}
 
-Migrating a platform to a new Kubernetes cluster is necessary in certain cases, such as infrastructure upgrades, cluster decommissioning, or scaling needs. Migrate the platform in the following situations :
+Migrating the platform to a new Kubernetes cluster is necessary in certain cases, such as infrastructure upgrades, cluster decommissioning, or scaling needs. Migrate the platform in the following situations:
 
 - The existing cluster is being decommissioned. The platform must move to a new cluster.
 
 - The platform is migrating to a new cluster. The original cluster is going to be cleaned up.
 
-- The platform is migrating to a new cluster. The original cluster is going to be remain connected.
+- The platform is migrating to a new cluster. The original cluster is going to remain connected.
 
 
-### Migration considerations
+### Migration considerations {#migration-considerations}
 
 :::warning
-IMPORTANT: the platform must run on a dedicated Kubernetes cluster. It must have its own ingress and DNS record before migration. Ensure these conditions are met before proceeding.
+The platform must run on a dedicated Kubernetes cluster. It must have its own external access (via ingress or LoadBalancer) and DNS record before migration. Ensure these conditions are met before proceeding.
 :::
 
 Review the following factors before migrating. These scenarios require a different migration approach.
 
-- **Loft router configurations**
+- Loft router configurations
   If the platform uses the Loft router (`<something.loft.host>`), special DNS handling is required. The DNS records must be updated to reflect the new cluster. Failure to update DNS settings can cause routing issues and service downtime.
 
-- **Automated deployment tools**
+- Automated deployment tools
   If the platform is managed by an automated deployment tool such as `ArgoCD`, migration must be coordinated with GitOps workflows. Changes to cluster configuration must be reflected in the repository before deployment. Skipping this step can lead to drift between the declared and actual state of the platform.
 
-- **Virtual cluster dependencies**
+- Virtual cluster dependencies
   If the platform has virtual cluster instances running on the same Kubernetes host cluster, these instances do not migrate automatically. They require a separate migration process after the platform has been moved. Migrating only the platform without considering virtual clusters can cause service disruptions and dependency issues.
 
-- **Virtual cluster agent on the destination cluster**
+- Virtual cluster agent on the destination cluster
   If the destination Kubernetes cluster has a virtual cluster agent, it must be decommissioned before migration. The agent can interfere with the new platform installation, potentially leading to scheduling conflicts and unexpected behavior.
 
 Not addressing these considerations before migration can lead to DNS misconfigurations, deployment failures, and conflicts with existing workloads.
 
-## Prerequisites
+## Prerequisites {#prerequisites}
 
-### Base prerequisites
+### Base prerequisites {#base-prerequisites}
 
 <BasePrerequisites />
 
-### Platform specific prerequisites
+### Platform specific prerequisites {#platform-specific-prerequisites}
 
 - Storage space for backup (approximately 1GB).
-- Access to DNS management for the platform's domain
+- Access to DNS management for the platform's domain.
 - Only one platform instance can exist per Kubernetes cluster. Do not install the platform twice in the same Kubernetes host cluster.
 - The migration process requires 15-30 minutes of downtime. Communicate this downtime to end users.
 - The source and destination installations must use the same platform version. Version changes during migration are not supported.
 
-## Migration steps
+## Migration steps {#migration-steps}
 
 <Flow id="migration procedure">
 
-### Install the platform in the new cluster
+### Install the platform in the new cluster {#install-platform-new-cluster}
 <Step>
 Configuration
 
@@ -74,12 +74,12 @@ Installation
 
 Install the platform in the new cluster following the [quick start guide](/platform/install/quick-start-guide).
 
-:::info Avoid DNS conflicts
+:::info Using a temporary hostname during installation
 When using cloud-managed ingress, use a temporary hostname to prevent conflicts with the running platform instance.
 :::
 </Step>
 
-### Prepare for migration
+### Prepare for migration {#prepare-for-migration}
 
 <Step>
 Send downtime communication to end users
@@ -93,7 +93,7 @@ Optional: stop `ArgoCD` sync of any virtual clusters
 [Perform a backup of the source platform](/platform/administer/backup-restore/backup-restore-platform)
 </Step>
 
-### Execute migration
+### Execute migration {#execute-migration}
 
 <Step>
 Scale down the source platform:
@@ -104,41 +104,42 @@ kubectl scale deployment loft --replicas=0 -n vcluster-platform
 </Step>
 
 <Step>
-[Restore the backup to the new installation](https://www.vcluster.com/docs/platform/administer/backup-restore/backup-restore-platform#restoring-vcluster-platform-from-backup)
+[Restore the backup to the new installation](/platform/administer/backup-restore/backup-restore-platform#restoring-vcluster-platform-from-backup)
 </Step>
 
 <Step>
 Apply the license certificate to the new cluster:
 
-  ```bash title="Apply license certificate"
-  TARGET_NAMESPACE='vcluster-platform'
-  CA_CERT=$(kubectl get secret loft-cert -n vcluster-platform -o jsonpath="{.data.ca\.crt}")
-  TLS_CERT=$(kubectl get secret loft-cert -n vcluster-platform -o jsonpath="{.data.tls\.crt}")
-  PRIVATE_KEY=$(kubectl get secret loft-cert -n vcluster-platform -o jsonpath="{.data.tls\.key}")
+```bash title="Capture certificate data from the source cluster"
+TARGET_NAMESPACE='vcluster-platform'
+CA_CERT=$(kubectl get secret loft-cert -n vcluster-platform -o jsonpath="{.data.ca\.crt}")
+TLS_CERT=$(kubectl get secret loft-cert -n vcluster-platform -o jsonpath="{.data.tls\.crt}")
+PRIVATE_KEY=$(kubectl get secret loft-cert -n vcluster-platform -o jsonpath="{.data.tls\.key}")
 
-  cat <<EOF > loft-cert-clean.yaml
-  apiVersion: v1
-  kind: Secret
-  metadata:
-    name: loft-cert
-    namespace: ${TARGET_NAMESPACE}
-  type: kubernetes.io/tls
-  data:
-    ca.crt: ${CA_CERT}
-    tls.crt: ${TLS_CERT}
-    tls.key: ${PRIVATE_KEY}
-  EOF
-  ```
+cat <<EOF > loft-cert-clean.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: loft-cert
+  namespace: ${TARGET_NAMESPACE}
+type: kubernetes.io/tls
+data:
+  ca.crt: ${CA_CERT}
+  tls.crt: ${TLS_CERT}
+  tls.key: ${PRIVATE_KEY}
+EOF
+```
 
-  ```bash title="Apply license certificate"
-  kubectl scale deployment loft --replicas=0 -n vcluster-platform
-  kubectl delete secret loft-cert -n ${TARGET_NAMESPACE} --ignore-not-found
-  kubectl create -f loft-cert-clean.yaml
-  ```
+```bash title="Apply certificate to the target cluster"
+kubectl scale deployment loft --replicas=0 -n vcluster-platform
+kubectl delete secret loft-cert -n ${TARGET_NAMESPACE} --ignore-not-found
+kubectl create -f loft-cert-clean.yaml
+kubectl scale deployment loft --replicas=1 -n vcluster-platform
+```
 
 </Step>
 <Step>
-Update the hostname in the platform configuration as described in the [configuration guide](https://www.vcluster.com/docs/platform/configure/config#changing-the-lofthost-variable)
+Update the hostname in the platform configuration as described in the [configuration guide](/platform/configure/config#changing-the-lofthost-variable)
 </Step>
 <Step>
 Update the DNS record to point to the new cluster if needed
@@ -149,7 +150,7 @@ If the original cluster is going to be used as a connected cluster: connect it t
 
 </Flow>
 
-## Post-migration validation
+## Post-migration validation {#post-migration-validation}
 <Flow id="post-migration validation">
 <Step>
 Log in to the platform UI and verify object presence:
@@ -165,9 +166,9 @@ Verify license status in the platform UI:
 <Step>
 Restart platform agents on connected clusters:
 
-  ```bash title="Restart platform agents"
-  kubectl rollout restart deployment loft -n vcluster-platform
-  ```
+```bash title="Restart platform agent"
+kubectl rollout restart deployment loft -n vcluster-platform
+```
 </Step>
 <Step>
 Validate the core capabilities of the platform:


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Add explicit instruction to scale up platform deployment after certificate application
- Clarify that platform external access can be via either `ingress` or `LoadBalancer`
- Fix inconsistency between migration and domain configuration documentation
- Improve migration process workflow to prevent extended downtime


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Migrate the platform to a different cluster](https://deploy-preview-579--vcluster-docs-site.netlify.app/docs/platform/administer/upgrade-migrate/migrate-to-hostcluster)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-536

