### PR TITLE
Create helm-permission-denied.mdx

### DIFF
--- a/staging/helm-permission-denied.mdx
+++ b/staging/helm-permission-denied.mdx
@@ -1,0 +1,39 @@
+---
+title: Helm permission denied
+sidebar_label: helm permission denied
+description: helm permission denied error while creating the vCluster using vCluster-platform.
+---
+
+
+Facing helm permission denied error while creating the vCluster using vCluster-platform.
+
+```
+ error installing / upgrading vcluster: error executing /usr/local/bin/helm upgrade <vcluster-release-name> <vcluster-helm-chart-repo> --version <vcluster-version> --kubeconfig <path-to-kubeconfig> --namespace <namespace> --install --values <values-file>: Release <vcluster-release-name> does not exist. Installing it now.
+    Error: mkdir /.cache: permission denied
+     (exit status 1)
+```
+
+## Reason
+
+The current user does not have permissions to create ​/.cache.
+
+• `​XDG­_CACHE­_HOME`​ is a [base directory spec](https://specifications.freedesktop.org/basedir-spec/latest/) that Helm adopted and will use it as the cache home if it is set, but still allows configuring via helm specific environment variables. If `​XDG­_CACHE­_HOME`​ is unset, it defaults to `​$HOME/.cache`​ which is `​/home/loft/.cache`​ and the loft user already has permission there. In this example environment, this directory is set to `​/.cache​` and the loft user does not have the needed file permissions.
+
+## Solution
+
+• `​HELM­_CACHE­_HOME​` can be set independently if for some reason `​XDG­_CACHE­_HOME`​ is set to `/.cache` (or something else)
+
+There are two options:
+
+• If using UID 998 when running the platform, then set `​HELM­_CACHE­_HOME`​ (or `​XDG­_CACHE­_HOME`​) to the loft home dir location `​/home/loft/.cache`​ in helm values.
+```
+env:
+  HELM­_CACHE­_HOME: /home/loft/.cache   # when using securityContext.runAsUser 998
+```
+
+• Or use UID 1000+, then set `​HELM­_CACHE­_HOME=/tmp/.cache`​ since all users have write permission to this location.
+
+```
+env:
+  HELM­_CACHE­_HOME: /tmp/.cache       # when using securityContext.runAsUser 1001
+```


### PR DESCRIPTION
helm permission denied error while creating the vCluster using vCluster-platform.

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

