### PR TITLE
fix: slight rewording for intro for vcluster

### DIFF
--- a/vcluster/_partials/what-are-virtual-clusters.mdx
+++ b/vcluster/_partials/what-are-virtual-clusters.mdx
@@ -1,4 +1,4 @@
-Virtual clusters are fully functional Kubernetes clusters nested inside a physical host cluster providing better isolation and flexibility to support multi-tenancy. Multiple teams can operate independently within the same physical infrastructure while minimizing conflicts, maximizing autonomy, and reducing costs.
+Virtual clusters are certified Kubernetes distributions that run as isolated, virtual environments nested inside a physical host cluster. They improve isolation and flexibility for multi-tenancy by allowing multiple teams to operate independently on the same infrastructure, minimizing conflicts, increasing autonomy, and reducing costs.
 
 <figure>
 <img
@@ -8,9 +8,9 @@ Virtual clusters are fully functional Kubernetes clusters nested inside a physic
   <figcaption>vCluster Architecture</figcaption>
 </figure>
 
-Virtual clusters run inside host cluster namespaces but function as separate Kubernetes clusters, with their own API server, control plane, syncer, and set of resources. While virtual clusters share the physical resources of the host cluster (such as CPU, memory, and storage), they manage their resources independently, allowing for efficient utilization and scaling. 
+Virtual clusters run inside host cluster namespaces but operate as independent Kubernetes environments, each with its own API server, control plane, syncer, and set of resources. They share the physical infrastructure of the host cluster—such as CPU, memory, and storage—while managing their resources independently to support efficient utilization and scaling.
 
-Virtual clusters interact with the host cluster for resource scheduling and networking but maintain a level of abstraction to ensure operations within a virtual cluster don't directly affect the host cluster's global state.
+Although they rely on the host cluster for resource scheduling and networking, virtual clusters maintain a level of abstraction that isolates their operations from the host cluster’s global state.
 
 ## Benefits
 Virtual clusters provide immense benefits for large-scale Kubernetes deployments and multi-tenancy.
@@ -24,35 +24,48 @@ Virtual clusters provide immense benefits for large-scale Kubernetes deployments
 </figure>
 
 ### Robust security and isolation
-    - **Granular Permissions:** vCluster users operate with minimized permissions in the host cluster, significantly reducing the risk of privileged access misuse. Within their vCluster, users have admin-level control, enabling them to manage CRDs, RBAC, and other security policies independently.
-    - **Isolated Control Plane:** Each vCluster comes with its own dedicated API server and control plane, creating a strong isolation boundary.
-    - **Customizable Security Policies:** Tenants can implement additional vCluster-specific governance, including OPA policies, network policies, resource quotas, limit ranges, and admission control, in addition to the existing policies and security measures in the underlying physical host cluster.
-    - **Enhanced Data Protection:** With options for separate backing stores, including embedded SQLite, etcd, or external databases, virtual clusters allow for isolated data management, reducing the risk of data leakage between tenants.
+
+  - **Granular permissions:** vCluster users operate with minimized permissions in the host cluster, significantly reducing the risk of privileged access misuse. Within their vCluster, users have admin-level control, enabling them to manage CRDs, RBAC, and other security policies independently.
+  - **Isolated control plane:** Each vCluster comes with its own dedicated API server and control plane, creating a strong isolation boundary.
+  - **Customizable security policies:** Tenants can implement additional vCluster-specific governance, including OPA policies, network policies, resource quotas, limit ranges, and admission control, in addition to the existing policies and security measures in the underlying physical host cluster.
+  - **Enhanced data protection:** With options for separate backing stores, including embedded SQLite, etcd, or external databases, virtual clusters allow for isolated data management, reducing the risk of data leakage between tenants.
+
 
 ### Access for tenants
-    - **Full Admin Access per Tenant:** Tenants can freely deploy CRDs, create namespaces, taint, and label nodes, and manage cluster-scoped resources typically restricted in standard Kubernetes namespaces.
-    - **Isolated yet Integrated Networking:** While ensuring automatic isolation (for example, pods in different virtual clusters cannot communicate by default), vCluster allows for configurable network policies and service sharing, supporting both separation and sharing as needed.
-    - **Node Management:** Assign static nodes to specific virtual clusters or share node pools among multiple virtual clusters, providing flexibility in resource allocation.
+
+  - **Full admin access per tenant:** Tenants can freely deploy CRDs, create namespaces, taint and label nodes, and manage cluster-scoped resources typically restricted in standard Kubernetes namespaces.
+  - **Isolated yet integrated networking:** While ensuring automatic isolation (for example, pods in different virtual clusters cannot communicate by default), vCluster allows for configurable network policies and service sharing, supporting both separation and sharing as needed.
+  - **Node management:** Assign static nodes to specific virtual clusters or share node pools among multiple virtual clusters, providing flexibility in resource allocation.
+
 
 ### Cost-effectiveness and reduced overhead
-    - **Lightweight Infrastructure:** Virtual clusters are significantly more lightweight than physical clusters, able to spin up in seconds, which contrasts sharply with the lengthy provisioning times often seen in environments like EKS (~45 minutes).
-    - **Resource Efficiency:** By sharing the underlying host cluster's resources, virtual clusters minimize the need for additional physical infrastructure, reducing costs and environmental impact.
-    - **Simplified Management:** The vCluster control plane, running inside a single pod, along with optional integrated CoreDNS, minimizes the operational overhead, making virtual clusters especially suitable for large-scale deployments and multi-tenancy scenarios.    
+
+  - **Lightweight infrastructure:** Virtual clusters are significantly more lightweight than physical clusters and can spin up in seconds, contrasting sharply with the lengthy provisioning times often seen in environments like EKS (~45 minutes).
+  - **Resource efficiency:** By sharing the underlying host cluster's resources, virtual clusters minimize the need for additional physical infrastructure, reducing costs and environmental impact.
+  - **Simplified management:** The vCluster control plane, running inside a single pod along with optional integrated CoreDNS, minimizes operational overhead, making virtual clusters especially suitable for large-scale deployments and multi-tenancy scenarios.
+
 
 ### Enhanced flexibility and compatibility
-    - **Diverse Kubernetes Environments:** vCluster supports different Kubernetes versions and distributions (including K8s, K3s, and K0s), allowing version skews. This makes it possible to tailor each virtual cluster to specific requirements without impacting others.
-    - **Adaptable Backing Stores:** Choose from a range of data stores, from lightweight (SQLite) to enterprise-grade options (embedded etcd, external data stores like Global RDS), catering to various scalability and durability needs.
-    - **Runs Anywhere:** Virtual clusters can run on EKS, GKE, AKS, OpenShift, RKE, K3s, cloud, edge, and on-prem. As long as it's a K8s cluster, you can run a virtual cluster on top of it.
+
+  - **Diverse Kubernetes environments:** vCluster supports different Kubernetes versions and distributions (including Kubernetes, K3s, and K0s), allowing version skews. This makes it possible to tailor each virtual cluster to specific requirements without impacting others.
+  - **Adaptable backing stores:** Choose from a range of data stores, from lightweight (SQLite) to enterprise-grade options (embedded etcd, external data stores like Global RDS), catering to various scalability and durability needs.
+  - **Runs anywhere:** Virtual clusters can run on EKS, GKE, AKS, OpenShift, RKE, K3s, cloud, edge, and on-prem. As long as it’s a Kubernetes cluster, you can run a virtual cluster on top of it.
+
 
 ### Improved scalability
-    - **Reduced API Server Load:** Virtual clusters, each with their own dedicated API server, significantly reduce the operational load on the host cluster's Kubernetes API server by isolating and handling requests internally.
-    - **Conflict-Free CRD Management:** Independent management of CRDs within each virtual cluster eliminates the potential for CRD conflicts and version discrepancies, ensuring smoother operations and easier scaling as the user base expands.
+
+  - **Reduced API server load:** Virtual clusters, each with their own dedicated API server, significantly reduce the operational load on the host cluster's Kubernetes API server by isolating and handling requests internally.
+  - **Conflict-free CRD management:** Independent management of CRDs within each virtual cluster eliminates the potential for CRD conflicts and version discrepancies, ensuring smoother operations and easier scaling as the user base expands.
+
 
 ## Common use cases
+
 ### Pre-production
-   - **Empower developers with self-service Kubernetes:** Simplify Kubernetes access for developers through self-service virtual clusters, reducing human error and enhancing developer autonomy without compromising security and compliance requirements. 
-   - **Accelerate CI/CD with ephemeral Kubernetes clusters:** Instantly create clean, new virtual Kubernetes clusters for each pull request, enabling fast, isolated testing and PR previews without wait times and the struggles of a shared test environment.
+
+  - **Empower developers with self-service Kubernetes:** Simplify Kubernetes access for developers through self-service virtual clusters, reducing human error and enhancing developer autonomy without compromising security and compliance requirements.
+  - **Accelerate CI/CD with ephemeral Kubernetes clusters:** Instantly create clean, new virtual Kubernetes clusters for each pull request, enabling fast, isolated testing and PR previews without wait times and the struggles of a shared test environment.
 
 ### Production
-   - **Elevate your ISV offering with a dedicated cluster per customer:** Host each customer in a virtual cluster with strict tenant isolation and seamless scalability, while consolidating essential tools into a unified platform stack serving multiple tenants.
-   - **Build a managed Kubernetes service with best-in-class COGS and high margins:** Enable direct customer access to dedicated virtual Kubernetes clusters, streamlining node and resource allocation for industry-leading efficiency and unparalleled scalability.
+
+  - **Elevate your ISV offering with a dedicated cluster per customer:** Host each customer in a virtual cluster with strict tenant isolation and seamless scalability while consolidating essential tools into a unified platform stack serving multiple tenants.
+  - **Build a managed Kubernetes service with best-in-class COGS and high margins:** Enable direct customer access to dedicated virtual Kubernetes clusters, streamlining node and resource allocation for industry-leading efficiency and unparalleled scalability.

--- a/vcluster_versioned_docs/version-0.24.0/_partials/what-are-virtual-clusters.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/what-are-virtual-clusters.mdx
@@ -1,4 +1,4 @@
-Virtual clusters are fully functional Kubernetes clusters nested inside a physical host cluster providing better isolation and flexibility to support multi-tenancy. Multiple teams can operate independently within the same physical infrastructure while minimizing conflicts, maximizing autonomy, and reducing costs.
+Virtual clusters are certified Kubernetes distributions that run as isolated, virtual environments nested inside a physical host cluster. They improve isolation and flexibility for multi-tenancy by allowing multiple teams to operate independently on the same infrastructure, minimizing conflicts, increasing autonomy, and reducing costs.
 
 <figure>
 <img
@@ -8,9 +8,9 @@ Virtual clusters are fully functional Kubernetes clusters nested inside a physic
   <figcaption>vCluster Architecture</figcaption>
 </figure>
 
-Virtual clusters run inside host cluster namespaces but function as separate Kubernetes clusters, with their own API server, control plane, syncer, and set of resources. While virtual clusters share the physical resources of the host cluster (such as CPU, memory, and storage), they manage their resources independently, allowing for efficient utilization and scaling. 
+Virtual clusters run inside host cluster namespaces but operate as independent Kubernetes environments, each with its own API server, control plane, syncer, and set of resources. They share the physical infrastructure of the host cluster—such as CPU, memory, and storage—while managing their resources independently to support efficient utilization and scaling.
 
-Virtual clusters interact with the host cluster for resource scheduling and networking but maintain a level of abstraction to ensure operations within a virtual cluster don't directly affect the host cluster's global state.
+Although they rely on the host cluster for resource scheduling and networking, virtual clusters maintain a level of abstraction that isolates their operations from the host cluster’s global state.
 
 ## Benefits
 Virtual clusters provide immense benefits for large-scale Kubernetes deployments and multi-tenancy.
@@ -24,35 +24,48 @@ Virtual clusters provide immense benefits for large-scale Kubernetes deployments
 </figure>
 
 ### Robust security and isolation
-    - **Granular Permissions:** vCluster users operate with minimized permissions in the host cluster, significantly reducing the risk of privileged access misuse. Within their vCluster, users have admin-level control, enabling them to manage CRDs, RBAC, and other security policies independently.
-    - **Isolated Control Plane:** Each vCluster comes with its own dedicated API server and control plane, creating a strong isolation boundary.
-    - **Customizable Security Policies:** Tenants can implement additional vCluster-specific governance, including OPA policies, network policies, resource quotas, limit ranges, and admission control, in addition to the existing policies and security measures in the underlying physical host cluster.
-    - **Enhanced Data Protection:** With options for separate backing stores, including embedded SQLite, etcd, or external databases, virtual clusters allow for isolated data management, reducing the risk of data leakage between tenants.
+
+  - **Granular permissions:** vCluster users operate with minimized permissions in the host cluster, significantly reducing the risk of privileged access misuse. Within their vCluster, users have admin-level control, enabling them to manage CRDs, RBAC, and other security policies independently.
+  - **Isolated control plane:** Each vCluster comes with its own dedicated API server and control plane, creating a strong isolation boundary.
+  - **Customizable security policies:** Tenants can implement additional vCluster-specific governance, including OPA policies, network policies, resource quotas, limit ranges, and admission control, in addition to the existing policies and security measures in the underlying physical host cluster.
+  - **Enhanced data protection:** With options for separate backing stores, including embedded SQLite, etcd, or external databases, virtual clusters allow for isolated data management, reducing the risk of data leakage between tenants.
+
 
 ### Access for tenants
-    - **Full Admin Access per Tenant:** Tenants can freely deploy CRDs, create namespaces, taint, and label nodes, and manage cluster-scoped resources typically restricted in standard Kubernetes namespaces.
-    - **Isolated yet Integrated Networking:** While ensuring automatic isolation (for example, pods in different virtual clusters cannot communicate by default), vCluster allows for configurable network policies and service sharing, supporting both separation and sharing as needed.
-    - **Node Management:** Assign static nodes to specific virtual clusters or share node pools among multiple virtual clusters, providing flexibility in resource allocation.
+
+  - **Full admin access per tenant:** Tenants can freely deploy CRDs, create namespaces, taint and label nodes, and manage cluster-scoped resources typically restricted in standard Kubernetes namespaces.
+  - **Isolated yet integrated networking:** While ensuring automatic isolation (for example, pods in different virtual clusters cannot communicate by default), vCluster allows for configurable network policies and service sharing, supporting both separation and sharing as needed.
+  - **Node management:** Assign static nodes to specific virtual clusters or share node pools among multiple virtual clusters, providing flexibility in resource allocation.
+
 
 ### Cost-effectiveness and reduced overhead
-    - **Lightweight Infrastructure:** Virtual clusters are significantly more lightweight than physical clusters, able to spin up in seconds, which contrasts sharply with the lengthy provisioning times often seen in environments like EKS (~45 minutes).
-    - **Resource Efficiency:** By sharing the underlying host cluster's resources, virtual clusters minimize the need for additional physical infrastructure, reducing costs and environmental impact.
-    - **Simplified Management:** The vCluster control plane, running inside a single pod, along with optional integrated CoreDNS, minimizes the operational overhead, making virtual clusters especially suitable for large-scale deployments and multi-tenancy scenarios.    
+
+  - **Lightweight infrastructure:** Virtual clusters are significantly more lightweight than physical clusters and can spin up in seconds, contrasting sharply with the lengthy provisioning times often seen in environments like EKS (~45 minutes).
+  - **Resource efficiency:** By sharing the underlying host cluster's resources, virtual clusters minimize the need for additional physical infrastructure, reducing costs and environmental impact.
+  - **Simplified management:** The vCluster control plane, running inside a single pod along with optional integrated CoreDNS, minimizes operational overhead, making virtual clusters especially suitable for large-scale deployments and multi-tenancy scenarios.
+
 
 ### Enhanced flexibility and compatibility
-    - **Diverse Kubernetes Environments:** vCluster supports different Kubernetes versions and distributions (including K8s, K3s, and K0s), allowing version skews. This makes it possible to tailor each virtual cluster to specific requirements without impacting others.
-    - **Adaptable Backing Stores:** Choose from a range of data stores, from lightweight (SQLite) to enterprise-grade options (embedded etcd, external data stores like Global RDS), catering to various scalability and durability needs.
-    - **Runs Anywhere:** Virtual clusters can run on EKS, GKE, AKS, OpenShift, RKE, K3s, cloud, edge, and on-prem. As long as it's a K8s cluster, you can run a virtual cluster on top of it.
+
+  - **Diverse Kubernetes environments:** vCluster supports different Kubernetes versions and distributions (including Kubernetes, K3s, and K0s), allowing version skews. This makes it possible to tailor each virtual cluster to specific requirements without impacting others.
+  - **Adaptable backing stores:** Choose from a range of data stores, from lightweight (SQLite) to enterprise-grade options (embedded etcd, external data stores like Global RDS), catering to various scalability and durability needs.
+  - **Runs anywhere:** Virtual clusters can run on EKS, GKE, AKS, OpenShift, RKE, K3s, cloud, edge, and on-prem. As long as it’s a Kubernetes cluster, you can run a virtual cluster on top of it.
+
 
 ### Improved scalability
-    - **Reduced API Server Load:** Virtual clusters, each with their own dedicated API server, significantly reduce the operational load on the host cluster's Kubernetes API server by isolating and handling requests internally.
-    - **Conflict-Free CRD Management:** Independent management of CRDs within each virtual cluster eliminates the potential for CRD conflicts and version discrepancies, ensuring smoother operations and easier scaling as the user base expands.
+
+  - **Reduced API server load:** Virtual clusters, each with their own dedicated API server, significantly reduce the operational load on the host cluster's Kubernetes API server by isolating and handling requests internally.
+  - **Conflict-free CRD management:** Independent management of CRDs within each virtual cluster eliminates the potential for CRD conflicts and version discrepancies, ensuring smoother operations and easier scaling as the user base expands.
+
 
 ## Common use cases
+
 ### Pre-production
-   - **Empower developers with self-service Kubernetes:** Simplify Kubernetes access for developers through self-service virtual clusters, reducing human error and enhancing developer autonomy without compromising security and compliance requirements. 
-   - **Accelerate CI/CD with ephemeral Kubernetes clusters:** Instantly create clean, new virtual Kubernetes clusters for each pull request, enabling fast, isolated testing and PR previews without wait times and the struggles of a shared test environment.
+
+  - **Empower developers with self-service Kubernetes:** Simplify Kubernetes access for developers through self-service virtual clusters, reducing human error and enhancing developer autonomy without compromising security and compliance requirements.
+  - **Accelerate CI/CD with ephemeral Kubernetes clusters:** Instantly create clean, new virtual Kubernetes clusters for each pull request, enabling fast, isolated testing and PR previews without wait times and the struggles of a shared test environment.
 
 ### Production
-   - **Elevate your ISV offering with a dedicated cluster per customer:** Host each customer in a virtual cluster with strict tenant isolation and seamless scalability, while consolidating essential tools into a unified platform stack serving multiple tenants.
-   - **Build a managed Kubernetes service with best-in-class COGS and high margins:** Enable direct customer access to dedicated virtual Kubernetes clusters, streamlining node and resource allocation for industry-leading efficiency and unparalleled scalability.
+
+  - **Elevate your ISV offering with a dedicated cluster per customer:** Host each customer in a virtual cluster with strict tenant isolation and seamless scalability while consolidating essential tools into a unified platform stack serving multiple tenants.
+  - **Build a managed Kubernetes service with best-in-class COGS and high margins:** Enable direct customer access to dedicated virtual Kubernetes clusters, streamlining node and resource allocation for industry-leading efficiency and unparalleled scalability.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

- Following a chat with @deniseschannon , we should use the term "certified Kubernetes distribution". Applying to `stable` and `main` docs.


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

