### PR TITLE
feat: document the current procedure for offline helm charts

### DIFF
--- a/platform/_partials/vcluster/air-gapped-helm-charts.mdx
+++ b/platform/_partials/vcluster/air-gapped-helm-charts.mdx
@@ -2,7 +2,7 @@
 The platform uses Helm to manage virtual clusters. If your cluster is running in an air-gapped environment, you may host
 Helm charts in an OCI compatible private registry. To use a private registry for virtual clusters there are several
 configuration options:
-- Configure the platform for [Offline Helm Charts](../../../install/advanced/air-gapped#offline-helm-charts)
+- Configure the platform for [offline Helm charts](../../../install/advanced/air-gapped#offline-helm-charts)
 - Configure the Helm chart repository and authentication for each [virtual cluster](../../../../api/resources/virtualclusterinstance).
 - Configure the Helm chart repository and authentication using [virtual cluster templates](../../../../api/resources/virtualclustertemplate).
 :::

--- a/platform/_partials/vcluster/air-gapped-helm-charts.mdx
+++ b/platform/_partials/vcluster/air-gapped-helm-charts.mdx
@@ -1,0 +1,8 @@
+:::tip
+The platform uses Helm to manage virtual clusters. If your cluster is running in an air-gapped environment, you may host
+Helm charts in an OCI compatible private registry. To use a private registry for virtual clusters there are several
+configuration options:
+- Configure the platform for [Offline Helm Charts](../../../install/advanced/air-gapped#offline-helm-charts)
+- Configure the Helm chart repository and authentication for each [virtual cluster](../../../../api/resources/virtualclusterinstance).
+- Configure the Helm chart repository and authentication using [virtual cluster templates](../../../../api/resources/virtualclustertemplate).
+:::

--- a/platform/install/advanced/air-gapped.mdx
+++ b/platform/install/advanced/air-gapped.mdx
@@ -27,6 +27,9 @@ To address image pulling issues from Docker Hub, you can [use a private image
 registry](#offline-images) to host your own copies of the platform images
 accessible to your cluster.
 
+To address pulling Helm charts from external chart registries, you can use an [OCI compatible private image registry](#offline-helm-charts) to
+host Helm charts.
+
 ## Prerequisites
 
 <BasePrerequisites />
@@ -57,7 +60,7 @@ Although the platform might work with other versions, using the supported versio
   - Limits
     - memory: `4Gi`
     - cpu: `2`
-  
+
 <NetworkPorts />
 
 
@@ -141,6 +144,86 @@ If your `REGISTRY` is set to `ecr.io/myteam`, a fully formed registry path might
 
 </Flow>
 
+### Offline Helm charts
+
+For clusters unable to pull Helm charts from external chart repositories, it is recommended to use an OCI compatible
+private image registry to host the required Helm charts.
+
+Follow these instructions to configure the platform and import the required Helm charts to your private registry:
+
+<Flow id="offline-charts">
+<Step>
+Set your private registry as a variable:
+
+```bash title="Set private OCI registry"
+CHART_REGISTRY=oci://ecr.io/myteam/charts      # The OCI prefix is required for Helm
+```
+</Step>
+
+<Step>
+Make a list of Helm Charts to be used in the platform. Be sure to include:
+- Helm Charts for each vCluster to be used when creating virtual clusters
+[manually](../../use-platform/virtual-clusters/create/create-no-template) or with a [template](../../use-platform/virtual-clusters/create/create-with-template).
+- Helm Charts to be used with [Apps](../../understand/what-are-apps)
+- Helm Charts to be used in virtual cluster `experimental.deploy.vcluster.helm` [configuration](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster)
+:::note
+Each platform version comes with support for a default vCluster version. Using this version works without the need
+import the vCluster Helm chart. However, it is recommended to import this version so that it is available after a
+platform upgrade.
+:::
+</Step>
+
+<Step>
+Run the follow command to pull each required Helm chart as a local `*.tgz` file. The `vcluster` chart is shown as an example:
+
+```bash title="Pull the vcluster Helm chart"
+helm pull vcluster --repo https://charts.loft.sh --version ${VERSION} # Replace ${VERSION}
+```
+</Step>
+
+<Step>
+Run the follow command to push each Helm chart's `*.tgz` file to your OCI registry. The `vcluster` chart is shown as an example:
+
+```bash title="Push the vcluster Helm chart to private registry"
+helm push vcluster-${VERSION}.tgz ${CHART_REGISTRY} # Replace ${VERSION}
+```
+</Step>
+
+<Step>
+To configure the platform to use your private registry as the default Helm repository when creating virtual clusters, edit your existing
+`vcluster-platform.yaml` file or create a new one with the following content:
+```yaml title="vcluster-platform.yaml"
+env:
+  DEFAULT_VCLUSTER_CHART_REPO: ${CHART_REGISTRY} # Replace ${CHART_REGISTRY}
+```
+</Step>
+
+<Step>
+If your OCI registry requires authentication, the platform can be configured to use an image pull
+secret for authenticating the `helm` command. Add this to your `vcluster-platform.yaml`:
+```yaml title="vcluster-platform.yaml"
+volumes:
+  - name: helm-pull-secret
+    secret:
+      secretName: ${IMAGE_PULL_SECRET} # Replace with the name of your image pull secret
+volumeMounts:
+  - name: helm-pull-secret
+    mountPath: /loft/helm
+    readOnly: true
+env:
+  HELM_REGISTRY_CONFIG: /loft/helm/.dockerconfigjson
+```
+
+:::warning
+This only configures the platform authentication for managing virtual clusters with Helm.
+- See [App Reference](../../api/resources/apps#app-reference) to configure the chart [repository URL](../../api/resources/apps#spec-config-chart-repoURL) with [username](../../api/resources/apps#spec-config-chart-usernameRef) and [password](../../api/resources/apps#spec-config-chart-passwordRef) authentication.
+- See `experimental.deploy.vcluster.helm` [configuration](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster) to configure [repository](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster-helm-chart-repo) with [username](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster-helm-chart-username) and [password](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster-helm-chart-password) authentication.
+:::
+</Step>
+
+<Step><PartialAdminUpgrade/>
+</Step>
+</Flow>
 
 ## Configuration
 

--- a/platform/install/advanced/air-gapped.mdx
+++ b/platform/install/advanced/air-gapped.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploy in Air-Gapped Environments
+title: Deploy in air-gapped environments
 sidebar_label: Using Air-Gapped Installation
 sidebar_position: 1
 description: Learn how to install vCluster platform in air-gapped, offline, or VPC environments with restricted network connectivity.
@@ -162,15 +162,15 @@ CHART_REGISTRY=oci://ecr.io/myteam/charts      # The OCI prefix is required for 
 
 <Step>
 Make a list of Helm Charts to be used in the platform. Be sure to include:
-- Helm Charts for each vCluster to be used when creating virtual clusters
+- Helm charts for each vCluster to be used when creating virtual clusters
 [manually](../../use-platform/virtual-clusters/create/create-no-template) or with a [template](../../use-platform/virtual-clusters/create/create-with-template).
-- Helm Charts to be used with [Apps](../../understand/what-are-apps)
-- Helm Charts to be used in virtual cluster `experimental.deploy.vcluster.helm` [configuration](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster)
+- Helm charts to be used with [apps](../../understand/what-are-apps)
+- Helm charts to be used in virtual cluster `experimental.deploy.vcluster.helm` [configuration](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster)
+
 :::note
-Each platform version comes with support for a default vCluster version. Using this version works without the need
-import the vCluster Helm chart. However, it is recommended to import this version so that it is available after a
-platform upgrade.
+Each platform version supports a default vCluster version that works immediately. While you can use this default version, we recommend importing the vCluster Helm chart to ensure compatibility after platform upgrades.
 :::
+
 </Step>
 
 <Step>
@@ -247,5 +247,7 @@ Apply this configuration during the initial installation process or when upgradi
 <LoginAfterHelmInstall />
 
 ## Next steps
+
 ### Create virtual clusters
+
 <InstallNextSteps />

--- a/platform/install/advanced/air-gapped.mdx
+++ b/platform/install/advanced/air-gapped.mdx
@@ -151,6 +151,7 @@ private image registry to host the required Helm charts.
 
 Follow these instructions to configure the platform and import the required Helm charts to your private registry:
 
+<!--vale off-->
 <Flow id="offline-charts">
 <Step>
 Set your private registry as a variable:
@@ -224,6 +225,8 @@ This only configures the platform authentication for managing virtual clusters w
 <Step><PartialAdminUpgrade/>
 </Step>
 </Flow>
+
+<!--vale on-->
 
 ## Configuration
 

--- a/platform/use-platform/troubleshooting/troubleshooting.mdx
+++ b/platform/use-platform/troubleshooting/troubleshooting.mdx
@@ -4,10 +4,6 @@ sidebar_label: Troubleshooting
 sidebar_position: 99
 ---
 
-import Flow, { Step } from "@site/src/components/Flow";
-import PartialAdminSetVersion from "../../_partials/install/set-version.mdx";
-import PartialAdminUpgrade from "../../_partials/install/upgrade.mdx";
-
 While we hope you don't run into any issues while deploying vCluster Platform, it sometimes happens. This
 page contains some information that may help you resolve deployment issues. If you're still
 stuck, please join us on [Slack](https://slack.loft.sh/) where you can find a #vcluster channel

--- a/platform/use-platform/virtual-clusters/create/create-no-template.mdx
+++ b/platform/use-platform/virtual-clusters/create/create-no-template.mdx
@@ -11,6 +11,7 @@ import PartialVirtualClusterCreateUI from "../../../_partials/vcluster/create-ui
 import PartialVirtualClusterCreateCLI from "../../../_partials/vcluster/create-cli.mdx";
 import PartialVirtualClusterCreateUINoTemplate from "../../../_partials/vcluster/create-ui-no-template.mdx";
 import PartialVirtualClusterCreateYamlNoTemplate from "../../../_partials/vcluster/create-yaml-no-template.mdx";
+import PartialVirtualClusterAirGapped from "../../../_partials/vcluster/air-gapped-helm-charts.mdx";
 
 Each virtual cluster that is created in the platform belongs to a [project](../../../understand/what-are-projects.mdx). There are two primary ways which
 virtual clusters can be created: from a template or manually.
@@ -41,4 +42,4 @@ Only project admins or platform admins can create a virtual cluster without a te
   </TabItem>
 </Tabs>
 
-
+<PartialVirtualClusterAirGapped />

--- a/platform/use-platform/virtual-clusters/create/create-with-template.mdx
+++ b/platform/use-platform/virtual-clusters/create/create-with-template.mdx
@@ -8,6 +8,7 @@ import TabItem from "@theme/TabItem";
 
 import PartialVirtualClusterCreateUI from "../../../_partials/vcluster/create-ui.mdx";
 import PartialVirtualClusterCreateCLI from "../../../_partials/vcluster/create-cli.mdx";
+import PartialVirtualClusterAirGapped from "../../../_partials/vcluster/air-gapped-helm-charts.mdx";
 
 Each virtual cluster that is created in the platform belongs to a [project](../../../understand/what-are-projects.mdx). There are two primary ways which
 virtual clusters can be created: from a template or manually.
@@ -58,3 +59,5 @@ having to manually upgrade them.
 
 Note that you can even set the version to "X.X.X" to _always_ have your virtual cluster updated
 to the latest template version.
+
+<PartialVirtualClusterAirGapped />


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Originally an engineering issue, it was determined that documenting a procedure for hosting and using Helm charts in an air-gapped environment would be sufficient until more extensive improvements could be made to the platform as part of the [Standardize Air-gapped/private registry install](https://linear.app/loft/project/standardize-air-gappedprivate-registry-install-f439efbc2ef8/overview) project.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENG-6264
Closes DOC-494

