### PR TITLE
fix: add links for sleep mode

### DIFF
--- a/vcluster/manage/accessing-vcluster.mdx
+++ b/vcluster/manage/accessing-vcluster.mdx
@@ -1,5 +1,5 @@
 ---
-title: Access and expose vCluster
+title: Accessa and expose vCluster
 sidebar_label: Access and Expose
 sidebar_position: 1
 ---
@@ -11,9 +11,9 @@ import InstallCLIFragment from '../_partials/deploy/install-cli-beta.mdx'
 ## Access vCluster
 There are multiple ways how you can access a vCluster with an external application like `kubectl`.
 
-### Connect Directly using the CLI
+### Connect directly using the CLI
 
-Please make sure to install the vCluster CLI.
+Ensure you install the vCluster CLI.
 
 <InstallCLIFragment/>
 
@@ -35,18 +35,18 @@ vcluster connect my-vcluster -- kubectl get namespaces
 vcluster connect my-vcluster -- bash
 ```
 
-Depending on if the vCluster was created within a local Kubernetes cluster or with the `--expose` flag, the CLI will either start port-forwarding or create a context that can be used directly.
+Depending on if the vCluster was created within a local Kubernetes cluster or with the `--expose` flag, the CLI either starts port-forwarding or creates a context that can be used directly.
 
 If you have manually [exposed the vCluster](#expose-vcluster), you can specify the domain where the vCluster is reachable via the `--server` flag:
 
 ```
-# Will create a kube context that uses https://my-domain.org as endpoint
+# Create a kube context that uses https://my-domain.org as endpoint
 vcluster connect my-vcluster -n my-vcluster --server my-domain.org
 ```
 
-### Connect via Service Accounts
+### Connect using Service Accounts
 
-By default, vCluster will update the current kubeconfig to access the vCluster that contains the default admin client certificate and client key to authenticate to the vCluster. This means that all kubeconfig files generated will have cluster admin access within the vCluster.
+By default, vCluster updates the current kubeconfig to access the vCluster that contains the default admin client certificate and client key to authenticate to the vCluster. This means that all kubeconfig files generated have cluster admin access within the vCluster.
 
 Often this might not be desired. Instead of giving a user admin access to the virtual cluster, you can also use [service account authentication](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#service-account-tokens) to the virtual cluster. Let's say we want to create a kubeconfig file that only has view access in the virtual cluster. Then you would create a new service account inside the vCluster and assign it the cluster role `view` via a cluster role binding. Then we would generate a service account token and use that instead of the client-cert and client-key inside the kubeconfig.
 
@@ -60,7 +60,7 @@ vcluster connect my-vcluster -n my-vcluster --service-account kube-system/my-use
 vcluster connect my-vcluster -n my-vcluster --service-account kube-system/my-user --cluster-role view --token-expiration 3600
 ```
 
-This will create a kube context similar to this as well as create the needed service account and cluster role binding:
+This creates a kube context similar to this as well as create the needed service account and cluster role binding:
 ```yaml
 apiVersion: v1
 clusters:
@@ -83,12 +83,12 @@ users:
     token: eyJhbGc...
 ```
 
-As you can see the service account token is used in this kubeconfig here instead of the client-cert and client-key that is used by default. Trying to create a namespace with this config will yield:
+As you can see the service account token is used in this kubeconfig here instead of the client-cert and client-key that is used by default. Trying to create a namespace with this config yields the following:
 
 ```
 export KUBECONFIG=kubeconfig.yaml
 
-# This will work as we have view access
+# This works as we have view access
 kubectl get namespaces
 
 # This won't work
@@ -96,7 +96,7 @@ kubectl create namespace test
 Error from server (Forbidden): namespaces is forbidden: User "system:serviceaccount:kube-system:my-user" cannot create resource "namespaces" in API group "" at the cluster scope
 ```
 
-You can replace the token field in the kubeconfig with any other service account token from inside the vCluster to act as this service account against the vCluster. For more information about service accounts and tokens, please refer to the [official Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#service-account-tokens).
+You can replace the token field in the kubeconfig with any other service account token from inside the vCluster to act as this service account against the vCluster. For more information about service accounts and tokens, refer to the [official Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#service-account-tokens).
 
 ## Retrieving the kubeconfig from the vCluster secret
 
@@ -108,7 +108,7 @@ The secret is prefixed with `vc-` and ends with the vCluster name, so a vCluster
 kubectl get secret vc-my-vcluster -n test --template={{.data.config}} | base64 -D
 ```
 
-The secret will hold a kubeconfig in this format:
+The secret holds a kubeconfig in this format:
 
 ```yaml
 apiVersion: v1
@@ -142,13 +142,13 @@ kubectl port-forward my-vcluster-0 -n test 8443
 With the syncer flag `--out-kube-config-secret-namespace` you can specify a different namespace where the kubeconfig secret should be created in. Keep in mind that you have to manually apply RBAC permissions for the vCluster to allow creation and retrieving of secrets in that namespace.
 :::
 
-### Access vCluster Externally
+### Access vCluster externally
 
 If you have [exposed the vCluster](#expose-vcluster), you can also tell the vCluster to create the kubeconfig secret with another server endpoint through the `exportKubeConfig` flag.
 
 For example, if you want to expose a vCluster at `https://my-domain.org`, you can create a `vcluster.yaml` like this:
 ```yaml
-# Make sure vCluster will sign the server certs for my-domain.org
+# Make sure vCluster signs the server certs for my-domain.org
 # and use it in the generated kube config secret.
 controlPlane:
   # distro: (update distro details as per your configurations)
@@ -185,7 +185,7 @@ kubectl get secret vc-my-vcluster -n my-vcluster --template={{.data.config}} | b
 By default, vCluster is only reachable via port-forwarding in remote clusters. However, this means that you need access to the host cluster, where the vCluster is running, in order to access it. To directly access vCluster without port-forwarding, you can use one of the following methods.
 
 :::info Local Kubernetes Clusters
-If you are using a local Kubernetes cluster, such as docker-desktop, rancher-desktop, KinD or minikube, vCluster will automatically connect to it without the need of port-forwarding.
+If you are using a local Kubernetes cluster, such as docker-desktop, rancher-desktop, kind or minikube, vCluster automatically connects to it without the need of port-forwarding.
 :::
 
 <Tabs
@@ -199,13 +199,13 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
     ]}>
 <TabItem value="ingress">
 
-  An [Ingress Controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/)  with SSL passthrough support will provide the best user experience, but there is a workaround if this feature is not natively supported.
+  An [Ingress Controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) with SSL passthrough support provide the best user experience, but there is a workaround if this feature is not natively supported.
 
   - [Kubernetes Nginx](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough)
   - [Traefik Proxy](https://doc.traefik.io/traefik/routing/routers/#passthrough)
   - [Emissary](https://www.getambassador.io/docs/emissary/latest/topics/using/tcpmappings#tls-termination)
 
-  Make sure your ingress controller is installed and healthy on the cluster that will host your virtual clusters. Create the following `ingress.yaml` for a vCluster called `my-vcluster` in the namespace `my-vcluster`:
+  Make sure your ingress controller is installed and healthy on the cluster that hosts your virtual clusters. Create the following `ingress.yaml` for a vCluster called `my-vcluster` in the namespace `my-vcluster`:
 
   ```yaml
   apiVersion: networking.k8s.io/v1
@@ -215,7 +215,7 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
       # We need the ingress to pass through ssl traffic to the vCluster
       # This only works for the nginx-ingress (enable via --enable-ssl-passthrough
       # https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough )
-      # for other ingress controllers please check their respective documentation.
+      # for other ingress controllers check their respective documentation.
       nginx.ingress.kubernetes.io/backend-protocol: HTTPS
       nginx.ingress.kubernetes.io/ssl-passthrough: "true"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
@@ -242,7 +242,7 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
   ```
 
   :::info Enable SSL Passthrough Feature
-  If you are using the ingress nginx controller, please make sure you have [enabled the SSL passthrough feature](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough) as it is disabled by default.
+  If you are using the ingress nginx controller, ensure you have [enabled the SSL passthrough feature](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough) as it is disabled by default.
   :::
 
   To enable the SSL Passthrough Feature you can edit the nginx ingress deployment within the nginx namespace. The option that needs to be added is `- --enable-ssl-passthrough` under the container args within spec. It should end up looking something like:
@@ -263,8 +263,8 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
           - --enable-ssl-passthrough
   ```
 
-  :::warning SSL Passthrough required
-  In order for this ingress to work correctly, you will need to enable SSL passthrough as TLS termination has to happen at the vCluster level and not ingress controller level. If you cannot do that, please take a look below for using an ingress without ssl passthrough.
+  :::warning SSL passthrough required
+  For this ingress to work properly, enable SSL passthrough since TLS termination must occur at the vCluster level, not at the ingress controller level. If SSL passthrough is unavailable in your environment, refer to the following section for implementing ingress without SSL passthrough.
   :::
 
   Now create a `vcluster.yaml` to create the vCluster with:
@@ -280,7 +280,7 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
   vcluster create my-vcluster -n my-vcluster --connect=false -f values.yaml
   ```
 
-  Retrieve the kube config via:
+  Retrieve the kube config using:
   ```
   vcluster connect my-vcluster -n my-vcluster --print --server=https://my-vcluster.example.com > kubeconfig.yaml
   ```
@@ -323,13 +323,13 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
       - my-vcluster.example.com
   ```
 
-  With this configuration you will need to use service account authentication in order to connect as the ingress controller won't be able to resolve the client-cert and client-key which is used by default as authentication method. To create a kube config that uses a service account, please run the following command:
+  With this configuration you must use service account authentication in order to connect as the ingress controller won't be able to resolve the client-cert and client-key which is used by default as authentication method. To create a kube config that uses a service account, run the following command:
 
   ```
   vcluster connect my-vcluster -n my-vcluster --server=https://my-vcluster.example.com --service-account admin --cluster-role cluster-admin --insecure
   ```
 
-  Then access the vCluster:
+  Access the vCluster:
   ```
   # Run any kubectl command
   kubectl get ns
@@ -350,7 +350,7 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
   That's it, your vCluster is now externally reachable through a LoadBalancer service.
 
   :::warning Check the costs first
-  Even though using a LoadBalancer is the easiest option, if you use a cloud provider it will be costly to create one Loadbalancer per cluster. Check your cloud vendor about the cost of each LoadBalancer. In general using an Ingress is the most cost effective method.
+  Even though using a LoadBalancer is the easiest option, if you use a cloud provider it is costly to create one Loadbalancer per cluster. Check your cloud vendor about the cost of each LoadBalancer. In general using an Ingress is the most cost effective method.
   :::
 
 **Manual LoadBalancer service creation**
@@ -500,5 +500,3 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
   </div>
 </TabItem>
 </Tabs>
-
-

--- a/vcluster/manage/accessing-vcluster.mdx
+++ b/vcluster/manage/accessing-vcluster.mdx
@@ -1,5 +1,5 @@
 ---
-title: Accessa and expose vCluster
+title: Access and expose vCluster
 sidebar_label: Access and Expose
 sidebar_position: 1
 ---

--- a/vcluster/manage/accessing-vcluster.mdx
+++ b/vcluster/manage/accessing-vcluster.mdx
@@ -1,6 +1,6 @@
 ---
-title: Access & Expose vCluster
-sidebar_label: Access & Expose
+title: Access and expose vCluster
+sidebar_label: Access and Expose
 sidebar_position: 1
 ---
 

--- a/vcluster/manage/backup-restore.mdx
+++ b/vcluster/manage/backup-restore.mdx
@@ -1,5 +1,5 @@
 ---
-title: Snapshot and Restore
+title: Snapshot and restore
 sidebar_label: Snapshot and Restore
 sidebar_position: 3
 ---

--- a/vcluster/manage/deploy-changes.mdx
+++ b/vcluster/manage/deploy-changes.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploy Changes in Configuration Options
+title: Deploy changes in configuration options
 sidebar_label: Deploy Config Changes
 sidebar_position: 2
 ---

--- a/vcluster/manage/sleep-wakeup.mdx
+++ b/vcluster/manage/sleep-wakeup.mdx
@@ -18,7 +18,7 @@ For more details on configuring sleep mode operations in vCluster, see the [Slee
   <InstallCli />
 
 
-## Sleep a vCluster
+## Put a vCluster to sleep
 
 Put a virtual cluster to sleep with the `vCluster` CLI:
 

--- a/vcluster/manage/sleep-wakeup.mdx
+++ b/vcluster/manage/sleep-wakeup.mdx
@@ -8,7 +8,7 @@ import InstallCli from '../_partials/deploy/install-cli.mdx';
 
 The sleep mode **temporarily scales down** a virtual cluster and deletes all its created workloads on the host cluster. This approach helps **save computing resources** used by virtual cluster workloads in the host cluster. For example, sleeping development clusters during non-working hours can significantly reduce infrastructure costs. 
 
-For more details on configuring sleep mode operations in vCluster, see the [Sleep mode documentation](../../).
+For more details on configuring sleep mode operations in vCluster, see the [Sleep mode documentation](../../configure/vcluster-yaml/sleep-mode).
 
 
 ## Prerequisites
@@ -18,7 +18,7 @@ For more details on configuring sleep mode operations in vCluster, see the [Slee
   <InstallCli />
 
 
-## Sleeping a vCluster
+## Sleep a vCluster
 
 Put a virtual cluster to sleep with the `vCluster` CLI:
 
@@ -44,7 +44,7 @@ When pods are restarted:
 - Pod IP addresses change
 :::
 
-## Waking up a vCluster
+## Wake up a vCluster
 
 You can wake up a virtual cluster with two different `vCluster` CLI commands.
 

--- a/vcluster/manage/sleep-wakeup.mdx
+++ b/vcluster/manage/sleep-wakeup.mdx
@@ -1,12 +1,15 @@
 ---
-title: Sleep & Wakeup vCluster
-sidebar_label: Sleep & Wakeup
+title: Sleep and wakeup vCluster
+sidebar_label: Sleep and Wakeup
 sidebar_position: 4
 ---
 import BasePrerequisites from '@site/docs/_partials/base-prerequisites.mdx';
 import InstallCli from '../_partials/deploy/install-cli.mdx';
 
-The sleep mode **temporarily scales down** a virtual cluster and deletes all its created workloads on the host cluster. This approach helps **save computing resources** used by virtual cluster workloads in the host cluster. For example, sleeping development clusters during non-working hours can significantly reduce infrastructure costs.
+The sleep mode **temporarily scales down** a virtual cluster and deletes all its created workloads on the host cluster. This approach helps **save computing resources** used by virtual cluster workloads in the host cluster. For example, sleeping development clusters during non-working hours can significantly reduce infrastructure costs. 
+
+For more details on configuring sleep mode operations in vCluster, see the [Sleep mode documentation](../../).
+
 
 ## Prerequisites
 

--- a/vcluster/manage/sleep-wakeup.mdx
+++ b/vcluster/manage/sleep-wakeup.mdx
@@ -8,7 +8,7 @@ import InstallCli from '../_partials/deploy/install-cli.mdx';
 
 The sleep mode **temporarily scales down** a virtual cluster and deletes all its created workloads on the host cluster. This approach helps **save computing resources** used by virtual cluster workloads in the host cluster. For example, sleeping development clusters during non-working hours can significantly reduce infrastructure costs. 
 
-For more details on configuring sleep mode operations in vCluster, see the [Sleep mode documentation](../../configure/vcluster-yaml/sleep-mode).
+For more details on automating sleep mode operations in vCluster, see the [Sleep mode documentation](../../configure/vcluster-yaml/sleep-mode).
 
 
 ## Prerequisites

--- a/vcluster_versioned_docs/version-0.24.0/manage/accessing-vcluster.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/manage/accessing-vcluster.mdx
@@ -1,5 +1,5 @@
 ---
-title: Accessa and expose vCluster
+title: Access and expose vCluster
 sidebar_label: Access and Expose
 sidebar_position: 1
 ---

--- a/vcluster_versioned_docs/version-0.24.0/manage/accessing-vcluster.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/manage/accessing-vcluster.mdx
@@ -1,6 +1,6 @@
 ---
-title: Access & Expose vCluster
-sidebar_label: Access & Expose
+title: Accessa and expose vCluster
+sidebar_label: Access and Expose
 sidebar_position: 1
 ---
 
@@ -11,9 +11,9 @@ import InstallCLIFragment from '../_partials/deploy/install-cli-beta.mdx'
 ## Access vCluster
 There are multiple ways how you can access a vCluster with an external application like `kubectl`.
 
-### Connect Directly using the CLI
+### Connect directly using the CLI
 
-Please make sure to install the vCluster CLI.
+Ensure you install the vCluster CLI.
 
 <InstallCLIFragment/>
 
@@ -35,18 +35,18 @@ vcluster connect my-vcluster -- kubectl get namespaces
 vcluster connect my-vcluster -- bash
 ```
 
-Depending on if the vCluster was created within a local Kubernetes cluster or with the `--expose` flag, the CLI will either start port-forwarding or create a context that can be used directly.
+Depending on if the vCluster was created within a local Kubernetes cluster or with the `--expose` flag, the CLI either starts port-forwarding or creates a context that can be used directly.
 
 If you have manually [exposed the vCluster](#expose-vcluster), you can specify the domain where the vCluster is reachable via the `--server` flag:
 
 ```
-# Will create a kube context that uses https://my-domain.org as endpoint
+# Create a kube context that uses https://my-domain.org as endpoint
 vcluster connect my-vcluster -n my-vcluster --server my-domain.org
 ```
 
-### Connect via Service Accounts
+### Connect using Service Accounts
 
-By default, vCluster will update the current kubeconfig to access the vCluster that contains the default admin client certificate and client key to authenticate to the vCluster. This means that all kubeconfig files generated will have cluster admin access within the vCluster.
+By default, vCluster updates the current kubeconfig to access the vCluster that contains the default admin client certificate and client key to authenticate to the vCluster. This means that all kubeconfig files generated have cluster admin access within the vCluster.
 
 Often this might not be desired. Instead of giving a user admin access to the virtual cluster, you can also use [service account authentication](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#service-account-tokens) to the virtual cluster. Let's say we want to create a kubeconfig file that only has view access in the virtual cluster. Then you would create a new service account inside the vCluster and assign it the cluster role `view` via a cluster role binding. Then we would generate a service account token and use that instead of the client-cert and client-key inside the kubeconfig.
 
@@ -60,7 +60,7 @@ vcluster connect my-vcluster -n my-vcluster --service-account kube-system/my-use
 vcluster connect my-vcluster -n my-vcluster --service-account kube-system/my-user --cluster-role view --token-expiration 3600
 ```
 
-This will create a kube context similar to this as well as create the needed service account and cluster role binding:
+This creates a kube context similar to this as well as create the needed service account and cluster role binding:
 ```yaml
 apiVersion: v1
 clusters:
@@ -83,12 +83,12 @@ users:
     token: eyJhbGc...
 ```
 
-As you can see the service account token is used in this kubeconfig here instead of the client-cert and client-key that is used by default. Trying to create a namespace with this config will yield:
+As you can see the service account token is used in this kubeconfig here instead of the client-cert and client-key that is used by default. Trying to create a namespace with this config yields the following:
 
 ```
 export KUBECONFIG=kubeconfig.yaml
 
-# This will work as we have view access
+# This works as we have view access
 kubectl get namespaces
 
 # This won't work
@@ -96,7 +96,7 @@ kubectl create namespace test
 Error from server (Forbidden): namespaces is forbidden: User "system:serviceaccount:kube-system:my-user" cannot create resource "namespaces" in API group "" at the cluster scope
 ```
 
-You can replace the token field in the kubeconfig with any other service account token from inside the vCluster to act as this service account against the vCluster. For more information about service accounts and tokens, please refer to the [official Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#service-account-tokens).
+You can replace the token field in the kubeconfig with any other service account token from inside the vCluster to act as this service account against the vCluster. For more information about service accounts and tokens, refer to the [official Kubernetes documentation](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#service-account-tokens).
 
 ## Retrieving the kubeconfig from the vCluster secret
 
@@ -108,7 +108,7 @@ The secret is prefixed with `vc-` and ends with the vCluster name, so a vCluster
 kubectl get secret vc-my-vcluster -n test --template={{.data.config}} | base64 -D
 ```
 
-The secret will hold a kubeconfig in this format:
+The secret holds a kubeconfig in this format:
 
 ```yaml
 apiVersion: v1
@@ -142,13 +142,13 @@ kubectl port-forward my-vcluster-0 -n test 8443
 With the syncer flag `--out-kube-config-secret-namespace` you can specify a different namespace where the kubeconfig secret should be created in. Keep in mind that you have to manually apply RBAC permissions for the vCluster to allow creation and retrieving of secrets in that namespace.
 :::
 
-### Access vCluster Externally
+### Access vCluster externally
 
 If you have [exposed the vCluster](#expose-vcluster), you can also tell the vCluster to create the kubeconfig secret with another server endpoint through the `exportKubeConfig` flag.
 
 For example, if you want to expose a vCluster at `https://my-domain.org`, you can create a `vcluster.yaml` like this:
 ```yaml
-# Make sure vCluster will sign the server certs for my-domain.org
+# Make sure vCluster signs the server certs for my-domain.org
 # and use it in the generated kube config secret.
 controlPlane:
   # distro: (update distro details as per your configurations)
@@ -185,7 +185,7 @@ kubectl get secret vc-my-vcluster -n my-vcluster --template={{.data.config}} | b
 By default, vCluster is only reachable via port-forwarding in remote clusters. However, this means that you need access to the host cluster, where the vCluster is running, in order to access it. To directly access vCluster without port-forwarding, you can use one of the following methods.
 
 :::info Local Kubernetes Clusters
-If you are using a local Kubernetes cluster, such as docker-desktop, rancher-desktop, KinD or minikube, vCluster will automatically connect to it without the need of port-forwarding.
+If you are using a local Kubernetes cluster, such as docker-desktop, rancher-desktop, kind or minikube, vCluster automatically connects to it without the need of port-forwarding.
 :::
 
 <Tabs
@@ -199,13 +199,13 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
     ]}>
 <TabItem value="ingress">
 
-  An [Ingress Controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/)  with SSL passthrough support will provide the best user experience, but there is a workaround if this feature is not natively supported.
+  An [Ingress Controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) with SSL passthrough support provide the best user experience, but there is a workaround if this feature is not natively supported.
 
   - [Kubernetes Nginx](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough)
   - [Traefik Proxy](https://doc.traefik.io/traefik/routing/routers/#passthrough)
   - [Emissary](https://www.getambassador.io/docs/emissary/latest/topics/using/tcpmappings#tls-termination)
 
-  Make sure your ingress controller is installed and healthy on the cluster that will host your virtual clusters. Create the following `ingress.yaml` for a vCluster called `my-vcluster` in the namespace `my-vcluster`:
+  Make sure your ingress controller is installed and healthy on the cluster that hosts your virtual clusters. Create the following `ingress.yaml` for a vCluster called `my-vcluster` in the namespace `my-vcluster`:
 
   ```yaml
   apiVersion: networking.k8s.io/v1
@@ -215,7 +215,7 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
       # We need the ingress to pass through ssl traffic to the vCluster
       # This only works for the nginx-ingress (enable via --enable-ssl-passthrough
       # https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough )
-      # for other ingress controllers please check their respective documentation.
+      # for other ingress controllers check their respective documentation.
       nginx.ingress.kubernetes.io/backend-protocol: HTTPS
       nginx.ingress.kubernetes.io/ssl-passthrough: "true"
       nginx.ingress.kubernetes.io/ssl-redirect: "true"
@@ -242,7 +242,7 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
   ```
 
   :::info Enable SSL Passthrough Feature
-  If you are using the ingress nginx controller, please make sure you have [enabled the SSL passthrough feature](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough) as it is disabled by default.
+  If you are using the ingress nginx controller, ensure you have [enabled the SSL passthrough feature](https://kubernetes.github.io/ingress-nginx/user-guide/tls/#ssl-passthrough) as it is disabled by default.
   :::
 
   To enable the SSL Passthrough Feature you can edit the nginx ingress deployment within the nginx namespace. The option that needs to be added is `- --enable-ssl-passthrough` under the container args within spec. It should end up looking something like:
@@ -263,8 +263,8 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
           - --enable-ssl-passthrough
   ```
 
-  :::warning SSL Passthrough required
-  In order for this ingress to work correctly, you will need to enable SSL passthrough as TLS termination has to happen at the vCluster level and not ingress controller level. If you cannot do that, please take a look below for using an ingress without ssl passthrough.
+  :::warning SSL passthrough required
+  For this ingress to work properly, enable SSL passthrough since TLS termination must occur at the vCluster level, not at the ingress controller level. If SSL passthrough is unavailable in your environment, refer to the following section for implementing ingress without SSL passthrough.
   :::
 
   Now create a `vcluster.yaml` to create the vCluster with:
@@ -280,7 +280,7 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
   vcluster create my-vcluster -n my-vcluster --connect=false -f values.yaml
   ```
 
-  Retrieve the kube config via:
+  Retrieve the kube config using:
   ```
   vcluster connect my-vcluster -n my-vcluster --print --server=https://my-vcluster.example.com > kubeconfig.yaml
   ```
@@ -323,13 +323,13 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
       - my-vcluster.example.com
   ```
 
-  With this configuration you will need to use service account authentication in order to connect as the ingress controller won't be able to resolve the client-cert and client-key which is used by default as authentication method. To create a kube config that uses a service account, please run the following command:
+  With this configuration you must use service account authentication in order to connect as the ingress controller won't be able to resolve the client-cert and client-key which is used by default as authentication method. To create a kube config that uses a service account, run the following command:
 
   ```
   vcluster connect my-vcluster -n my-vcluster --server=https://my-vcluster.example.com --service-account admin --cluster-role cluster-admin --insecure
   ```
 
-  Then access the vCluster:
+  Access the vCluster:
   ```
   # Run any kubectl command
   kubectl get ns
@@ -350,7 +350,7 @@ If you are using a local Kubernetes cluster, such as docker-desktop, rancher-des
   That's it, your vCluster is now externally reachable through a LoadBalancer service.
 
   :::warning Check the costs first
-  Even though using a LoadBalancer is the easiest option, if you use a cloud provider it will be costly to create one Loadbalancer per cluster. Check your cloud vendor about the cost of each LoadBalancer. In general using an Ingress is the most cost effective method.
+  Even though using a LoadBalancer is the easiest option, if you use a cloud provider it is costly to create one Loadbalancer per cluster. Check your cloud vendor about the cost of each LoadBalancer. In general using an Ingress is the most cost effective method.
   :::
 
 **Manual LoadBalancer service creation**

--- a/vcluster_versioned_docs/version-0.24.0/manage/deploy-changes.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/manage/deploy-changes.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploy Changes in Configuration Options
+title: Deploy changes in configuration options
 sidebar_label: Deploy Config Changes
 sidebar_position: 2
 ---

--- a/vcluster_versioned_docs/version-0.24.0/manage/sleep-wakeup.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/manage/sleep-wakeup.mdx
@@ -8,7 +8,7 @@ import InstallCli from '../_partials/deploy/install-cli.mdx';
 
 The sleep mode temporarily scales down a virtual cluster and deletes all its created workloads on the host cluster. This approach helps save computing resources used by virtual cluster workloads in the host cluster. For example, sleeping development clusters during non-working hours can significantly reduce infrastructure costs.
 
-For more details on configuring sleep mode operations in vCluster, see the [Sleep mode documentation](vcluster/configure/vcluster-yaml/sleep-mode).
+For more details on configuring sleep mode operations in vCluster, see the [Sleep mode documentation](https://www.vcluster.com/docs/vcluster/configure/vcluster-yaml/sleep-mode).
 
 ## Prerequisites
 

--- a/vcluster_versioned_docs/version-0.24.0/manage/sleep-wakeup.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/manage/sleep-wakeup.mdx
@@ -1,12 +1,14 @@
 ---
-title: Sleep & Wakeup vCluster
-sidebar_label: Sleep & Wakeup
+title: Sleep and wakeup vCluster
+sidebar_label: Sleep and Wakeup
 sidebar_position: 4
 ---
 import BasePrerequisites from '@site/docs/_partials/base-prerequisites.mdx';
 import InstallCli from '../_partials/deploy/install-cli.mdx';
 
-The sleep mode **temporarily scales down** a virtual cluster and deletes all its created workloads on the host cluster. This approach helps **save computing resources** used by virtual cluster workloads in the host cluster. For example, sleeping development clusters during non-working hours can significantly reduce infrastructure costs.
+The sleep mode temporarily scales down a virtual cluster and deletes all its created workloads on the host cluster. This approach helps save computing resources used by virtual cluster workloads in the host cluster. For example, sleeping development clusters during non-working hours can significantly reduce infrastructure costs.
+
+For more details on configuring sleep mode operations in vCluster, see the [Sleep mode documentation](../../configure/vcluster-yaml/sleep-mode).
 
 ## Prerequisites
 
@@ -15,7 +17,7 @@ The sleep mode **temporarily scales down** a virtual cluster and deletes all its
   <InstallCli />
 
 
-## Sleeping a vCluster
+## Put a vCluster to sleep
 
 Put a virtual cluster to sleep with the `vCluster` CLI:
 
@@ -41,7 +43,7 @@ When pods are restarted:
 - Pod IP addresses change
 :::
 
-## Waking up a vCluster
+## Wake up a vCluster
 
 You can wake up a virtual cluster with two different `vCluster` CLI commands.
 

--- a/vcluster_versioned_docs/version-0.24.0/manage/sleep-wakeup.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/manage/sleep-wakeup.mdx
@@ -8,7 +8,7 @@ import InstallCli from '../_partials/deploy/install-cli.mdx';
 
 The sleep mode temporarily scales down a virtual cluster and deletes all its created workloads on the host cluster. This approach helps save computing resources used by virtual cluster workloads in the host cluster. For example, sleeping development clusters during non-working hours can significantly reduce infrastructure costs.
 
-For more details on configuring sleep mode operations in vCluster, see the [Sleep mode documentation](../../../../vcluster/configure/vcluster-yaml/sleep-mode).
+For more details on configuring sleep mode operations in vCluster, see the [Sleep mode documentation](vcluster/configure/vcluster-yaml/sleep-mode).
 
 ## Prerequisites
 

--- a/vcluster_versioned_docs/version-0.24.0/manage/sleep-wakeup.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/manage/sleep-wakeup.mdx
@@ -8,7 +8,7 @@ import InstallCli from '../_partials/deploy/install-cli.mdx';
 
 The sleep mode temporarily scales down a virtual cluster and deletes all its created workloads on the host cluster. This approach helps save computing resources used by virtual cluster workloads in the host cluster. For example, sleeping development clusters during non-working hours can significantly reduce infrastructure costs.
 
-For more details on configuring sleep mode operations in vCluster, see the [Sleep mode documentation](../../../vcluster/configure/vcluster-yaml/sleep-mode).
+For more details on configuring sleep mode operations in vCluster, see the [Sleep mode documentation](../../../../vcluster/configure/vcluster-yaml/sleep-mode).
 
 ## Prerequisites
 

--- a/vcluster_versioned_docs/version-0.24.0/manage/sleep-wakeup.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/manage/sleep-wakeup.mdx
@@ -8,7 +8,7 @@ import InstallCli from '../_partials/deploy/install-cli.mdx';
 
 The sleep mode temporarily scales down a virtual cluster and deletes all its created workloads on the host cluster. This approach helps save computing resources used by virtual cluster workloads in the host cluster. For example, sleeping development clusters during non-working hours can significantly reduce infrastructure costs.
 
-For more details on configuring sleep mode operations in vCluster, see the [Sleep mode documentation](../../configure/vcluster-yaml/sleep-mode).
+For more details on configuring sleep mode operations in vCluster, see the [Sleep mode documentation](../../../vcluster/configure/vcluster-yaml/sleep-mode).
 
 ## Prerequisites
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Add a link from manual sleep to sleep mode page


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

[Link to Preview](https://deploy-preview-627--vcluster-docs-site.netlify.app/docs/vcluster/next/manage/sleep-wakeup)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-495

