### PR TITLE
fix(ci): ci reference needs full commit hash

### DIFF
--- a/.github/workflows/backport-docs.yml
+++ b/.github/workflows/backport-docs.yml
@@ -19,6 +19,6 @@ jobs:
       
       # Commit hash for testing
       - name: Backport Docusaurus Changes
-        uses: loft-sh/docs-backport-action@877d906
+        uses: loft-sh/docs-backport-action@877d906ca7669cf9377067da3a7346d16cbcc13f
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
N/A

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
References DOC-555

