### PR TITLE
chore(ci): update vale rules to include platform versioned docs

### DIFF
--- a/.github/workflows/reviewdog.yaml
+++ b/.github/workflows/reviewdog.yaml
@@ -11,6 +11,8 @@ on:
       - "vcluster/**/*.md"
       - "vcluster_versioned_docs/**/*.mdx"
       - "vcluster_versioned_docs/**/*.md"
+      - "platform_versioned_docs/**/*.mdx"
+      - "platform_versioned_docs/**/*.md"
       - .github/workflows/reviewdog.yaml
       - "*.md"
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
N/A

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-552

