### PR TITLE
docs: add info about translated pod name in admission review

### DIFF
--- a/vcluster/configure/vcluster-yaml/policies/admission-control.mdx
+++ b/vcluster/configure/vcluster-yaml/policies/admission-control.mdx
@@ -24,7 +24,7 @@ Centralized Admission Control is an advanced feature for cluster admins that hav
 
 Central admission webhooks are different from the other policies:
 
-- `LimitRange` and `ResourceQuota` resources are created and enforced on the host cluster. They do do not appear as resources in the virtual cluster.
+- `LimitRange` and `ResourceQuota` resources are created and enforced on the host cluster. They do not appear as resources in the virtual cluster.
 - A user could define `LimitRange` and `ResourceQuota` resources inside the virtual cluster, but they have full control over them and can delete them at will.
 - Webhooks are different because they need to be configured inside the virtual cluster in order for them to be called by the vCluster's API server.
 - vCluster rewrites these definitions to point to a proxy for a host cluster service that handles webhook requests. The host may also have webhook configurations that use this service.

--- a/vcluster/configure/vcluster-yaml/policies/admission-control.mdx
+++ b/vcluster/configure/vcluster-yaml/policies/admission-control.mdx
@@ -31,7 +31,13 @@ Central admission webhooks are different from the other policies:
 - A user can still install a webhook service or webhook configuration into the virtual cluster outside of this config, but it would run inside the virtual cluster like any other workload.
 
 :::info Namespace Rewriting
-vCluster rewrites the namespace of the object (if the object is namespace scoped) to the host namespace where vCluster is running in. This is not visible to the end-user, but the admission controller is able to use things like namespace selector like usual. Some admission controllers like gatekeeper wouldn't work otherwise as they rely on the namespace to always be there in the underlying cluster. To access the virtual namespace in a webhook, you can access the `request.options.vCluster.namespace.metadata.name` field in the [admission request object](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#request) that holds the full virtual namespace object. 
+vCluster rewrites the namespace of the object (if the object is namespace scoped) to the host namespace where vCluster is running in. This is not visible to the end-user, but the admission controller is able to use things like namespace selector like usual. Some admission controllers like gatekeeper wouldn't work otherwise as they rely on the namespace to always be there in the underlying cluster. To access the virtual namespace in a webhook, you can access the `request.options.vCluster.namespace.metadata.name` field in the [admission request object](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#request) that holds the full virtual namespace object.
+:::
+
+:::info Translated name of Pods
+In some circumstances it might be necessary to have the translated name of a Pod, which will be used when this Pod is created on the host cluster, available in a webhook running inside a virtual cluster.
+Therefore, vCluster puts the translated Pod name under the `request.options.vCluster.name` field in the [admission request object](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#request).
+As the final name is only available during validation phase this only works when using `validatingWebhooks` that have rules configured for Pods.
 :::
 
 ## Kyverno Example
@@ -88,7 +94,7 @@ error: the resource kyverno-webhook is protected
 
 ## Gatekeeper (OPA) Example
 
-First [install gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/install/) to your Kubernetes cluster. 
+First [install gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/install/) to your Kubernetes cluster.
 
 Then create the following constraint template that denies pods without specified labels:
 ```yaml


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
https://deploy-preview-629--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/policies/admission-control

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Part of ENG-6252

