### PR TITLE
feat: Add additional permanent redirects for the platform UI

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -106,6 +106,24 @@ command = """
 
 ## Misc. platform links
 
+# Database connector
+[[redirects]]
+from = "/docs/platform-ui-link/platform/database-connector"
+to = "/docs/platform/administer/connector/database"
+
+[[redirects]]
+from = "/docs/platform-ui-link/platform/database-connector/:version"
+to = "/docs/platform/:version/administer/connector/database"
+
+# Permissions overview
+[[redirects]]
+from = "/docs/platform-ui-link/platform/permissions-overview"
+to = "/docs/platform/administer/users-permissions/overview"
+
+[[redirects]]
+from = "/docs/platform-ui-link/platform/permissions-overview/:version"
+to = "/docs/platform/:version/administer/users-permissions/overview"
+
 # OIDC tutorial
 [[redirects]]
   from = "/docs/platform-ui-link/platform/how-to-oidc-provider"
@@ -189,13 +207,22 @@ command = """
 
 ## Misc. vCluster links
 
+# Migrate vCluster configuration / Backup and Restore
+[[redirects]]
+from = "/docs/platform-ui-link/vcluster/backup-restore-migration"
+to = "/docs/vcluster/manage/backup-restore#migrate-and-override-vcluster-configuration-options-to-create-a-new-vcluster"
+
+[[redirects]]
+from = "/docs/platform-ui-link/vcluster/backup-restore-migration/:version"
+to = "/docs/vcluster/:version/manage/backup-restore#migrate-and-override-vcluster-configuration-options-to-create-a-new-vcluster"
+
 # Control Plane
 [[redirects]]
-  from = "/docs/platform-ui-link/platform/control-plane"
+  from = "/docs/platform-ui-link/vcluster/control-plane"
   to = "/docs/vcluster/category/components"
 
 [[redirects]]
-  from = "/docs/platform-ui-link/platform/control-plane/:version"
+  from = "/docs/platform-ui-link/vcluster/control-plane/:version"
   to = "/docs/vcluster/:version/category/components"
 
 # Resource quota
@@ -214,7 +241,7 @@ command = """
 
 [[redirects]]
   from = "/docs/platform-ui-link/vcluster/0-20-migration/:version"
-  to = "/docs/vcluster/:version0/reference/migrations/0-20-migration"
+  to = "/docs/vcluster/:version/reference/migrations/0-20-migration"
 
 # Sync from host
 [[redirects]]


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description

This adds two new redirects for docs links in the platform UI.

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-419

