### PR TITLE
fix: image refs for images.txt

### DIFF
--- a/vcluster/configure/vcluster-yaml/control-plane/other/advanced/default-image-registry.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/other/advanced/default-image-registry.mdx
@@ -19,7 +19,7 @@ controlPlane:
 
 vCluster prepends the image registry to all images used by vCluster, such as syncer, K3s, and CoreDNS. For example, `rancher/k3s:v1.29.1+k3s2` becomes `my-private-registry:5000/vcluster/rancher/k3s:v1.29.1+k3s2`.
 
-You can find a list of all needed images by vCluster in the file images.txt at the releases page, as well as two scripts (download-images.sh & push-images.sh) to pull and push those to your private registry.
+You can find a list of all needed images by vCluster in the file `images.txt` at the releases page, as well as two scripts (`download-images.sh` and `push-images.sh`) to pull and push those to your private registry.
 
 To use your private registry, you need to [configure `imagePullSecrets`](./service-account.mdx).
 

--- a/vcluster/configure/vcluster-yaml/control-plane/other/advanced/default-image-registry.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/other/advanced/default-image-registry.mdx
@@ -19,7 +19,7 @@ controlPlane:
 
 vCluster prepends the image registry to all images used by vCluster, such as syncer, K3s, and CoreDNS. For example, `rancher/k3s:v1.29.1+k3s2` becomes `my-private-registry:5000/vcluster/rancher/k3s:v1.29.1+k3s2`.
 
-You can find a list of all needed images by vCluster in the file vcluster-images.txt at the releases page, as well as two scripts (download-images.sh & push-images.sh) to pull and push those to your private registry.
+You can find a list of all needed images by vCluster in the file images.txt at the releases page, as well as two scripts (download-images.sh & push-images.sh) to pull and push those to your private registry.
 
 To use your private registry, you need to [configure `imagePullSecrets`](./service-account.mdx).
 

--- a/vcluster/configure/vcluster-yaml/control-plane/other/advanced/default-image-registry.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/other/advanced/default-image-registry.mdx
@@ -26,7 +26,7 @@ To use your private registry, you need to [configure `imagePullSecrets`](./servi
 {/*
 `advanced.defaultImageRegistry`:
 - existing docs covers this well, however it may be needed to configure the vCluster service account with a pullSecret to use the private registry. See [this issue](https://github.com/loft-sh/vcluster/issues/333)
-- multiple default image registries are not supported, and instead users will need to override each image, see [this issue](https://github.com/loft-sh/vcluster/issues/1200)
+- multiple default image registries are not supported, and instead users need to override each image, see [this issue](https://github.com/loft-sh/vcluster/issues/1200)
 */}
 
 ## Config reference

--- a/vcluster/deploy/topologies/air-gapped.mdx
+++ b/vcluster/deploy/topologies/air-gapped.mdx
@@ -82,7 +82,7 @@ to deploy the vCluster control plane.
 
 For clusters unable to pull images from Docker Hub, you need to push the
 platform images to your private registry. Each vCluster release includes a
-`vcluster-images.txt` file that lists the necessary images.
+`images.txt` file that lists the necessary images.
 
 :::warning
 When using virtual clusters in air-gapped environments, the
@@ -124,19 +124,19 @@ Set environment variables for the setup process:
 </Step>
   <Step>
 
-Download the `vcluster-images.txt` file and the required scripts
+Download the `images.txt` file and the required scripts
 `download-images.sh` and `push-images.sh`, then make them executable.
 
 :::tip
 Note that the
-`vcluster-images.txt` contains all the distros and versions. You can edit the
+`images.txt` contains all the distros and versions. You can edit the
 file and remove images you do not need.
 Each release also has a corresponding `vcluster-images-k8s-[version].txt` file,
 use it to download k8s distro images for the desired version.
 :::
 
 ```bash title="Download and prepare scripts"
-wget https://github.com/loft-sh/vcluster/releases/download/v"${VERSION}"/vcluster-images.txt
+wget https://github.com/loft-sh/vcluster/releases/download/v"${VERSION}"/images.txt
 wget https://github.com/loft-sh/vcluster/releases/download/v"${VERSION}"/download-images.sh
 wget https://github.com/loft-sh/vcluster/releases/download/v"${VERSION}"/push-images.sh
 
@@ -150,7 +150,7 @@ chmod +x ./push-images.sh
 Run `download-images.sh` to download all images locally:
 
 ```bash title="Download images"
-./download-images.sh --image-list vcluster-images.txt
+./download-images.sh --image-list images.txt
 ```
 
 :::tip


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Update instances `vcluster-images.txt` to `images.txt`
- I do not see `vcluster-optional-images.txt` in the doc set so did not replace this. Also only applied this to v.25. Not sure if this needs to back ported


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

[Link to Preview](https://deploy-preview-659--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/control-plane/other/advanced/default-image-registry)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-535

