### PR TITLE
fix: update compatibility matrix with 1.33

### DIFF
--- a/vcluster/deploy/upgrade/supported_versions.mdx
+++ b/vcluster/deploy/upgrade/supported_versions.mdx
@@ -29,40 +29,48 @@ Kubernetes versions that are no longer supported upstream can still be used but 
 <!-- Markdown does not support merged cells (colspan/rowspan), so using HTML for visual formatting instead. -->
 
 <table>
-  <tr>
-    <th rowspan="2">Host Cluster Kubernetes Version</th>
-    <th colspan="3">vCluster Kubernetes Version</th>
-  </tr>
-  <tr>
-    <th>v1.33</th>
-    <th>v1.32</th>
-    <th>v1.31</th>
-    <th>v1.30</th>
-  </tr>
-  <tr>
-    <td><b>v1.33</b></td>
-    <td>🆗</td>
-    <td>🆗</td>
-    <td>🆗</td>
-  </tr>
-  <tr>
-    <td><b>v1.32</b></td>
-    <td>✅</td>
-    <td>🆗</td>
-    <td>🆗</td>
-  </tr>
-  <tr>
-    <td><b>v1.31</b></td>
-    <td>🆗</td>
-    <td>✅</td>
-    <td>🆗</td>
-  </tr>
-  <tr>
-    <td><b>v1.30</b></td>
-    <td>🆗</td>
-    <td>🆗</td>
-    <td>✅</td>
-  </tr>
+  <thead>
+    <tr>
+      <th rowspan="2">Host Cluster Kubernetes Version</th>
+      <th colspan="4">vCluster Kubernetes Version</th>
+    </tr>
+    <tr>
+      <th>v1.33</th>
+      <th>v1.32</th>
+      <th>v1.31</th>
+      <th>v1.30</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><b>v1.33</b></td>
+      <td>🆗</td>
+      <td>🆗</td>
+      <td>🆗</td>
+      <td>🆗</td>
+    </tr>
+    <tr>
+      <td><b>v1.32</b></td>
+      <td>✅</td>
+      <td>🆗</td>
+      <td>🆗</td>
+      <td>🆗</td>
+    </tr>
+    <tr>
+      <td><b>v1.31</b></td>
+      <td>🆗</td>
+      <td>✅</td>
+      <td>🆗</td>
+      <td>🆗</td>
+    </tr>
+    <tr>
+      <td><b>v1.30</b></td>
+      <td>🆗</td>
+      <td>🆗</td>
+      <td>✅</td>
+      <td>🆗</td>
+    </tr>
+  </tbody>
 </table>
 
 - ✅ **Tested and verified** – Officially tested and supported.

--- a/vcluster/deploy/upgrade/supported_versions.mdx
+++ b/vcluster/deploy/upgrade/supported_versions.mdx
@@ -34,9 +34,16 @@ Kubernetes versions that are no longer supported upstream can still be used but 
     <th colspan="3">vCluster Kubernetes Version</th>
   </tr>
   <tr>
+    <th>v1.33</th>
     <th>v1.32</th>
     <th>v1.31</th>
     <th>v1.30</th>
+  </tr>
+  <tr>
+    <td><b>v1.33</b></td>
+    <td>🆗</td>
+    <td>🆗</td>
+    <td>🆗</td>
   </tr>
   <tr>
     <td><b>v1.32</b></td>

--- a/vcluster/deploy/upgrade/supported_versions.mdx
+++ b/vcluster/deploy/upgrade/supported_versions.mdx
@@ -28,6 +28,8 @@ Kubernetes versions that are no longer supported upstream can still be used but 
 
 <!-- Markdown does not support merged cells (colspan/rowspan), so using HTML for visual formatting instead. -->
 
+<br />
+
 <table>
   <thead>
     <tr>


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Add v1.33 for table.  


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

[Link to Preview](https://deploy-preview-672--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/upgrade/supported_versions#kubernetes-compatibility-matrix)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-613

