### PR TITLE
fix: add deprecation note

### DIFF
--- a/docs/_partials/deprecation-notice.mdx
+++ b/docs/_partials/deprecation-notice.mdx
@@ -8,7 +8,7 @@ import Admonition from '@theme/Admonition';
  * - extraNote: string (optional)
  */
 
-<Admonition type="warning" title="Deprecated">
+<Admonition type="warning" title="Deprecation Notice">
   {`Support for **${feature}** is deprecated`}
   {deprecatedVersion && ` in \`${deprecatedVersion}\``}.
   {removedVersion && ` It is removed in \`${removedVersion}\`.`}

--- a/docs/_partials/deprecation-notice.mdx
+++ b/docs/_partials/deprecation-notice.mdx
@@ -1,0 +1,16 @@
+import Admonition from '@theme/Admonition';
+
+/**
+ * Props:
+ * - feature: string (required)
+ * - deprecatedVersion: string (optional)
+ * - removedVersion: string (optional)
+ * - extraNote: string (optional)
+ */
+
+<Admonition type="warning" title="Deprecated">
+  {`Support for **${feature}** is deprecated`}
+  {deprecatedVersion && ` in \`${deprecatedVersion}\``}.
+  {removedVersion && ` It is removed in \`${removedVersion}\`.`}
+  {extraNote && ` ${extraNote}`}
+</Admonition>

--- a/vcluster/_partials/deploy/distros.mdx
+++ b/vcluster/_partials/deploy/distros.mdx
@@ -11,7 +11,7 @@ After deploying your vCluster, changing the Kubernetes distribution of vCluster 
 By default, the distribution of vCluster is vanilla Kubernetes (K8s) and is the recommended distribution to use. 
 
 :::warning Deprecation notice
-Support for **K0s** and **K3s** is deprecated in vCluster `v0.25`. K0s support is removed in `v0.26`.   
+Support for **K0s** and **K3s** is deprecated in vCluster `v0.25`. **K0s** support is removed in `v0.26`.   
 Migration to a supported Kubernetes distribution is recommended.
 :::
 

--- a/vcluster/_partials/deploy/distros.mdx
+++ b/vcluster/_partials/deploy/distros.mdx
@@ -1,20 +1,25 @@
 import KubernetesVersions from './kubernetes-versions.mdx'
 import { HostClusterCompat } from './host-cluster-compat.mdx'
 
-vCluster is deployed with its own Kubernetes distribution that does not need to match with the host cluster's distribution. For example, you can deploy virtual clusters with the k8s distro on top of EKS clusters. 
+vCluster is deployed with its own Kubernetes distribution that does not need to match with the host cluster's distribution. For example, you can deploy virtual clusters with the K8s distro on top of EKS clusters. 
 
 
 :::warning
 After deploying your vCluster, changing the Kubernetes distribution of vCluster is not supported.
 :::
 
-By default, the distribution of vCluster is vanilla Kubernetes (k8s) and is the recommended distribution to use. 
+By default, the distribution of vCluster is vanilla Kubernetes (K8s) and is the recommended distribution to use. 
+
+:::warning Deprecation notice
+Support for **K0s** and **K3s** is deprecated in vCluster `v0.25`. K0s support is removed in `v0.26`.   
+Migration to a supported Kubernetes distribution is recommended.
+:::
 
 The following distributions are supported for virtual clusters:
   
-- **k8s**: By default, vCluster uses vanilla Kubernetes. This is the recommended distribution.
-- [**k3s**](https://github.com/k3s-io/k3s)**: A lightweight, certified Kubernetes distribution designed for resource-constrained environments, remote locations, and IoT devices.
-- [**k0s**](https://github.com/k0sproject/k0s): A single-binary Kubernetes distribution with built-in cluster configuration. It can run on dual-stack host clusters but does not fully support dual-stack networking.
+- **K8s**: By default, vCluster uses vanilla Kubernetes. This is the recommended distribution.
+- [**K3s**](https://github.com/k3s-io/k3s): A lightweight, certified Kubernetes distribution designed for resource-constrained environments, remote locations, and IoT devices.
+- [**K0s**](https://github.com/k0sproject/k0s): A single-binary Kubernetes distribution with built-in cluster configuration. It can run on dual-stack host clusters but does not fully support dual-stack networking.
 
 <HostClusterCompat distro="any supported Kubernetes distribution"/>
 

--- a/vcluster/configure/vcluster-yaml/control-plane/README.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/README.mdx
@@ -7,7 +7,10 @@ description: Configuration for ...
 
 import ControlPlane from '../../../_partials/config/controlPlane.mdx'
 
-
+:::warning Deprecation notice
+Support for **K0s** and **K3s** is deprecated in vCluster `v0.25`. K0s support is removed in `v0.26`.   
+Migration to a supported Kubernetes distribution is recommended.
+:::
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/control-plane/README.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/README.mdx
@@ -8,7 +8,7 @@ description: Configuration for ...
 import ControlPlane from '../../../_partials/config/controlPlane.mdx'
 
 :::warning Deprecation notice
-Support for **K0s** and **K3s** is deprecated in vCluster `v0.25`. K0s support is removed in `v0.26`.   
+Support for **K0s** and **K3s** is deprecated in vCluster `v0.25`. **K0s** support is removed in `v0.26`.   
 Migration to a supported Kubernetes distribution is recommended.
 :::
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/README.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/README.mdx
@@ -7,12 +7,6 @@ description: Configure the Kubernetes distribution to use for your virtual clust
 
 import Distros from '../../../../../_partials/deploy/distros.mdx'
 
-:::warning Deprecation notice
-Support for **K0s** is deprecated in vCluster `v0.25` and removed in `v0.26`.  
-Support for **K3s** is deprecated in vCluster`v0.25`.  
-Migration to a supported Kubernetes distribution is recommended.
-:::
-
 <Distros/>
 
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/README.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/README.mdx
@@ -7,6 +7,12 @@ description: Configure the Kubernetes distribution to use for your virtual clust
 
 import Distros from '../../../../../_partials/deploy/distros.mdx'
 
+:::warning Deprecation notice
+Support for **K0s** is deprecated in `v0.25` and removed in `v0.26`.  
+Support for **K3s** is deprecated in `v0.25`.  
+Migration to a supported Kubernetes distribution is recommended.
+:::
+
 <Distros/>
 
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/README.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/README.mdx
@@ -8,8 +8,8 @@ description: Configure the Kubernetes distribution to use for your virtual clust
 import Distros from '../../../../../_partials/deploy/distros.mdx'
 
 :::warning Deprecation notice
-Support for **K0s** is deprecated in `v0.25` and removed in `v0.26`.  
-Support for **K3s** is deprecated in `v0.25`.  
+Support for **K0s** is deprecated in vCluster `v0.25` and removed in `v0.26`.  
+Support for **K3s** is deprecated in vCluster`v0.25`.  
 Migration to a supported Kubernetes distribution is recommended.
 :::
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/k0s.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/k0s.mdx
@@ -1,5 +1,5 @@
 ---
-title: k0s
+title: K0s
 sidebar_label: K0s
 sidebar_position: 3
 description: Configure k0s as the distro for the virtual cluster.
@@ -12,14 +12,14 @@ import K0sCompat from '@site/vcluster/_fragments/distro/compat-k0s.mdx'
 Support for **K0s** is deprecated in vCluster `v0.25` and removed in `v0.26`. Migration to a supported Kubernetes distribution is recommended.
 :::
 
-[Zero Friction Kubernetes (K0s)](https://k0sproject.io/) is an all-inclusive Kubernetes distribution, which is configured with all of the features needed to build a Kubernetes cluster and packaged as a single binary for ease of use. For more information on features, see the [k0s docs](https://docs.k0sproject.io/).
+[Zero Friction Kubernetes (K0s)](https://k0sproject.io/) is an all-inclusive Kubernetes distribution, which is configured with all of the features needed to build a Kubernetes cluster and packaged as a single binary for ease of use. For more information on features, see the [K0s documentation](https://docs.k0sproject.io/).
 
 <br />
 :::warning
-vCluster does not support dual stack networking when you use k0s. You can deploy k0s on a dual stack host cluster, but it does not have all the dual stack features.
+vCluster does not support dual stack networking when you use k0s. You can deploy K0s on a dual stack host cluster, but it does not have all the dual stack features.
 :::
 
-To use k0s with default deployment options, add the following to your `vcluster.yaml` config file:
+To use K0s with default deployment options, add the following to your `vcluster.yaml` config file:
 
 ```yaml
 controlPlane:

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/k0s.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/k0s.mdx
@@ -8,7 +8,11 @@ description: Configure k0s as the distro for the virtual cluster.
 import DistroK0s from '../../../../../_partials/config/controlPlane/distro/k0s.mdx'
 import K0sCompat from '@site/vcluster/_fragments/distro/compat-k0s.mdx'
 
-[Zero Friction Kubernetes (k0s)](https://k0sproject.io/) is an all-inclusive Kubernetes distribution, which is configured with all of the features needed to build a Kubernetes cluster and packaged as a single binary for ease of use. See the [k0s docs](https://docs.k0sproject.io/) for k0s' features.
+:::warning Deprecation notice
+Support for **K0s** is deprecated in vCluster `v0.25` and removed in `v0.26`. Migration to a supported Kubernetes distribution is recommended.
+:::
+
+[Zero Friction Kubernetes (k0s)](https://k0sproject.io/) is an all-inclusive Kubernetes distribution, which is configured with all of the features needed to build a Kubernetes cluster and packaged as a single binary for ease of use. For more information on features, see the [k0s docs](https://docs.k0sproject.io/).
 
 <br />
 :::warning

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/k0s.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/k0s.mdx
@@ -1,6 +1,6 @@
 ---
 title: k0s
-sidebar_label: k0s
+sidebar_label: K0s
 sidebar_position: 3
 description: Configure k0s as the distro for the virtual cluster.
 ---
@@ -12,7 +12,7 @@ import K0sCompat from '@site/vcluster/_fragments/distro/compat-k0s.mdx'
 Support for **K0s** is deprecated in vCluster `v0.25` and removed in `v0.26`. Migration to a supported Kubernetes distribution is recommended.
 :::
 
-[Zero Friction Kubernetes (k0s)](https://k0sproject.io/) is an all-inclusive Kubernetes distribution, which is configured with all of the features needed to build a Kubernetes cluster and packaged as a single binary for ease of use. For more information on features, see the [k0s docs](https://docs.k0sproject.io/).
+[Zero Friction Kubernetes (K0s)](https://k0sproject.io/) is an all-inclusive Kubernetes distribution, which is configured with all of the features needed to build a Kubernetes cluster and packaged as a single binary for ease of use. For more information on features, see the [k0s docs](https://docs.k0sproject.io/).
 
 <br />
 :::warning

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/k3s.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/k3s.mdx
@@ -12,7 +12,7 @@ import K3sCompat from '@site/vcluster/_fragments/distro/compat-k3s.mdx'
 Support for **K3s** is deprecated. Migration to a supported Kubernetes distribution is recommended.
 :::
 
-[Lightweight Kubernetes (K3s)](https://k3s.io) is a highly available, certified Kubernetes distribution designed for production workloads in unattended, resource-constrained, remote locations or inside IoT appliances. For more information on features, see the [K3s docs](https://docs.k3s.io/).
+[Lightweight Kubernetes (K3s)](https://k3s.io) is a highly available, certified Kubernetes distribution designed for production workloads in unattended, resource-constrained, remote locations or inside IoT appliances. For more information on features, see the [K3s documentation](https://docs.k3s.io/).
 
 To use K3s with default deployment options, add the following to your `vcluster.yaml` config file:
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/k3s.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/k3s.mdx
@@ -8,6 +8,10 @@ description: Configure K3s as the distro for the virtual cluster.
 import DistroK3s from '../../../../../_partials/config/controlPlane/distro/k3s.mdx'
 import K3sCompat from '@site/vcluster/_fragments/distro/compat-k3s.mdx'
 
+:::warning Deprecation notice
+Support for **K3s** is deprecated. Migration to a supported Kubernetes distribution is recommended.
+:::
+
 [Lightweight Kubernetes (K3s)](https://k3s.io) is a highly available, certified Kubernetes distribution designed for production workloads in unattended, resource-constrained, remote locations or inside IoT appliances. See the [K3s docs](https://docs.k3s.io/) for K3s' features.
 
 To use K3s with default deployment options, add the following to your `vcluster.yaml` config file:

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/k3s.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/k3s.mdx
@@ -1,6 +1,6 @@
 ---
 title: Lightweight Kubernetes K3s
-sidebar_label: k3s
+sidebar_label: K3s
 sidebar_position: 2
 description: Configure K3s as the distro for the virtual cluster.
 ---
@@ -12,7 +12,7 @@ import K3sCompat from '@site/vcluster/_fragments/distro/compat-k3s.mdx'
 Support for **K3s** is deprecated. Migration to a supported Kubernetes distribution is recommended.
 :::
 
-[Lightweight Kubernetes (K3s)](https://k3s.io) is a highly available, certified Kubernetes distribution designed for production workloads in unattended, resource-constrained, remote locations or inside IoT appliances. See the [K3s docs](https://docs.k3s.io/) for K3s' features.
+[Lightweight Kubernetes (K3s)](https://k3s.io) is a highly available, certified Kubernetes distribution designed for production workloads in unattended, resource-constrained, remote locations or inside IoT appliances. For more information on features, see the [K3s docs](https://docs.k3s.io/).
 
 To use K3s with default deployment options, add the following to your `vcluster.yaml` config file:
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
@@ -1,6 +1,6 @@
 ---
 title: Kubernetes distro
-sidebar_label: k8s
+sidebar_label: K8s
 sidebar_position: 1
 description: Configure Kubernetes as the distro for the virtual cluster.
 ---


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Add deprecation not for k0s and k3s


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

[Link to Preview](https://deploy-preview-656--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/control-plane/)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-577

