### PR TITLE
feat(netlify): redirect vcluster 0.24 to latest version

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -60,3 +60,9 @@ command = """
 [[redirects]]
   from = "/docs/deploy/basics/*"
   to = "/docs/vcluster/deploy/basics/"
+
+[[redirects]]
+  from = "/docs/vcluster/0.24.0/*"
+  to = "/docs/vcluster/:splat"
+  status = 301
+  force = true


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-613--vcluster-docs-site.netlify.app/docs/vcluster/0.24.0/ should redirect to vcluster latest

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-568

