### PR TITLE
fix: add standard verbs

### DIFF
--- a/platform_versioned_docs/version-4.2.0/api/resources/virtualclusterinstance/virtualclusterinstance.mdx
+++ b/platform_versioned_docs/version-4.2.0/api/resources/virtualclusterinstance/virtualclusterinstance.mdx
@@ -36,6 +36,58 @@ status: {}
 
 <Reference />
 
+```markdown
+## Virtual Cluster Example
+An example Virtual Cluster:
+```yaml
+apiVersion: management.loft.sh/v1
+kind: VirtualClusterInstance
+metadata:
+  name: my-virtual-cluster
+  namespace: loft-p-my-project
+spec:
+  clusterRef: {}
+  displayName: my-display-name
+  owner:
+    user: my-user
+  parameters: 'my-parameter: my-value'
+  templateRef:
+    name: my-virtual-cluster-template
+status: {}
+```
+
+## Virtual Cluster Reference
+<Reference />
+
+### Verbs
+
+The platform supports two categories of verbs that define what actions users can perform on resources. These categories determine how permissions are granted:
+
+- **Standard verbs** map directly to Kubernetes API operations with corresponding HTTP methods.
+- **Non-standard verbs** require explicit RBAC policy assignments.
+
+The `verbs` array in the `access` object specifies which operations users and teams can perform on virtual cluster instances.
+
+<details>
+<summary>Verbs for Virtual Cluster Instances </summary>
+
+The following table lists the verbs for the `VirtualClusterInstance` resource, including their HTTP methods, descriptions, and category.
+
+| Verb       | HTTP Method   | Description    | Type         |
+|--------- --|---------------|----------------|--------------|
+| `get`      | GET           | Retrieves virtual cluster instance from UI and API                          | Standard     |
+| `list`     | GET           | Lists collections of virtual cluster instances                              | Standard     |
+| `watch`    | GET with `?watch=1` | Watches for changes to virtual cluster instances                      | Standard     |
+| `create`          | POST                | Creates new virtual cluster instances                          | Standard     |
+| `update`          | PATCH               | Updates existing virtual cluster instances from UI             | Standard     |
+| `patch`           | PATCH               | Partially modifies resources via API                           | Standard     |
+| `delete`          | DELETE              | Deletes resources from UI and API                              | Standard     |
+| `deletecollection`| DELETE with filters | Deletes resources by criteria (e.g., label selector)           | Standard     |
+| `use`             | N/A                 | Manages access to vcluster API, kubeconfig, and resources      | Non-standard |
+
+For more information, see [Kubernetes authorization documentation](https://kubernetes.io/docs/reference/access-authn-authz/authorization/).
+</details>
+
 ## Retrieve: Virtual Clusters
 
 <Retrieve />


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

- Add standard verbs outlined in [this Linear ticket](https://linear.app/loft/issue/DOC-59/platform-api-docs-do-not-document-all-of-the-api-verbs-which-makes)


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-59

