### PR TITLE
fix: updates to vale rules

### DIFF
--- a/.github/styles/Google/Colons.yml
+++ b/.github/styles/Google/Colons.yml
@@ -2,7 +2,7 @@ extends: existence
 message: "'%s' should be in lowercase."
 link: 'https://developers.google.com/style/colons'
 nonword: true
-level: warning
+level: suggestion
 scope: sentence
 tokens:
   - ':\s[A-Z]'

--- a/.github/styles/config/vocabularies/Loft/accept.txt
+++ b/.github/styles/config/vocabularies/Loft/accept.txt
@@ -1,16 +1,43 @@
-CLI
-admin
-OAuth2
-[aA]pplication
-ArgoCD
-vCluster Open Source
-vCluster Pro
-HostPath Mapper
-Pro
-AWS
-[Ee][Kk][Ss]
-GKE
-GCP
-AKS
-CRD
-DevSpace
+AKS  
+admin  
+ArgoCD  
+AWS  
+[aA]pplication  
+CLI  
+ClusterRole  
+ClusterRoleBinding  
+ConfigMap  
+CRD  
+CronJob  
+CustomResourceDefinition  
+DaemonSet  
+Deployment  
+DevSpace  
+[Ee][Kk][Ss]  
+GCP  
+GKE  
+HostPath Mapper  
+HorizontalPodAutoscaler  
+Ingress  
+Job  
+LimitRange  
+Namespace  
+NetworkPolicy  
+Node  
+OAuth2  
+PersistentVolume  
+PersistentVolumeClaim  
+Pod  
+PodDisruptionBudget  
+Pro  
+ReplicaSet  
+ResourceQuota  
+Role  
+RoleBinding  
+Secret  
+Service  
+ServiceAccount  
+StatefulSet  
+vCluster Open Source  
+vCluster Pro  
+VolumeAttachment


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

- Google does allow capitalization after a colon if it's a full sentence. The colon rule assumes that capitalization is always wrong — which is not correct per Google or Microsoft's guide.
-  Add more acceptable words to list and alphabetize list


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

