### PR TITLE
Explain how replicated services are cleaned up

### DIFF
--- a/vcluster/configure/vcluster-yaml/networking/replicate-services.mdx
+++ b/vcluster/configure/vcluster-yaml/networking/replicate-services.mdx
@@ -23,7 +23,7 @@ networking:
 vCluster replicates the service in the virtual cluster, with the virtual cluster service pointing to the service running in the host cluster. Pods inside the virtual cluster can access the host service using `my-virtual-service.my-virtual-namespace` syntax. For example, if you use cURL, the command is `curl http://my-virtual-service.my-virtual-namespace`.
 
 In the above example, when you remove the `my-host-namespace/my-host-service` service replication config from `networking.replicateServices.fromHost`,
-the virtual cluster service `my-virtual-namespace/my-virtual-service` will be automatically deleted from the virtual cluster.
+the virtual cluster service `my-virtual-namespace/my-virtual-service` is automatically deleted from the virtual cluster.
 
 ## Virtual cluster to host cluster
 
@@ -42,7 +42,7 @@ networking:
 With this configuration, vCluster manages a service called `my-host-service` inside the namespace where the vCluster workloads are synced, which points to the virtual service `my-virtual-service` in namespace `my-virtual-namespace` inside the virtual cluster. Pods in the host cluster are able to access the virtual service by calling the host service. If you use cURL, the command based on the preceding example is `curl http://my-host-service`.
 
 In the above example, when you remove the `my-virtual-namespace/my-virtual-service` service replication config from
-`networking.replicateServices.toHost`, the host cluster service `my-host-service` will not be automatically deleted from
+`networking.replicateServices.toHost`, the host cluster service `my-host-service` is not automatically deleted from
 the host cluster, so you need to delete it manually, if you don't want to keep it in the host cluster.
 
 ## Config reference

--- a/vcluster/configure/vcluster-yaml/networking/replicate-services.mdx
+++ b/vcluster/configure/vcluster-yaml/networking/replicate-services.mdx
@@ -22,6 +22,9 @@ networking:
 
 vCluster replicates the service in the virtual cluster, with the virtual cluster service pointing to the service running in the host cluster. Pods inside the virtual cluster can access the host service using `my-virtual-service.my-virtual-namespace` syntax. For example, if you use cURL, the command is `curl http://my-virtual-service.my-virtual-namespace`.
 
+In the above example, when you remove the `my-host-namespace/my-host-service` service replication config from `networking.replicateServices.fromHost`,
+the virtual cluster service `my-virtual-namespace/my-virtual-service` will be automatically deleted from the virtual cluster.
+
 ## Virtual cluster to host cluster
 
 You can also map a virtual cluster service to a host cluster service. This is especially useful if you want to expose an application that runs inside the virtual cluster to other workloads running in the host cluster, which makes it easier to share services across vCluster instances.
@@ -38,6 +41,9 @@ networking:
 
 With this configuration, vCluster manages a service called `my-host-service` inside the namespace where the vCluster workloads are synced, which points to the virtual service `my-virtual-service` in namespace `my-virtual-namespace` inside the virtual cluster. Pods in the host cluster are able to access the virtual service by calling the host service. If you use cURL, the command based on the preceding example is `curl http://my-host-service`.
 
+In the above example, when you remove the `my-virtual-namespace/my-virtual-service` service replication config from
+`networking.replicateServices.toHost`, the host cluster service `my-host-service` will not be automatically deleted from
+the host cluster, so you need to delete it manually, if you don't want to keep it in the host cluster.
 
 ## Config reference
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Explain how replicated services are cleaned up when they are removed from `networking.replicateServices.fromHost` config.


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

[Replicate services docs preview](https://deploy-preview-630--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/networking/replicate-services)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-418

