### PR TITLE
fix: add sleepMode to configReference

### DIFF
--- a/vcluster/configure/vcluster-yaml/README.mdx
+++ b/vcluster/configure/vcluster-yaml/README.mdx
@@ -12,6 +12,7 @@ import Networking from '../../_partials/config/networking.mdx'
 import Policies from '../../_partials/config/policies.mdx'
 import ControlPlane from '../../_partials/config/controlPlane.mdx'
 import RBAC from '../../_partials/config/rbac.mdx'
+import SleepMode from '../../_partials/config/sleepMode.mdx'
 import Plugins from '../../_partials/config/plugins.mdx'
 import Experimental from '../../_partials/config/experimental.mdx'
 import Telemetry from '../../_partials/config/telemetry.mdx'
@@ -44,6 +45,7 @@ The `vcluster.yaml` file holds your vCluster configuration and can override the 
 <Policies/>
 <ControlPlane/>
 <RBAC/>
+<SleepMode/>
 <Plugins/>
 <Experimental/>
 <External />

--- a/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/README.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/configure/vcluster-yaml/README.mdx
@@ -12,6 +12,7 @@ import Networking from '../../_partials/config/networking.mdx'
 import Policies from '../../_partials/config/policies.mdx'
 import ControlPlane from '../../_partials/config/controlPlane.mdx'
 import RBAC from '../../_partials/config/rbac.mdx'
+import SleepMode from '../../_partials/config/sleepMode.mdx'
 import Plugins from '../../_partials/config/plugins.mdx'
 import Experimental from '../../_partials/config/experimental.mdx'
 import Telemetry from '../../_partials/config/telemetry.mdx'
@@ -44,6 +45,7 @@ The `vcluster.yaml` file holds your vCluster configuration and can override the 
 <Policies/>
 <ControlPlane/>
 <RBAC/>
+<SleepMode />
 <Plugins/>
 <Experimental/>
 <External />


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[main Preview](https://deploy-preview-660--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/#config-reference)
[0.24 Preview](https://deploy-preview-660--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml/#config-reference)


## Internal Reference
Closes DOC-612

