### PR TITLE
feat(platform): add info about metrics endpoint

### DIFF
--- a/platform/administer/clusters/advanced/networking.mdx
+++ b/platform/administer/clusters/advanced/networking.mdx
@@ -16,6 +16,7 @@ Kubernetes must connect to the platform’s API extensions and webhooks to proce
 
 | Port   | Description | Purpose                               |
 |--------|-------------|---------------------------------------|
+| `8080` | Legacy metrics endpoint | Enables scraping metrics when `serviceMonitor.enabled=true` |
 | `8443` | API service extension (`v1.cluster.loft.sh`)| Enables Kubernetes API integration with the platform |
 | `9443` | Webhook validation (`loft webhook`)| Validates requests and enforces policies |
 | `9444` | Management API (`v1.management.loft.sh`)| Handles platform-wide administration and cluster management |
@@ -65,7 +66,7 @@ Run the following command to allow Kubernetes to communicate with the platform:
 
 ```sh
 gcloud compute firewall-rules create allow-k8s-api-to-vcluster-platform \
-  --allow tcp:8443,tcp:9443,tcp:9444 \
+  --allow tcp:8080,tcp:8443,tcp:9443,tcp:9444 \
   --source-ranges=<KUBERNETES_API_IP_RANGE> \
   --target-tags=vcluster-platform
 ```

--- a/platform/administer/monitoring/metrics.mdx
+++ b/platform/administer/monitoring/metrics.mdx
@@ -4,11 +4,11 @@ sidebar_label: Metrics And Monitoring
 sidebar_position: 3
 ---
 
-## Logging
+## Configure logging
 
-By default, vCluster Platform will print out structured logs to the console with a log level of `info`.
+By default, vCluster Platform prints out structured logs to the console with a log level of `info`.
 
-These logs will include constant log messages, a human-readable timestamp, log levels, the file and line number of the source caller, and with variables in the body:
+These logs include constant log messages, a human-readable timestamp, log levels, the file and line number of the source caller, and with variables in the body:
 
 ```text
 2023-07-11 09:20:56     INFO    controller-runtime.metrics      metrics/listener.go:44  Metrics server is starting to listen    {"component": "loft", "addr": "127.0.0.1:12000"}
@@ -17,7 +17,7 @@ These logs will include constant log messages, a human-readable timestamp, log l
 2023-07-11 09:21:02     INFO    initialize/context.go:80        Ensure crds...  {"component": "loft"}
 ```
 
-You can change the log level by setting the helm value `logging.level` to one of the following values: `debug`, `info`, `error`, and upgrading your vCluster Platform release with the following command:
+You can change the log level by setting the Helm value `logging.level` to one of the following values: `debug`, `info`, `error`, and upgrading your vCluster Platform release with the following command:
 
 ```bash
 helm upgrade loft vcluster-platform --repo https://charts.loft.sh/ \
@@ -26,13 +26,13 @@ helm upgrade loft vcluster-platform --repo https://charts.loft.sh/ \
   --set logging.level=error # or debug or info
 ```
 
-### JSON Output Encoding
+### Use JSON output encoding
 
 In addition to the console output, vCluster Platform also supports printing logs encoded in JSON format.
 
 This output format is helpful for structured logging, which allows you to search and filter logs easily.
 
-You can change the log output by setting the helm value `logging.encoding` to one of the following values: `json`, and upgrading your vCluster Platform release with the following command:
+You can change the log output by setting the Helm value `logging.encoding` to one of the following values: `json`, and upgrading your vCluster Platform release with the following command:
 
 ```bash
 helm upgrade loft vcluster-platform --repo https://charts.loft.sh/ \
@@ -41,7 +41,7 @@ helm upgrade loft vcluster-platform --repo https://charts.loft.sh/ \
   --set logging.encoding=json
 ```
 
-These JSON-encoded logs will include constant log messages with different variables in the body, like the default console output:
+These JSON-encoded logs include constant log messages with different variables in the body, like the default console output:
 
 ```json
 {"level":"info","ts":1689067388.209614,"logger":"controller-runtime.metrics","caller":"metrics/listener.go:44","msg":"Metrics server is starting to listen","component":"loft","addr":"127.0.0.1:12000"}
@@ -50,7 +50,7 @@ These JSON-encoded logs will include constant log messages with different variab
 {"level":"info","ts":1689067389.678155,"caller":"initialize/context.go:80","msg":"Ensure crds...","component":"loft"}
 ```
 
-The JSON encoded logs will contain at least the following fields:
+The JSON encoded logs contain at least the following fields:
 
 - `level`: The log level of the message
 - `ts`: The timestamp of the message (floating-point number of seconds since the Unix epoch)
@@ -62,9 +62,11 @@ The JSON encoded logs will contain at least the following fields:
 
 vCluster Platform exposes several [prometheus conformant](https://prometheus.io/docs/practices/naming/) metrics that can be scraped.
 
-### Create the Prometheus ServiceMonitor
+<!-- vale off -->
+### Create the Prometheus servicemonitor
+<!-- vale on -->
 
-The metrics can be scraped with the included `ServiceMonitor` in the vCluster Platform chart, which can be deployed with helm. In order for this to work, make sure you have installed a [prometheus operator](https://github.com/prometheus-operator/prometheus-operator) into your cluster. You'll also need to upgrade your vCluster Platform release with the following command to create the `ServiceMonitor`:
+The metrics can be scraped with the included `ServiceMonitor` in the vCluster Platform chart, which can be deployed with Helm. In order for this to work, make sure you have installed a [prometheus operator](https://github.com/prometheus-operator/prometheus-operator) into your cluster. You'll also need to upgrade your vCluster Platform release with the following command to create the `ServiceMonitor`:
 
 ```bash
 # Make sure you change serviceMonitor.namespace if your prometheus installation requires this.
@@ -75,14 +77,26 @@ helm upgrade loft vcluster-platform --repo https://charts.loft.sh/ \
   --set serviceMonitor.namespace=loft
 ```
 
+:::note
+When `serviceMonitor.enabled=true`, the platform exposes metrics on port `8080`. If your environment has firewall rules or network policies, make sure that port `8080` is open for your Prometheus server to scrape metrics.
+:::
+
 ### Access the metrics endpoint directly without a ServiceMonitor
 
-vCluster Platform will expose its internal metrics at `https://my-loft-subdomain.my-url.com/metrics`.
-By default vCluster Platform will require an `Authorization` http header field with a kubernetes bearer token that has access to the non resource url `/metrics` in the kubernetes cluster where vCluster Platform is installed.
-If the header is not provided, vCluster Platform will deny the request.
+vCluster Platform exposes its internal metrics at 
+<!-- vale off -->
+`https://my-loft-subdomain.my-url.com/metrics`
+<!-- vale on -->
+.
+By default vCluster Platform requires an `Authorization` http header field with a kubernetes bearer token that has access to the non resource 
+<!-- vale off -->
+url `/metrics`
+<!-- vale on -->
+ in the kubernetes cluster where vCluster Platform is installed.
+If the header is not provided, vCluster Platform denies the request.
 
 :::info Disable metrics authentication
-If you wish to scrape metrics without authentication, you can disable it via the environment variable `INSECURE_METRICS=true` in the vCluster Platform helm chart.
+If you wish to scrape metrics without authentication, you can disable it via the environment variable `INSECURE_METRICS=true` in the vCluster Platform Helm chart.
 :::
 
 If you have kubernetes service account token that has the appropriate rights, you can access the metrics via curl:

--- a/platform/administer/monitoring/metrics.mdx
+++ b/platform/administer/monitoring/metrics.mdx
@@ -60,16 +60,16 @@ The JSON encoded logs contain at least the following fields:
 
 ## Metrics
 
-vCluster Platform exposes several [prometheus conformant](https://prometheus.io/docs/practices/naming/) metrics that can be scraped.
+vCluster Platform exposes several [Prometheus-conformant](https://prometheus.io/docs/practices/naming/) metrics that can be scraped.
 
 <!-- vale off -->
 ### Create the Prometheus servicemonitor
 <!-- vale on -->
 
-The metrics can be scraped with the included `ServiceMonitor` in the vCluster Platform chart, which can be deployed with Helm. In order for this to work, make sure you have installed a [prometheus operator](https://github.com/prometheus-operator/prometheus-operator) into your cluster. You'll also need to upgrade your vCluster Platform release with the following command to create the `ServiceMonitor`:
+The metrics can be scraped with the included `ServiceMonitor` in the vCluster Platform chart, which can be deployed with Helm. In order for this to work, make sure you have installed a [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) into your cluster. You'll also need to upgrade your vCluster Platform release with the following command to create the `ServiceMonitor`:
 
 ```bash
-# Make sure you change serviceMonitor.namespace if your prometheus installation requires this.
+# Make sure you change serviceMonitor.namespace if your Prometheus installation requires this.
 helm upgrade loft vcluster-platform --repo https://charts.loft.sh/ \
   --namespace vcluster-platform \
   --reuse-values \

--- a/platform_versioned_docs/version-4.2.0/administer/clusters/advanced/networking.mdx
+++ b/platform_versioned_docs/version-4.2.0/administer/clusters/advanced/networking.mdx
@@ -16,6 +16,7 @@ Kubernetes must connect to the platform’s API extensions and webhooks to proce
 
 | Port   | Description | Purpose                               |
 |--------|-------------|---------------------------------------|
+| `8080` | Legacy metrics endpoint | Enables scraping metrics when `serviceMonitor.enabled=true` |
 | `8443` | API service extension (`v1.cluster.loft.sh`)| Enables Kubernetes API integration with the platform |
 | `9443` | Webhook validation (`loft webhook`)| Validates requests and enforces policies |
 | `9444` | Management API (`v1.management.loft.sh`)| Handles platform-wide administration and cluster management |
@@ -65,7 +66,7 @@ Run the following command to allow Kubernetes to communicate with the platform:
 
 ```sh
 gcloud compute firewall-rules create allow-k8s-api-to-vcluster-platform \
-  --allow tcp:8443,tcp:9443,tcp:9444 \
+  --allow tcp:8080,tcp:8443,tcp:9443,tcp:9444 \
   --source-ranges=<KUBERNETES_API_IP_RANGE> \
   --target-tags=vcluster-platform
 ```

--- a/platform_versioned_docs/version-4.2.0/administer/monitoring/metrics.mdx
+++ b/platform_versioned_docs/version-4.2.0/administer/monitoring/metrics.mdx
@@ -4,11 +4,11 @@ sidebar_label: Metrics And Monitoring
 sidebar_position: 3
 ---
 
-## Logging
+## Configure logging
 
-By default, vCluster Platform will print out structured logs to the console with a log level of `info`.
+By default, vCluster Platform prints out structured logs to the console with a log level of `info`.
 
-These logs will include constant log messages, a human-readable timestamp, log levels, the file and line number of the source caller, and with variables in the body:
+These logs include constant log messages, a human-readable timestamp, log levels, the file and line number of the source caller, and with variables in the body:
 
 ```text
 2023-07-11 09:20:56     INFO    controller-runtime.metrics      metrics/listener.go:44  Metrics server is starting to listen    {"component": "loft", "addr": "127.0.0.1:12000"}
@@ -17,7 +17,7 @@ These logs will include constant log messages, a human-readable timestamp, log l
 2023-07-11 09:21:02     INFO    initialize/context.go:80        Ensure crds...  {"component": "loft"}
 ```
 
-You can change the log level by setting the helm value `logging.level` to one of the following values: `debug`, `info`, `error`, and upgrading your vCluster Platform release with the following command:
+You can change the log level by setting the Helm value `logging.level` to one of the following values: `debug`, `info`, `error`, and upgrading your vCluster Platform release with the following command:
 
 ```bash
 helm upgrade loft vcluster-platform --repo https://charts.loft.sh/ \
@@ -26,13 +26,13 @@ helm upgrade loft vcluster-platform --repo https://charts.loft.sh/ \
   --set logging.level=error # or debug or info
 ```
 
-### JSON Output Encoding
+### Use JSON output encoding
 
 In addition to the console output, vCluster Platform also supports printing logs encoded in JSON format.
 
 This output format is helpful for structured logging, which allows you to search and filter logs easily.
 
-You can change the log output by setting the helm value `logging.encoding` to one of the following values: `json`, and upgrading your vCluster Platform release with the following command:
+You can change the log output by setting the Helm value `logging.encoding` to one of the following values: `json`, and upgrading your vCluster Platform release with the following command:
 
 ```bash
 helm upgrade loft vcluster-platform --repo https://charts.loft.sh/ \
@@ -41,7 +41,7 @@ helm upgrade loft vcluster-platform --repo https://charts.loft.sh/ \
   --set logging.encoding=json
 ```
 
-These JSON-encoded logs will include constant log messages with different variables in the body, like the default console output:
+These JSON-encoded logs include constant log messages with different variables in the body, like the default console output:
 
 ```json
 {"level":"info","ts":1689067388.209614,"logger":"controller-runtime.metrics","caller":"metrics/listener.go:44","msg":"Metrics server is starting to listen","component":"loft","addr":"127.0.0.1:12000"}
@@ -50,7 +50,7 @@ These JSON-encoded logs will include constant log messages with different variab
 {"level":"info","ts":1689067389.678155,"caller":"initialize/context.go:80","msg":"Ensure crds...","component":"loft"}
 ```
 
-The JSON encoded logs will contain at least the following fields:
+The JSON encoded logs contain at least the following fields:
 
 - `level`: The log level of the message
 - `ts`: The timestamp of the message (floating-point number of seconds since the Unix epoch)
@@ -62,9 +62,11 @@ The JSON encoded logs will contain at least the following fields:
 
 vCluster Platform exposes several [prometheus conformant](https://prometheus.io/docs/practices/naming/) metrics that can be scraped.
 
-### Create the Prometheus ServiceMonitor
+<!-- vale off -->
+### Create the Prometheus servicemonitor
+<!-- vale on -->
 
-The metrics can be scraped with the included `ServiceMonitor` in the vCluster Platform chart, which can be deployed with helm. In order for this to work, make sure you have installed a [prometheus operator](https://github.com/prometheus-operator/prometheus-operator) into your cluster. You'll also need to upgrade your vCluster Platform release with the following command to create the `ServiceMonitor`:
+The metrics can be scraped with the included `ServiceMonitor` in the vCluster Platform chart, which can be deployed with Helm. In order for this to work, make sure you have installed a [prometheus operator](https://github.com/prometheus-operator/prometheus-operator) into your cluster. You'll also need to upgrade your vCluster Platform release with the following command to create the `ServiceMonitor`:
 
 ```bash
 # Make sure you change serviceMonitor.namespace if your prometheus installation requires this.
@@ -75,14 +77,26 @@ helm upgrade loft vcluster-platform --repo https://charts.loft.sh/ \
   --set serviceMonitor.namespace=loft
 ```
 
+:::note
+When `serviceMonitor.enabled=true`, the platform exposes metrics on port `8080`. If your environment has firewall rules or network policies, make sure that port `8080` is open for your Prometheus server to scrape metrics.
+:::
+
 ### Access the metrics endpoint directly without a ServiceMonitor
 
-vCluster Platform will expose its internal metrics at `https://my-loft-subdomain.my-url.com/metrics`.
-By default vCluster Platform will require an `Authorization` http header field with a kubernetes bearer token that has access to the non resource url `/metrics` in the kubernetes cluster where vCluster Platform is installed.
-If the header is not provided, vCluster Platform will deny the request.
+vCluster Platform exposes its internal metrics at 
+<!-- vale off -->
+`https://my-loft-subdomain.my-url.com/metrics`
+<!-- vale on -->
+.
+By default vCluster Platform requires an `Authorization` http header field with a kubernetes bearer token that has access to the non resource 
+<!-- vale off -->
+url `/metrics`
+<!-- vale on -->
+ in the kubernetes cluster where vCluster Platform is installed.
+If the header is not provided, vCluster Platform denies the request.
 
 :::info Disable metrics authentication
-If you wish to scrape metrics without authentication, you can disable it via the environment variable `INSECURE_METRICS=true` in the vCluster Platform helm chart.
+If you wish to scrape metrics without authentication, you can disable it via the environment variable `INSECURE_METRICS=true` in the vCluster Platform Helm chart.
 :::
 
 If you have kubernetes service account token that has the appropriate rights, you can access the metrics via curl:

--- a/platform_versioned_docs/version-4.2.0/administer/monitoring/metrics.mdx
+++ b/platform_versioned_docs/version-4.2.0/administer/monitoring/metrics.mdx
@@ -60,13 +60,13 @@ The JSON encoded logs contain at least the following fields:
 
 ## Metrics
 
-vCluster Platform exposes several [prometheus conformant](https://prometheus.io/docs/practices/naming/) metrics that can be scraped.
+vCluster Platform exposes several [Prometheus-conformant](https://prometheus.io/docs/practices/naming/) metrics that can be scraped.
 
 <!-- vale off -->
 ### Create the Prometheus servicemonitor
 <!-- vale on -->
 
-The metrics can be scraped with the included `ServiceMonitor` in the vCluster Platform chart, which can be deployed with Helm. In order for this to work, make sure you have installed a [prometheus operator](https://github.com/prometheus-operator/prometheus-operator) into your cluster. You'll also need to upgrade your vCluster Platform release with the following command to create the `ServiceMonitor`:
+The metrics can be scraped with the included `ServiceMonitor` in the vCluster Platform chart, which can be deployed with Helm. In order for this to work, make sure you have installed a [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator) into your cluster. You'll also need to upgrade your vCluster Platform release with the following command to create the `ServiceMonitor`:
 
 ```bash
 # Make sure you change serviceMonitor.namespace if your prometheus installation requires this.
@@ -88,7 +88,7 @@ vCluster Platform exposes its internal metrics at
 `https://my-loft-subdomain.my-url.com/metrics`
 <!-- vale on -->
 .
-By default vCluster Platform requires an `Authorization` http header field with a kubernetes bearer token that has access to the non resource 
+By default vCluster Platform requires an `Authorization` http header field with a Kubernetes bearer token that has access to the non resource 
 <!-- vale off -->
 url `/metrics`
 <!-- vale on -->


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-646--vcluster-docs-site.netlify.app/docs/platform/administer/clusters/advanced/networking/#connect-kubernetes-to-the-platform
https://deploy-preview-646--vcluster-docs-site.netlify.app/docs/platform/next/administer/monitoring/metrics/#metrics

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-579

