### PR TITLE
fix: update eso partials and adjust partials generate script

### DIFF
--- a/hack/vcluster/partials/main.go
+++ b/hack/vcluster/partials/main.go
@@ -105,8 +105,8 @@ func main() {
 
 	util.DefaultRequire = false
 	versionDir := os.Args[1]
-	jsonSchemaPath := filepath.Join(versionDir, "vcluster.schema.json")
-	defaultValues := filepath.Join(versionDir, "default_values.yaml")
+	jsonSchemaPath := filepath.Join(versionDir, "values.schema.json")
+	defaultValues := filepath.Join(versionDir, "values.yaml")
 	values, err := os.ReadFile(defaultValues)
 	if err != nil {
 		panic(fmt.Errorf("failed to read default values from %q: %w", defaultValues, err))

--- a/vcluster/_fragments/eso.mdx
+++ b/vcluster/_fragments/eso.mdx
@@ -12,7 +12,7 @@ import ProAdmonition from '../_partials/admonitions/pro-admonition.mdx'
 
 # External secrets integration
 
-To enable the external secret integration, set the following fields:
+To enable the External Secret integration, set the following fields:
 
 ```yaml
 integrations:
@@ -27,9 +27,10 @@ integrations:
         enabled: true
 ```
 
-This enables the integration, imports cluster stores from the host cluster into the virtual cluster, and exports namespaced stores from the virtual cluster into the host cluster.
+This enables the integration, imports `ClusterSecretStores` from the host cluster into the virtual cluster, and exports namespaced `SecretStores` from the virtual cluster into the host cluster.
+**NOTE**: After `SecretStores` have been exported, any changes to them in the host cluster are also reflected into the virtual cluster and vice versa.
 
-Once the virtual cluster is up and running, you can create a secret store inside the virtual cluster. For this guide, you use the `fake` store type, which prefills data instead of connecting to a distant secret store.
+Once the virtual cluster is up and running, you can create a `SecretStore` inside the virtual cluster. For this guide, you use the `fake` store type, which prefills data instead of connecting to a remote one.
 
 ```yaml
 apiVersion: external-secrets.io/v1beta1
@@ -76,6 +77,6 @@ spec:
       version: v1
 ```
 
-After the external secret is created in the virtual cluster, the integration creates a corresponding external secret inside the host cluster.
-The external secret operator running in the host creates the corresponding Kubernetes secret, and the integration imports this
-Kubernetes secret into the virtual cluster. Running `kubectl get secrets` in the virtual cluster includes the `secret-to-be-created` in its output.
+After the `ExternalSecret` is created in the virtual cluster, the integration creates a corresponding `ExternalSecret` inside the host cluster.
+The External Secret Operator running in the host cluster creates the corresponding Kubernetes Secret, and the integration imports this
+Secret into the virtual cluster. Running `kubectl get secrets` in the virtual cluster includes the `secret-to-be-created` in its output.

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/integrations.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/integrations.mdx
@@ -481,7 +481,10 @@ Enabled defines if this option should be enabled.
 
 ### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets}
 
-ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster
+ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster.
+- ExternalSecrets will be synced from the virtual cluster to the host cluster.
+- SecretStores will be synced bi-directionally after an initial sync from the virtual cluster to the host cluster.
+- ClusterSecretStores will be synced from the host cluster to the virtual cluster.
 
 </summary>
 
@@ -550,7 +553,7 @@ Sync defines the syncing behavior for the integration
 
 ##### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-externalSecrets}
 
-ExternalSecrets defines whether to sync external secrets or not
+ExternalSecrets defines if external secrets should get synced from the virtual cluster to the host cluster.
 
 </summary>
 
@@ -580,7 +583,7 @@ Enabled defines if this option should be enabled.
 
 ##### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-stores}
 
-Stores defines whether to sync stores or not
+Stores defines if secret stores should get synced bi-directionally after an initial sync from the virtual cluster to the host cluster.
 
 </summary>
 
@@ -610,7 +613,7 @@ Enabled defines if this option should be enabled.
 
 ##### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-clusterStores}
 
-ClusterStores defines whether to sync cluster stores or not
+ClusterStores defines if cluster secrets stores should get synced from the host cluster to the virtual cluster.
 
 </summary>
 

--- a/vcluster_versioned_docs/version-0.24.0/_partials/config/integrations/externalSecrets.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/config/integrations/externalSecrets.mdx
@@ -4,7 +4,10 @@
 
 ## `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets}
 
-ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster
+ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster.
+- ExternalSecrets will be synced from the virtual cluster to the host cluster.
+- SecretStores will be synced bi-directionally after an initial sync from the virtual cluster to the host cluster.
+- ClusterSecretStores will be synced from the host cluster to the virtual cluster.
 
 </summary>
 
@@ -73,7 +76,7 @@ Sync defines the syncing behavior for the integration
 
 #### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-externalSecrets}
 
-ExternalSecrets defines whether to sync external secrets or not
+ExternalSecrets defines if external secrets should get synced from the virtual cluster to the host cluster.
 
 </summary>
 
@@ -103,7 +106,7 @@ Enabled defines if this option should be enabled.
 
 #### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-stores}
 
-Stores defines whether to sync stores or not
+Stores defines if secret stores should get synced bi-directionally after an initial sync from the virtual cluster to the host cluster.
 
 </summary>
 
@@ -133,7 +136,7 @@ Enabled defines if this option should be enabled.
 
 #### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-clusterStores}
 
-ClusterStores defines whether to sync cluster stores or not
+ClusterStores defines if cluster secrets stores should get synced from the host cluster to the virtual cluster.
 
 </summary>
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Copies over the adjusted ESO comments and adjusts the partials script to use the correct files.
**NOTE**: Should be merged after the ESO comments have been merged in [vcluster](https://github.com/loft-sh/vcluster/pull/2637) and [backported to 0.24](https://github.com/loft-sh/vcluster/pull/2645). Therefore, this PR is in draft.


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Part of ENG-6173

