### PR TITLE
fix: configmap sidebar

### DIFF
--- a/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
@@ -1,6 +1,6 @@
 ---
 title: ConfigMaps
-sidebar_label: configmaps
+sidebar_label: configMaps
 sidebar_position: 10
 description: Configuration for ...
 ---

--- a/vcluster_versioned_docs/version-0.23.0/configure/vcluster-yaml/sync/from-host/configmaps.mdx
+++ b/vcluster_versioned_docs/version-0.23.0/configure/vcluster-yaml/sync/from-host/configmaps.mdx
@@ -1,6 +1,6 @@
 ---
 title: ConfigMaps
-sidebar_label: configmaps
+sidebar_label: configMaps
 sidebar_position: 10
 description: Configuration for ...
 ---

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/sync/from-host/configmaps.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/sync/from-host/configmaps.mdx
@@ -1,6 +1,6 @@
 ---
 title: ConfigMaps
-sidebar_label: configmaps
+sidebar_label: configMaps
 sidebar_position: 10
 description: Configuration for ...
 ---


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Small typo fix for sidebar

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

[Link to Preview](https://deploy-preview-643--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml/sync/from-host/)


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-580

