### PR TITLE
fix: reference correct version in ESO example

### DIFF
--- a/vcluster/_fragments/eso.mdx
+++ b/vcluster/_fragments/eso.mdx
@@ -6,13 +6,13 @@ import ProAdmonition from '../_partials/admonitions/pro-admonition.mdx'
 <ProAdmonition/>
 
 ### Prerequisites
-This guide assumes you have the following prerequisites:
+
 - `kubectl` installed
 - `external-secrets` operator installed on your host cluster. See instructions at https://external-secrets.io/latest/
 
-# External Secrets integration
+# External secrets integration
 
-To enable the external secret integration, set the following fields as shown below:
+To enable the external secret integration, set the following fields:
 
 ```yaml
 integrations:
@@ -27,9 +27,9 @@ integrations:
         enabled: true
 ```
 
-This will enable the integration, import cluster stores from the host cluster into the virtual cluster and export namespaced stores from the virtual cluster into the host cluster.
+This enables the integration, imports cluster stores from the host cluster into the virtual cluster, and exports namespaced stores from the virtual cluster into the host cluster.
 
-Once that the virtual cluster is up and running, you can create a secret store inside the virtual cluster. For the purpose of this guide, we will use the `fake` store type, which prefills data instead of connecting to a distant secret store.
+Once the virtual cluster is up and running, you can create a secret store inside the virtual cluster. For this guide, you use the `fake` store type, which prefills data instead of connecting to a distant secret store.
 
 ```yaml
 apiVersion: external-secrets.io/v1beta1
@@ -51,7 +51,7 @@ spec:
         version: "v1"
 ```
 
-Inside the virtual cluster, create the store with `kubectl apply -f fake.yaml`. This should create a corresponding store in the host cluster. You can then create an ExternalSecret in the virtual cluster, which references the SecretStore.
+Inside the virtual cluster, create the store with `kubectl apply -f fake.yaml`. This should create a corresponding store in the host cluster. You can then create an `ExternalSecret` in the virtual cluster, which references the `SecretStore`.
 
 ```yaml
 apiVersion: external-secrets.io/v1beta1
@@ -76,8 +76,6 @@ spec:
       version: v1
 ```
 
-Once that external secret is created in the virtual cluster, the integration will take care or creating a corresponding external secret inside the host cluster,
-the external secret operator running in the host will take care of creating the corresponding Kubernetes secret, and the integration will import this
-Kubernetes secret into the virtual cluster. Running `kubectl get secrets` in the virtual cluster should now include the `secret-to-be-created` in its output.
-
-
+After the external secret is created in the virtual cluster, the integration creates a corresponding external secret inside the host cluster.
+The external secret operator running in the host creates the corresponding Kubernetes secret, and the integration imports this
+Kubernetes secret into the virtual cluster. Running `kubectl get secrets` in the virtual cluster includes the `secret-to-be-created` in its output.

--- a/vcluster/_fragments/eso.mdx
+++ b/vcluster/_fragments/eso.mdx
@@ -73,7 +73,7 @@ spec:
   dataFrom:
   - extract:
       key: /foo/baz
-      version: v1beta1
+      version: v1
 ```
 
 Once that external secret is created in the virtual cluster, the integration will take care or creating a corresponding external secret inside the host cluster,


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
The ESO example was referencing a wrong version number.


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
part of ENG-6173

