### PR TITLE
fix: make docs page footer smaller

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -251,7 +251,8 @@ const config = {
         style: "light",
         links: [
           {
-            title: "Contribute",
+            // Use a non-breaking space to prevent any title from showing
+            title: "\u00A0",
             items: [
               {
                 html: `
@@ -268,7 +269,7 @@ const config = {
                 `
               }
             ]
-          }
+          },
         ],
         copyright: `Copyright © ${
           new Date().getFullYear()

--- a/src/css/footer.scss
+++ b/src/css/footer.scss
@@ -1,44 +1,54 @@
 .footer {
-  padding-top: 0.375rem !important;
-  padding-bottom: 0.375rem !important;
-  font-size: 0.9rem;
+  padding-top: 0.1rem !important;
+  padding-bottom: 0.1rem !important;
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+  font-size: 0.85rem;
+  line-height: 1.2;
 }
 
-/* Footer icon links */
+.footer .container {
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+  margin: 0 !important;
+}
+
 .footer-create-link:before {
   content: "";
-  margin-right: 8px;
-  width: 20px;
-  height: 20px;
-  display: flex;
+  margin-right: 6px;
+  width: 16px;  /* Smaller width */
+  height: 16px; /* Smaller height */
+  display: inline-flex;
   background-image: url('/img/create-doc-icon.svg');
   background-repeat: no-repeat;
-  background-position: center center;
+  background-position: center;
   background-size: contain;
 }
 
 .footer-devpod-link:before {
   content: "";
-  margin-right: 8px;
-  width: 20px;
-  height: 20px;
-  display: flex;
+  margin-right: 6px;
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
   background-image: url('/img/devpod-icon.svg');
   background-repeat: no-repeat;
-  background-position: center center;
+  background-position: center;
   background-size: contain;
 }
 
-.footer-create-link, 
+.footer-create-link,
 .footer-devpod-link {
   display: flex;
   align-items: center;
-  color: var(--ifm-color-gray-700);
-  margin-bottom: 12px;
+  font-size: 0.85rem;
   font-weight: 500;
+  color: var(--ifm-color-gray-700);
+  margin-bottom: 4px;
+  padding: 0 !important;
 }
 
-.footer-create-link:hover, 
+.footer-create-link:hover,
 .footer-devpod-link:hover {
   color: var(--ifm-color-primary);
   text-decoration: none;

--- a/src/css/footer.scss
+++ b/src/css/footer.scss
@@ -1,9 +1,15 @@
+.footer {
+  padding-top: 0.5rem !important;
+  padding-bottom: 0.5rem !important;
+  font-size: 0.9rem;
+}
+
 /* Footer icon links */
 .footer-create-link:before {
   content: "";
   margin-right: 8px;
-  width: 24px;
-  height: 24px;
+  width: 20px;
+  height: 20px;
   display: flex;
   background-image: url('/img/create-doc-icon.svg');
   background-repeat: no-repeat;
@@ -14,8 +20,8 @@
 .footer-devpod-link:before {
   content: "";
   margin-right: 8px;
-  width: 24px;
-  height: 24px;
+  width: 20px;
+  height: 20px;
   display: flex;
   background-image: url('/img/devpod-icon.svg');
   background-repeat: no-repeat;

--- a/src/css/footer.scss
+++ b/src/css/footer.scss
@@ -16,12 +16,12 @@
 .footer-create-link:before {
   content: "";
   margin-right: 6px;
-  width: 16px;  /* Smaller width */
-  height: 16px; /* Smaller height */
+  width: 16px;
+  height: 16px;
   display: inline-flex;
   background-image: url('/img/create-doc-icon.svg');
   background-repeat: no-repeat;
-  background-position: center;
+  background-position: center center;
   background-size: contain;
 }
 
@@ -33,7 +33,7 @@
   display: inline-flex;
   background-image: url('/img/devpod-icon.svg');
   background-repeat: no-repeat;
-  background-position: center;
+  background-position: center center;
   background-size: contain;
 }
 

--- a/src/css/footer.scss
+++ b/src/css/footer.scss
@@ -1,55 +1,141 @@
 .footer {
-  padding-top: 0.1rem !important;
-  padding-bottom: 0.1rem !important;
-  margin-top: 0 !important;
-  margin-bottom: 0 !important;
-  font-size: 0.85rem;
+  padding: 0.7rem 0;  /* Increased vertical padding for more height */
+  font-size: 0.8rem;
   line-height: 1.2;
+  background-color: #f5f6f7;
 }
 
 .footer .container {
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
-  margin: 0 !important;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 1.5rem;  /* Increased horizontal padding */
+  overflow: visible; /* Ensure content doesn't get clipped */
 }
 
+/* Reset Docusaurus default column styles */
+.footer__links {
+  display: flex;
+  width: auto;
+  margin-bottom: 0;
+}
+
+.footer__col {
+  padding: 0;
+  display: flex;
+  flex-direction: row;
+}
+
+/* Fix spacing of links column to remove space for title */
+.footer__links {
+  column-gap: 0;
+}
+
+/* Completely hide the footer title section */
+.footer__title {
+  display: none !important;
+  visibility: hidden !important;
+  width: 0 !important;
+  height: 0 !important;
+  overflow: hidden !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+.footer__items {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0 0 1rem; /* Only add padding to the left */
+}
+
+/* Create a horizontal layout for links */
+.footer__item {
+  display: inline-block;
+  margin-right: 1.5rem;
+}
+
+/* Icon styles for footer links */
 .footer-create-link:before {
   content: "";
-  margin-right: 6px;
-  width: 16px;
-  height: 16px;
-  display: inline-flex;
+  margin-right: 8px; /* Slightly increased spacing between icon and text */
+  width: 14px;
+  height: 14px;
+  display: inline-block;
   background-image: url('/img/create-doc-icon.svg');
   background-repeat: no-repeat;
   background-position: center center;
   background-size: contain;
+  vertical-align: middle;
 }
 
 .footer-devpod-link:before {
   content: "";
   margin-right: 6px;
-  width: 16px;
-  height: 16px;
-  display: inline-flex;
+  width: 14px;
+  height: 14px;
+  display: inline-block;
   background-image: url('/img/devpod-icon.svg');
   background-repeat: no-repeat;
   background-position: center center;
   background-size: contain;
+  vertical-align: middle;
 }
 
+/* Style for footer links */
 .footer-create-link,
 .footer-devpod-link {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
   font-weight: 500;
-  color: var(--ifm-color-gray-700);
-  margin-bottom: 4px;
-  padding: 0 !important;
+  color: #555;
+  white-space: nowrap;
+  padding: 0.25rem 0;  /* Added vertical padding to increase clickable area */
 }
 
 .footer-create-link:hover,
 .footer-devpod-link:hover {
   color: var(--ifm-color-primary);
   text-decoration: none;
+}
+
+/* Style for copyright text */
+.footer__copyright {
+  font-size: 0.75rem;
+  color: #666;
+  text-align: right;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  height: 100%;
+}
+
+/* Make footer responsive */
+@media (max-width: 996px) {
+  .footer .container {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  
+  .footer__links {
+    margin-bottom: 0.5rem;
+    flex-direction: column;
+  }
+  
+  .footer__items {
+    display: flex;
+    flex-direction: column;
+    margin-top: 0.3rem;
+  }
+  
+  .footer__item {
+    margin-bottom: 0.3rem;
+  }
+  
+  .footer__copyright {
+    margin-top: 0.5rem;
+    text-align: left;
+  }
 }

--- a/src/css/footer.scss
+++ b/src/css/footer.scss
@@ -1,6 +1,6 @@
 .footer {
-  padding-top: 0.5rem !important;
-  padding-bottom: 0.5rem !important;
+  padding-top: 0.375rem !important;
+  padding-bottom: 0.375rem !important;
   font-size: 0.9rem;
 }
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

- Reduce footer for docs site


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

[Link to Preview](https://deploy-preview-657--vcluster-docs-site.netlify.app/docs/)


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-606

