### PR TITLE
Add istio example to sleep mode docs

### DIFF
--- a/vcluster/_fragments/sleepmode-istio-example.mdx
+++ b/vcluster/_fragments/sleepmode-istio-example.mdx
@@ -9,6 +9,9 @@ import SleepmodeIstioExample from '!!raw-loader!@site/vcluster/configure/vcluste
   <Step>
 Create the `kind` cluster.
 
+Here we are pinning the ports 80, 443 and the status port 15021 to specific ports in the Kubernetes node port range.  These
+ are used by Istio Gateway and needed for running this example with `kind`.
+
 ```shell title="Create a kind cluster"
 kind create cluster --name istio-demo --config - <<EOF
 kind: Cluster
@@ -43,11 +46,10 @@ EOF
     ```shell title="Install with ambient"
     istioctl install --set profile=ambient --set "components.ingressGateways[0].enabled=true" --set "components.ingressGateways[0].name=istio-ingressgateway" --skip-confirmation
     ```
-
   </Step>
 
   <Step>
-Patch the Istio gateway's service to match the ports in the kind configuration.
+The Istio Gateway service starts with some random node ports.  To line them up with the kind cluster configuration, patch the Istio gateway service.
 
 ```shell title="Patch ingress service ports"
 kubectl patch service istio-ingressgateway -n istio-system --patch "$(cat <<EOF
@@ -72,7 +74,7 @@ EOF
   <Step>
     Create the vCluster.
 
-    Use the following `vcluster.yaml` to create a virtual cluster on your host. Save this file as `vcluster.yaml`
+    Use the following `vcluster.yaml` to create a virtual cluster on your host cluster. Save this file as `vcluster.yaml`
 
     <CodeBlock title="vCluster config for auto sleep" language="yaml">{SleepmodeIstioConfig}</CodeBlock>
     And run the following command:

--- a/vcluster/_fragments/sleepmode-istio-example.mdx
+++ b/vcluster/_fragments/sleepmode-istio-example.mdx
@@ -1,0 +1,109 @@
+import Flow, { Step } from '@site/src/components/Flow';
+import CodeBlock from '@theme/CodeBlock'
+import SleepmodeIstioConfig from '!!raw-loader!@site/vcluster/configure/vcluster-yaml/_code/sleepmode-istio-config.yaml'
+import SleepmodeIstioExample from '!!raw-loader!@site/vcluster/configure/vcluster-yaml/experimental/_code/sleepmode-istio-examples.yaml'
+
+### Configure sleep mode for use with Istio
+
+<Flow id="sleepmode-ingress-example">
+  <Step>
+Create the `kind` cluster.
+
+```shell title="Create a kind cluster"
+kind create cluster --name istio-demo --config - <<EOF
+    kind: Cluster
+    apiVersion: kind.x-k8s.io/v1alpha4
+    nodes:
+    - role: control-plane
+    extraPortMappings:
+    - containerPort: 30000
+    listenAddress: 127.0.0.1
+    hostPort: 80
+    protocol: TCP
+    - containerPort: 31000
+    listenAddress: 127.0.0.1
+    hostPort: 443
+    protocol: TCP
+    - containerPort: 32000
+    listenAddress: 127.0.0.1
+    hostPort: 15021
+    protocol: TCP
+EOF
+```
+  </Step>
+  <Step>
+    Install istio
+
+    ```shell title="Install istio"
+    istioctl install -y
+    ```
+  </Step>
+
+  <Step>
+Patch the Istio gateway's service to match the ports in the kind configuration.
+
+```shell title="Patch ingress service ports"
+kubectl patch service istio-ingressgateway -n istio-system --patch "$(cat <<EOF
+spec:
+  type: NodePort
+  ports:
+  - name: http2
+    port: 80
+    nodePort: 30000
+  - name: https
+    port: 443
+    nodePort: 31000
+  - name: status-port
+    port: 15021
+    targetPort: 15021
+    nodePort: 32000
+EOF
+)"
+```
+  </Step>
+
+  <Step>
+    Create the vCluster.
+
+    Use the following `vcluster.yaml` to create a virtual cluster on your host. Save this file as `vcluster.yaml`
+
+    <CodeBlock title="vCluster config for auto sleep" language="yaml">{SleepmodeIstioConfig}</CodeBlock>
+    And run the following command:
+
+    ```bash title="Create vCluster with autoSleep config"
+    vcluster create my-vcluster -f vcluster.yaml
+    ```
+  </Step>
+
+  <Step>
+    Enable local DNS resolution for the virtual cluster.
+
+    Add `127.0.0.1 	httpbin.example.com` to your `/etc/hosts` file to match the host configured in the `Gateway` configuration.
+  </Step>
+
+  <Step>
+    Create resources for the `Ingress` such as a `Deployment` and `Service`.
+
+    Use the following manifest to create:
+
+    - `ServiceAccount`
+    - `Service`
+    - `Deployment`
+    - `Gateway` for `httpbin.example.com`
+    - `VirtualService` to route from the above gateway
+
+    <CodeBlock title="Example resources" language="yaml">{SleepmodeIstioExample}</CodeBlock>
+  </Step>
+
+  <Step>
+    Verify the `Gateway` is working properly with `curl`.
+
+    Test the `Gate` endpoint within the 30-second activity window by running `curl --silent httpbin.example.com/status/418` to see the response "I'm a teapot!"
+  </Step>
+
+  <Step>
+    Allow the virtual cluster to go to sleep.
+
+    Wait 30 seconds for the cluster to sleep, then run the `curl` command again. For convenience, run `watch -d curl --silent httpbin.example.com/status/418` to repeatedly test the endpoint. While asleep, or during wake a `503` will be returned.
+  </Step>
+</Flow>

--- a/vcluster/_fragments/sleepmode-istio-example.mdx
+++ b/vcluster/_fragments/sleepmode-istio-example.mdx
@@ -11,23 +11,23 @@ Create the `kind` cluster.
 
 ```shell title="Create a kind cluster"
 kind create cluster --name istio-demo --config - <<EOF
-    kind: Cluster
-    apiVersion: kind.x-k8s.io/v1alpha4
-    nodes:
-    - role: control-plane
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
     extraPortMappings:
-    - containerPort: 30000
-    listenAddress: 127.0.0.1
-    hostPort: 80
-    protocol: TCP
-    - containerPort: 31000
-    listenAddress: 127.0.0.1
-    hostPort: 443
-    protocol: TCP
-    - containerPort: 32000
-    listenAddress: 127.0.0.1
-    hostPort: 15021
-    protocol: TCP
+      - containerPort: 30000
+        listenAddress: 127.0.0.1
+        hostPort: 80
+        protocol: TCP
+      - containerPort: 31000
+        listenAddress: 127.0.0.1
+        hostPort: 443
+        protocol: TCP
+      - containerPort: 32000
+        listenAddress: 127.0.0.1
+        hostPort: 15021
+        protocol: TCP
 EOF
 ```
   </Step>
@@ -37,6 +37,13 @@ EOF
     ```shell title="Install istio"
     istioctl install -y
     ```
+
+    or
+
+    ```shell title="Install with ambient"
+    istioctl install --set profile=ambient --set "components.ingressGateways[0].enabled=true" --set "components.ingressGateways[0].name=istio-ingressgateway" --skip-confirmation
+    ```
+
   </Step>
 
   <Step>

--- a/vcluster/configure/vcluster-yaml/_code/sleepmode-istio-config.yaml
+++ b/vcluster/configure/vcluster-yaml/_code/sleepmode-istio-config.yaml
@@ -1,0 +1,8 @@
+pro: true
+sleepMode:
+  enabled: true
+  autoSleep:
+    afterInactivity: 30s
+integrations:
+  istio:
+    enabled: true

--- a/vcluster/configure/vcluster-yaml/experimental/_code/sleepmode-istio-examples.yaml
+++ b/vcluster/configure/vcluster-yaml/experimental/_code/sleepmode-istio-examples.yaml
@@ -1,0 +1,80 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: httpbin
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  labels:
+    app: httpbin
+    service: httpbin
+spec:
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8080
+  selector:
+    app: httpbin
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: httpbin
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: httpbin
+        version: v1
+    spec:
+      serviceAccountName: httpbin
+      containers:
+        - image: docker.io/mccutchen/go-httpbin:v2.15.0
+          imagePullPolicy: IfNotPresent
+          name: httpbin
+          ports:
+            - containerPort: 8080
+---
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: httpbin-gateway
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+    - port:
+        number: 80
+        name: http
+        protocol: HTTP
+      hosts:
+        - "httpbin.example.com"
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: httpbin
+spec:
+  hosts:
+    - "httpbin.example.com"
+  gateways:
+    - httpbin-gateway
+  http:
+    - match:
+        - uri:
+            prefix: /status
+        - uri:
+            prefix: /delay
+      route:
+        - destination:
+            port:
+              number: 8000
+            host: httpbin.default.svc.cluster.local
+

--- a/vcluster/configure/vcluster-yaml/sleep-mode.mdx
+++ b/vcluster/configure/vcluster-yaml/sleep-mode.mdx
@@ -190,6 +190,10 @@ To configure sleep mode for the ingress controller, make sure it stays responsiv
 
 ### Istio gateway
 
+:::note
+Istio integration must be enabled for sleep mode to work with Istio resources.
+:::
+
 With Istio installed on the host cluster and the [Istio integration](./integrations/istio) enabled, [Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/) and [VirtualService](https://istio.io/latest/docs/reference/config/networking/virtual-service/) resources created in the vCluster
 get synced to the host cluster.  If you have sleep mode enabled as well, then any traffic that is correctly routed to a `Service` in the vCluster is tracked as activity to keep the vCluster awake.  If the vCluster is asleep, that same access wakes it up.
 

--- a/vcluster/configure/vcluster-yaml/sleep-mode.mdx
+++ b/vcluster/configure/vcluster-yaml/sleep-mode.mdx
@@ -9,6 +9,7 @@ import ProAdmonition from '../../_partials/admonitions/pro-admonition.mdx'
 import SleepMode from '../../_partials/config/sleepMode.mdx'
 import SleepModeDeploymentExample from '../../../vcluster/_fragments/sleepmode-deployment-example.mdx'
 import SleepModeIngressExample from '../../../vcluster/_fragments/sleepmode-ingress-example.mdx'
+import SleepModeIstioExample from '../../../vcluster/_fragments/sleepmode-istio-example.mdx'
 import BasePrerequisites from '@site/docs/_partials/base-prerequisites.mdx';
 import InstallCli from '../../_partials/deploy/install-cli.mdx';
 
@@ -35,7 +36,7 @@ sleepMode:
 
 ## Sleep mode operations
 
-Sleep mode involves two main actions: **sleeping** and **waking**. These actions help save resources when the cluster is not in use. 
+Sleep mode involves two main actions: **sleeping** and **waking**. These actions help save resources when the cluster is not in use.
 
 **Sleeping** reduces resource consumption and costs during inactive periods.
 
@@ -120,7 +121,7 @@ This requires compatible versions of vCluster and the platform. The [vCluster an
 | 0.22.x | 4.2.x | ✅ | Update the vCluster config manually, moving it from `experimental` to `external.platform`. Convert durations, such as "90m", into seconds, for example, "5400". Schema validation prevents both configurations from being applied at the same time. | Manually revert the configuration. |
 | 0.23.x | 4.2.x | ✅ | Update the vCluster config manually, moving it from `experimental` to `external.platform`. Convert durations, such as "90m", into seconds, for example, "5400". Schema validation prevents both configurations from being applied at the same time. | Manually revert the configuration. |
 | 0.24.0 | &lt;4.3.0 | ❌ | These versions are not compatible, as the vCluster version is ahead of the platform, which causes the vCluster creation to be rejected. | Not applicable.|
-| 0.24.0 | &ge;4.3.0 | ✅ | No action is required. The platform reads the unified vCluster config and takes over as if it had been configured for the platform all along. | Remove the annotation `vcluster.loft.sh/agent-installed` from the vCluster config secret in the host cluster to notify the vCluster that it needs to resume sleep mode. The secret’s name is `vc-config-<vcluster-name>`.|
+| 0.24.0 | &ge;4.3.0 | ✅ | No action is required. The platform reads the unified vCluster config and takes over as if it had been configured for the platform all along. | Remove the annotation `vcluster.loft.sh/agent-installed` from the vCluster config secret in the host cluster to notify the vCluster that it needs to resume sleep mode. The secret’s name is `vc-config-[vcluster-name]`.|
 | &ge;0.24.0 (future release) | &ge;4.3.0 | ✅ | No action is required. The platform reads the unified config and takes over as if it had been configured for the platform all along. | No action is required, and the vCluster resumes sleep mode for workloads only, not the control plane. |
 </details>
 
@@ -169,7 +170,7 @@ Ensure you install the necessary prerequisites.
 
 ### Deployment
 
-A deployment resource in Kubernetes manages a set of identical pods. Configuring sleep mode for a deployment scales down the pods while keeping the control plane active. 
+A deployment resource in Kubernetes manages a set of identical pods. Configuring sleep mode for a deployment scales down the pods while keeping the control plane active.
 This setup allows the virtual cluster to reduce resource usage while still being able to monitor activity and trigger wake-up actions when needed.
 
 <details>
@@ -177,7 +178,7 @@ This setup allows the virtual cluster to reduce resource usage while still being
 <SleepModeDeploymentExample />
 </details>
 
-### Ingress controller
+### Ingress controller (NGINX)
 
 An ingress controller manages external HTTP/S traffic to services in a Kubernetes cluster.
 To configure sleep mode for the ingress controller, make sure it stays responsive to incoming traffic and can wake up the cluster if needed. This setup keeps the ingress controller active, even when the vCluster is in sleep mode and allows the controller to handle requests that trigger the virtual cluster to wake up.
@@ -186,6 +187,17 @@ To configure sleep mode for the ingress controller, make sure it stays responsiv
 <summary>Configure sleep mode with an ingress resource</summary>
 <SleepModeIngressExample />
 </details>
+
+### Istio gateway
+
+With Istio installed on the host cluster and the [Istio integration](./integrations/istio) enabled, [Gateway](https://istio.io/latest/docs/reference/config/networking/gateway/) and [VirtualService](https://istio.io/latest/docs/reference/config/networking/virtual-service/) resources created in the vCluster
+get synced to the host cluster.  If you have sleep mode enabled as well, then any traffic that is correctly routed to a `Service` in the vCluster is tracked as activity to keep the vCluster awake.  If the vCluster is asleep, that same access wakes it up.
+
+<details>
+  <summary>Configure sleep mode with Istio</summary>
+  <SleepModeIstioExample />
+</details>
+
 
 ### Enable sleep mode with label selectors and schedules
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Istio Example Preview](https://deploy-preview-640--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/sleep-mode#istio-gateway)



## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENG-6495

