### PR TITLE
Update sync-from-host-namespaced-custom-resources-example.mdx

### DIFF
--- a/vcluster/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
+++ b/vcluster/_fragments/sync-from-host-namespaced-custom-resources-example.mdx
@@ -140,7 +140,7 @@ guide](/vcluster/#deploy-vcluster).
     Check CustomResource in the virtual cluster:
 
     ```bash title="Get synced CustomResource"
-    kubectl --context="${VCLUSTER_CTX}" et examples.demo.loft.sh --namespace default
+    kubectl --context="${VCLUSTER_CTX}" get examples.demo.loft.sh --namespace default
     ```
 
     you should see similar output:


### PR DESCRIPTION
typo fixed

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

