### PR TITLE
feat(migration): k3s->k8s migration guide

### DIFF
--- a/vcluster/deploy/upgrade/distro-migration.mdx
+++ b/vcluster/deploy/upgrade/distro-migration.mdx
@@ -114,7 +114,7 @@ vcluster --upgrade my-vcluster --values vcluster.yaml
 
 After a successful migration, the control plane pod uses the Kubernetes distro instead of K3s. You can verify this by checking the container image of the control plane pod, which now shows a Kubernetes image.
 
-### Clean up K3s resources {#clean-up-K3s-resources}
+### Clean up k3s resources {#clean-up-k3s-resources}
 
 The migration process preserves the K3s configuration and certificates on the control plane pod. These resources are located in specific directories on the control plane pod and are safe to delete once you've confirmed the migration was successful:
 

--- a/vcluster/deploy/upgrade/distro-migration.mdx
+++ b/vcluster/deploy/upgrade/distro-migration.mdx
@@ -1,13 +1,13 @@
 ---
-title: Migrate from k3s to Kubernetes
-sidebar_label: k3s to k8s Migration
+title: Migrate from K3s to Kubernetes
+sidebar_label: K3s to K8s Migration
 sidebar_position: 2.2
-description: Learn how to migrate your virtual clusters from k3s distro to Kubernetes (k8s) distro.
+description: Learn how to migrate virtual clusters from the K3s distribution to Kubernetes (K8s)
 ---
 
 import BasePrerequisites from '../../../docs/_partials/base-prerequisites.mdx';
 
-Starting with vCluster 0.25.0, you can migrate an existing virtual cluster from k3s distro to Kubernetes (k8s) distro. This feature allows you to benefit from the full Kubernetes implementation while preserving your existing workloads and configuration.
+Starting in vCluster 0.25.0, you can migrate virtual clusters from the K3s distribution to the standard Kubernetes (K8s) distribution. This migration gives you access to the full Kubernetes feature set while preserving your existing workloads and configuration.
 
 ## Prerequisites {#prerequisites}
 
@@ -15,11 +15,11 @@ Starting with vCluster 0.25.0, you can migrate an existing virtual cluster from 
 
 Additionally, you need:
 - `vCluster` CLI version 0.25.0 or higher
-- An existing virtual cluster using k3s distro
+- An existing virtual cluster using K3s distro
 
 ## Migration process {#migration-process}
 
-The migration happens automatically when you change the distro from k3s to k8s during an upgrade. There are two supported methods for initiating the migration:
+The migration is triggered automatically when changing the distribution from K3s to Kubernetes (K8s) during an upgrade. Two supported methods are available for starting this migration:
 
 1. Using the CLI with direct flags (`--distro=k8s`)
 <!-- vale off -->
@@ -32,11 +32,11 @@ Both approaches trigger the same underlying migration process. Choose the method
 
 Regardless of the method you choose, the vCluster system performs these actions during migration:
 
-- Detects that you are switching from k3s to k8s
-- Copies all relevant certificates and configuration from k3s paths to k8s paths
+- Detects that you are switching from K3s to K8s
+- Copies all relevant certificates and configuration from K3s paths to K8s paths
 - Preserves database content (for both SQLite and embedded etcd backing stores)
 - Adds an annotation to prevent accidental re-migration
-- Launches the new control plane with k8s distro
+- Launches the new control plane with K8s distro
 
 ```mermaid
 sequenceDiagram
@@ -44,8 +44,8 @@ sequenceDiagram
     participant CLI as vCluster CLI
     participant CP as Control Plane
 
-    User->>CLI: vcluster --upgrade my-vcluster --distro=k8s
-    CLI->>CP: Initiate distro migration (k3s → k8s)
+    User->>CLI: vcluster --upgrade my-vcluster --distro=K8s
+    CLI->>CP: Initiate distro migration (K3s → K8s)
     Note over CP: Migration process
     CP-->>CP: 1. Preserve workloads & data
     CP-->>CP: 2. Copy certificates & configs
@@ -53,10 +53,10 @@ sequenceDiagram
     CP->>User: Migration complete
 ```
 
-All your existing workloads, services, and resources remain available after migration without interruption. Both migration methods are covered in detail in the [Migrate a virtual cluster](#migrate-a-virtual-cluster) section below.
+All your existing workloads, services, and resources remain available after migration without interruption. Both migration methods are covered in detail in the [Migrate a virtual cluster](#migrate-a-virtual-cluster) section.
 
 :::warning Migration limitations
-The automated migration process only supports migrating from k3s to k8s distro. Migration between other distro types is not supported. Migration is one-way - you cannot migrate back from k8s to k3s.
+The automated migration process only supports moving from the K3s distro to the K8s distro. Migration between other distro types is not supported. This is a one-way process—migrating back from the K8s distro to K3s is not possible.
 :::
 
 ## Migrate a virtual cluster {#migrate-a-virtual-cluster}
@@ -65,10 +65,10 @@ The automated migration process only supports migrating from k3s to k8s distro. 
 ### Use the vCluster CLI {#use-vcluster-cli}
 <!-- vale on -->
 
-You can migrate using the CLI by specifying the k8s distro during upgrade:
+You can migrate using the CLI by specifying the K8s distro during upgrade:
 
 ```bash title="Migrate using vcluster CLI"
-vcluster --upgrade my-vcluster --distro=k8s
+vcluster --upgrade my-vcluster --distro=K8s
 ```
 
 <!-- vale off -->
@@ -76,12 +76,12 @@ vcluster --upgrade my-vcluster --distro=k8s
 <!-- vale on -->
 
 <!-- vale off -->
-If you're managing your virtual cluster with a vcluster.yaml file, modify it to use k8s distro:
+If you're managing your virtual cluster with a vcluster.yaml file, modify it to use K8s distro:
 <!-- vale on -->
 
 Original configuration:
 
-```yaml title="Original vcluster.yaml with k3s"
+```yaml title="Original vcluster.yaml with K3s"
 controlPlane:
   distro:
     k3s:
@@ -90,7 +90,7 @@ controlPlane:
 
 New configuration:
 
-```yaml title="Updated vcluster.yaml with k8s"
+```yaml title="Updated vcluster.yaml with K8s"
 controlPlane:
   distro:
     k8s:
@@ -103,30 +103,30 @@ Then apply the changes:
 vcluster --upgrade my-vcluster --values vcluster.yaml
 ```
 
-## Important notes {#important-notes}
-
-- Migration is one-way: you cannot migrate back from k8s to k3s
-- The k3s-specific resources and directories are preserved after migration for safety
+:::important Migration considerations
+- Migration is one-way: you cannot migrate back from K8s to K3s
+- The K3s-specific resources and directories are preserved after migration for safety
 - Migration supports both SQLite and embedded etcd backing stores
 - High-availability configurations are fully supported
+:::
 
 ## After migration {#after-migration}
 
-After a successful migration, the control plane pod uses the Kubernetes distro instead of k3s. You can verify this by checking the container image of the control plane pod, which now shows a Kubernetes image.
+After a successful migration, the control plane pod uses the Kubernetes distro instead of K3s. You can verify this by checking the container image of the control plane pod, which now shows a Kubernetes image.
 
-### Clean up k3s resources {#clean-up-k3s-resources}
+### Clean up K3s resources {#clean-up-K3s-resources}
 
-The migration process preserves the k3s configuration and certificates on the control plane pod. These resources are located in specific directories on the control plane pod and are safe to delete once you've confirmed the migration was successful:
+The migration process preserves the K3s configuration and certificates on the control plane pod. These resources are located in specific directories on the control plane pod and are safe to delete once you've confirmed the migration was successful:
 
-```bash title="k3s resource directories on the control plane pod"
-/data/k3s-config    # Contains the k3s kubeconfig and other configuration files
-/data/agent         # Contains k3s agent credentials, certificates and keys
+```bash title="K3s resource directories on the control plane pod"
+/data/k3s-config    # Contains the K3s kubeconfig and other configuration files
+/data/agent         # Contains K3s agent credentials, certificates and keys
 ```
 
 You can remove these directories using a kubectl exec command:
 
-```bash title="Removing k3s resources after successful migration"
-kubectl exec -n <vcluster-namespace> <vcluster-control-plane-pod> -- rm -rf /data/k3s-config /data/agent
+```bash title="Removing K3s resources after successful migration"
+kubectl exec -n <vcluster-namespace> <vcluster-control-plane-pod> -- rm -rf /data/K3s-config /data/agent
 ```
 
 :::tip
@@ -146,4 +146,4 @@ If you encounter issues during migration, check the control plane pod logs for e
 kubectl logs -n <namespace> <vcluster-control-plane-pod> -c syncer
 ```
 
-Look for log entries that include "Migrating k3s distro certificates to k8s" to trace the migration process.
+Look for log entries that include "Migrating K3s distro certificates to K8s" to trace the migration process.

--- a/vcluster/deploy/upgrade/distro-migration.mdx
+++ b/vcluster/deploy/upgrade/distro-migration.mdx
@@ -114,7 +114,7 @@ vcluster --upgrade my-vcluster --values vcluster.yaml
 
 After a successful migration, the control plane pod uses the Kubernetes distro instead of K3s. You can verify this by checking the container image of the control plane pod, which now shows a Kubernetes image.
 
-### Clean up k3s resources {#clean-up-k3s-resources}
+### Clean up K3s resources {#clean-up-k3s-resources}
 
 The migration process preserves the K3s configuration and certificates on the control plane pod. These resources are located in specific directories on the control plane pod and are safe to delete once you've confirmed the migration was successful:
 

--- a/vcluster/deploy/upgrade/distro-migration.mdx
+++ b/vcluster/deploy/upgrade/distro-migration.mdx
@@ -1,0 +1,149 @@
+---
+title: Migrate from k3s to Kubernetes
+sidebar_label: k3s to k8s Migration
+sidebar_position: 2.2
+description: Learn how to migrate your virtual clusters from k3s distro to Kubernetes (k8s) distro.
+---
+
+import BasePrerequisites from '../../../docs/_partials/base-prerequisites.mdx';
+
+Starting with vCluster 0.25.0, you can migrate an existing virtual cluster from k3s distro to Kubernetes (k8s) distro. This feature allows you to benefit from the full Kubernetes implementation while preserving your existing workloads and configuration.
+
+## Prerequisites {#prerequisites}
+
+<BasePrerequisites />
+
+Additionally, you need:
+- `vCluster` CLI version 0.25.0 or higher
+- An existing virtual cluster using k3s distro
+
+## Migration process {#migration-process}
+
+The migration happens automatically when you change the distro from k3s to k8s during an upgrade. There are two supported methods for initiating the migration:
+
+1. Using the CLI with direct flags (`--distro=k8s`)
+<!-- vale off -->
+2. Using a configuration file (vcluster.yaml) with updated Kubernetes distro settings
+<!-- vale on -->
+
+:::info Supported migration methods
+Both approaches trigger the same underlying migration process. Choose the method that best fits your workflow and preferences.
+:::
+
+Regardless of the method you choose, the vCluster system performs these actions during migration:
+
+- Detects that you are switching from k3s to k8s
+- Copies all relevant certificates and configuration from k3s paths to k8s paths
+- Preserves database content (for both SQLite and embedded etcd backing stores)
+- Adds an annotation to prevent accidental re-migration
+- Launches the new control plane with k8s distro
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant CLI as vCluster CLI
+    participant CP as Control Plane
+
+    User->>CLI: vcluster --upgrade my-vcluster --distro=k8s
+    CLI->>CP: Initiate distro migration (k3s → k8s)
+    Note over CP: Migration process
+    CP-->>CP: 1. Preserve workloads & data
+    CP-->>CP: 2. Copy certificates & configs
+    CP-->>CP: 3. Update paths & annotate
+    CP->>User: Migration complete
+```
+
+All your existing workloads, services, and resources remain available after migration without interruption. Both migration methods are covered in detail in the [Migrate a virtual cluster](#migrate-a-virtual-cluster) section below.
+
+:::warning Migration limitations
+The automated migration process only supports migrating from k3s to k8s distro. Migration between other distro types is not supported. Migration is one-way - you cannot migrate back from k8s to k3s.
+:::
+
+## Migrate a virtual cluster {#migrate-a-virtual-cluster}
+
+<!-- vale off -->
+### Use the vCluster CLI {#use-vcluster-cli}
+<!-- vale on -->
+
+You can migrate using the CLI by specifying the k8s distro during upgrade:
+
+```bash title="Migrate using vcluster CLI"
+vcluster --upgrade my-vcluster --distro=k8s
+```
+
+<!-- vale off -->
+### Use a vcluster.yaml file {#use-vcluster-yaml}
+<!-- vale on -->
+
+<!-- vale off -->
+If you're managing your virtual cluster with a vcluster.yaml file, modify it to use k8s distro:
+<!-- vale on -->
+
+Original configuration:
+
+```yaml title="Original vcluster.yaml with k3s"
+controlPlane:
+  distro:
+    k3s:
+      enabled: true
+```
+
+New configuration:
+
+```yaml title="Updated vcluster.yaml with k8s"
+controlPlane:
+  distro:
+    k8s:
+      enabled: true
+```
+
+Then apply the changes:
+
+```bash title="Apply the updated configuration"
+vcluster --upgrade my-vcluster --values vcluster.yaml
+```
+
+## Important notes {#important-notes}
+
+- Migration is one-way: you cannot migrate back from k8s to k3s
+- The k3s-specific resources and directories are preserved after migration for safety
+- Migration supports both SQLite and embedded etcd backing stores
+- High-availability configurations are fully supported
+
+## After migration {#after-migration}
+
+After a successful migration, the control plane pod uses the Kubernetes distro instead of k3s. You can verify this by checking the container image of the control plane pod, which now shows a Kubernetes image.
+
+### Clean up k3s resources {#clean-up-k3s-resources}
+
+The migration process preserves the k3s configuration and certificates on the control plane pod. These resources are located in specific directories on the control plane pod and are safe to delete once you've confirmed the migration was successful:
+
+```bash title="k3s resource directories on the control plane pod"
+/data/k3s-config    # Contains the k3s kubeconfig and other configuration files
+/data/agent         # Contains k3s agent credentials, certificates and keys
+```
+
+You can remove these directories using a kubectl exec command:
+
+```bash title="Removing k3s resources after successful migration"
+kubectl exec -n <vcluster-namespace> <vcluster-control-plane-pod> -- rm -rf /data/k3s-config /data/agent
+```
+
+:::tip
+Consider keeping these resources for some time after migration before deleting them. They can be useful for:
+- Troubleshooting any issues that might arise after migration
+- Providing a reference for certificate paths and configurations
+- Enabling potential recovery options if needed
+:::
+
+The storage impact of these directories is typically minimal, so there's usually no urgency to remove them immediately.
+
+## Troubleshoot migration issues {#troubleshoot-migration-issues}
+
+If you encounter issues during migration, check the control plane pod logs for error messages:
+
+```bash title="Check control plane logs"
+kubectl logs -n <namespace> <vcluster-control-plane-pod> -c syncer
+```
+
+Look for log entries that include "Migrating k3s distro certificates to k8s" to trace the migration process.

--- a/vcluster/deploy/upgrade/distro-migration.mdx
+++ b/vcluster/deploy/upgrade/distro-migration.mdx
@@ -105,7 +105,9 @@ vcluster my-vcluster --values vcluster.yaml
 
 After a successful migration, the control plane pod uses the Kubernetes distro instead of K3s. You can verify this by checking the container image of the control plane pod, which now shows a Kubernetes image.
 
+<!-- vale off -->
 ### Clean up K3s resources {#clean-up-k3s-resources}
+<!-- vale on -->
 
 The migration process preserves the K3s configuration and certificates on the control plane pod. These resources are located in specific directories on the control plane pod and are safe to delete once you've confirmed the migration was successful:
 

--- a/vcluster/deploy/upgrade/distro-migration.mdx
+++ b/vcluster/deploy/upgrade/distro-migration.mdx
@@ -19,18 +19,9 @@ Additionally, you need:
 
 ## Migration process {#migration-process}
 
-The migration is triggered automatically when changing the distribution from K3s to Kubernetes (K8s) during an upgrade. Two supported methods are available for starting this migration:
+The migration is triggered automatically when changing the distribution from K3s to Kubernetes (K8s) during an upgrade.
 
-1. Using the CLI with direct flags (`--distro=k8s`)
-<!-- vale off -->
-2. Using a configuration file (vcluster.yaml) with updated Kubernetes distro settings
-<!-- vale on -->
-
-:::info Supported migration methods
-Both approaches trigger the same underlying migration process. Choose the method that best fits your workflow and preferences.
-:::
-
-Regardless of the method you choose, the vCluster system performs these actions during migration:
+During migration process `vCluster` performs these actions:
 
 - Detects that you are switching from K3s to K8s
 - Copies all relevant certificates and configuration from K3s paths to K8s paths
@@ -100,7 +91,7 @@ controlPlane:
 Then apply the changes:
 
 ```bash title="Apply the updated configuration"
-vcluster --upgrade my-vcluster --values vcluster.yaml
+vcluster my-vcluster --values vcluster.yaml
 ```
 
 :::important Migration considerations

--- a/vcluster/deploy/upgrade/upgrade-version.mdx
+++ b/vcluster/deploy/upgrade/upgrade-version.mdx
@@ -15,9 +15,9 @@ configuration option changes.
 If you are moving from vCluster 0.19.x to 0.20+, see the [conversion guide](/vcluster/reference/migrations/0-20-migration) for how to automatically convert your existing `values.yaml` configuration file to the new `vcluster.yaml` format.
 <!-- vale on -->
 
-## (Optional) update `vcluster.yaml`
+## Update `vcluster.yaml`
 
-Update your `vcluster.yaml` to change your configuration options during a vCluster version upgrade.
+Optionally, you can update your `vcluster.yaml` to change your configuration options during a vCluster version upgrade.
 
 <p></p>
 :::warning Limitations on changing configuration

--- a/vcluster/deploy/upgrade/upgrade-version.mdx
+++ b/vcluster/deploy/upgrade/upgrade-version.mdx
@@ -11,17 +11,18 @@ configuration option changes.
 
 <p></p>
 
-:::tip
+<!-- vale off -->
 If you are moving from vCluster 0.19.x to 0.20+, see the [conversion guide](/vcluster/reference/migrations/0-20-migration) for how to automatically convert your existing `values.yaml` configuration file to the new `vcluster.yaml` format.
 :::
+<!-- vale on -->
 
 ## (Optional) update `vcluster.yaml`
 
 Update your `vcluster.yaml` to change your configuration options during a vCluster version upgrade.
 
 <p></p>
-:::warning
-Remember that you can't change distros or backing store once a vCluster is deployed.
+:::warning Limitations on changing configuration
+You cannot change distros or backing store once a virtual cluster is deployed, with one exception: starting with vCluster 0.25.0, migration from k3s to k8s distro is supported. See [k3s to k8s Migration](./distro-migration.mdx) for details.
 :::
 
 ## Upgrade vCluster version

--- a/vcluster/deploy/upgrade/upgrade-version.mdx
+++ b/vcluster/deploy/upgrade/upgrade-version.mdx
@@ -13,7 +13,6 @@ configuration option changes.
 
 <!-- vale off -->
 If you are moving from vCluster 0.19.x to 0.20+, see the [conversion guide](/vcluster/reference/migrations/0-20-migration) for how to automatically convert your existing `values.yaml` configuration file to the new `vcluster.yaml` format.
-:::
 <!-- vale on -->
 
 ## (Optional) update `vcluster.yaml`
@@ -22,15 +21,15 @@ Update your `vcluster.yaml` to change your configuration options during a vClust
 
 <p></p>
 :::warning Limitations on changing configuration
-You cannot change distros or backing store once a virtual cluster is deployed, with one exception: starting with vCluster 0.25.0, migration from k3s to k8s distro is supported. See [k3s to k8s Migration](./distro-migration.mdx) for details.
+You cannot change distros or backing store once a virtual cluster is deployed, with one exception: starting with vCluster 0.25.0, migration from K3s to K8s distro is supported. For more details, see the [K3s to K8s Migration](./distro-migration.mdx).
 :::
 
 ## Upgrade vCluster version
 
 These steps assume that you have been a `vcluster.yaml`, but there are variables in the code blocks for you to replace for:
 
-* Name of the virtual cluster
-* Namespace of where the virtual cluster is deployed
-* Version to upgrade to
+- Name of the virtual cluster
+- Namespace of where the virtual cluster is deployed
+- Version to upgrade to
 
 <UpgradeVersion />

--- a/vcluster/manage/deploy-changes.mdx
+++ b/vcluster/manage/deploy-changes.mdx
@@ -8,12 +8,12 @@ import DeployChanges from '../_partials/manage/deploy-changes.mdx'
 
 You can always introduce or update your `vcluster.yaml` and deploy new configuration options.
 
-The vCluster control plane pod will be re-deployed. 
+The vCluster control plane pod is going to be re-deployed.
 
 <p></p>
 
-:::warning 
-Remember that you can't change distros or backing store once a vCluster is deployed. 
+:::warning Limitations on changing configuration
+You cannot change distros or backing store once a virtual cluster is deployed, with one exception: starting with vCluster 0.25.0, migration from k3s to k8s distro is supported. See [k3s to k8s Migration](/vcluster/deploy/upgrade/distro-migration.mdx) for details.
 :::
 
 <DeployChanges />

--- a/vcluster/manage/deploy-changes.mdx
+++ b/vcluster/manage/deploy-changes.mdx
@@ -13,7 +13,7 @@ The vCluster control plane pod is going to be re-deployed.
 <p></p>
 
 :::warning Limitations on changing configuration
-You cannot change distros or backing store once a virtual cluster is deployed, with one exception: starting with vCluster 0.25.0, migration from k3s to k8s distro is supported. See [k3s to k8s Migration](/vcluster/deploy/upgrade/distro-migration.mdx) for details.
+You cannot change distros or backing store once a virtual cluster is deployed, with one exception: starting with vCluster 0.25.0, migration from K3s to K8s distro is supported. For more details, see the [K3s to K8s migration guide](/vcluster/deploy/upgrade/distro-migration.mdx).
 :::
 
 <DeployChanges />


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Migration guide from k3s to regular Kuberentes distro.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-663--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/upgrade/distro-migration
https://deploy-preview-663--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/upgrade/upgrade-version#optional-update-vclusteryaml
https://deploy-preview-663--vcluster-docs-site.netlify.app/docs/vcluster/next/manage/deploy-changes

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-574

