### PR TITLE
Remove syncLabels from the sync-settings.mdx

### DIFF
--- a/vcluster/configure/vcluster-yaml/experimental/sync-settings.mdx
+++ b/vcluster/configure/vcluster-yaml/experimental/sync-settings.mdx
@@ -10,7 +10,7 @@ import ProAdmonition from '../../../_partials/admonitions/pro-admonition.mdx'
 
 {/*
 
-- `syncSettings.disableSync`: as stated, this will skip starting all sync controllers, but also skips deploying CoreDNS
+- `syncSettings.disableSync`: This skips starting all sync controllers, but also skips deploying CoreDNS
   - almost always used with `syncSettings.rewriteKubernetesService`
   - Previous flag (possibly undocumented) `--noop-syncer=true`
 - `syncSettings.rewriteKubernetesService`:
@@ -29,12 +29,11 @@ import ProAdmonition from '../../../_partials/admonitions/pro-admonition.mdx'
 | rewriteKubernetesService              |    :x:           |   :white_check_mark:                | Replaces `--noop-syncer` and `--sync-k8s-service`. |
 |  targetNamespace             |   :white_check_mark:            |  :white_check_mark:                  |  Replaces `--target-namespace` |
 |  setOwner             |     :white_check_mark:          |   :white_check_mark:                 |  Replaces `--set-owner`.|
-|  syncLabels             |  :white_check_mark:             |   :white_check_mark:                 | Replaces `--sync-labels`. |
 |  hostMetricsBindAddress             |   :white_check_mark:            |     :white_check_mark:               | |
 | virtualMetricsBindAddress              |    :white_check_mark:           |  :white_check_mark:                  | |
 
 
-## Config notes
+## Config
 
 Use `syncSettings.disableSync` and `syncSettings.rewriteKubernetesService` together.
 

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/experimental/sync-settings.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/experimental/sync-settings.mdx
@@ -10,7 +10,7 @@ import ProAdmonition from '../../../_partials/admonitions/pro-admonition.mdx'
 
 {/*
 
-- `syncSettings.disableSync`: as stated, this will skip starting all sync controllers, but also skips deploying CoreDNS
+- `syncSettings.disableSync`: as stated, this skips starting all sync controllers, but also skips deploying CoreDNS
   - almost always used with `syncSettings.rewriteKubernetesService`
   - Previous flag (possibly undocumented) `--noop-syncer=true`
 - `syncSettings.rewriteKubernetesService`:

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/experimental/sync-settings.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/experimental/sync-settings.mdx
@@ -29,7 +29,6 @@ import ProAdmonition from '../../../_partials/admonitions/pro-admonition.mdx'
 | rewriteKubernetesService              |    :x:           |   :white_check_mark:                | Replaces `--noop-syncer` and `--sync-k8s-service`. |
 |  targetNamespace             |   :white_check_mark:            |  :white_check_mark:                  |  Replaces `--target-namespace` |
 |  setOwner             |     :white_check_mark:          |   :white_check_mark:                 |  Replaces `--set-owner`.|
-|  syncLabels             |  :white_check_mark:             |   :white_check_mark:                 | Replaces `--sync-labels`. |
 |  hostMetricsBindAddress             |   :white_check_mark:            |     :white_check_mark:               | |
 | virtualMetricsBindAddress              |    :white_check_mark:           |  :white_check_mark:                  | |
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Removing documentation for the syncLabels field, which is no longer part of the confi.
Related to https://github.com/loft-sh/vcluster/issues/2718

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
#Closes DOC-

