### PR TITLE
Docs for platform install using airgap and fixes for vcluster airgap and backport

### DIFF
--- a/platform/install/advanced/air-gapped.mdx
+++ b/platform/install/advanced/air-gapped.mdx
@@ -6,53 +6,306 @@ description: Learn how to install vCluster platform in air-gapped, offline, or V
 ---
 
 import Flow, { Step } from "@site/src/components/Flow";
-import PartialAdminSetVersion from "../../_partials/install/set-version.mdx";
-import PartialAdminUpgrade from "../../_partials/install/upgrade.mdx";
 import Mark from "@site/src/components/Mark";
 
 import BasePrerequisites from '../../_partials/install/base-prerequisites.mdx';
-import LoginAfterHelmInstall from '../../_partials/install/login-after-helm-install.mdx';
-import InstallNextSteps from '../../_partials/install/install-next-steps.mdx';
 import NetworkPorts from '../../_partials/install/open-ports.mdx';
 
+This document details the steps to install vCluster Platform and deploy virtual clusters onto Kubernetes clusters that don't have access to the internet. 
 
-If your cluster is air-gapped, within a VPC, or has restricted network connectivity, you may encounter issues validating the platform license and pulling required container images.
+## Pre-requisites
 
-To solve the licensing issue, you can either use allow HTTP requests from
-the platform pods to
-`https://admin.loft.sh/*` (this is the preferred option), or use an
-[offline license key](#offline-license-key).
+- **OCI-compliant private registry with a `/charts` folder** - A private registry accessible to both the Kubernetes cluster for the platform and connected host clusters and a separate, internet-connected machine.
+- **An offline license key for vCluster Platform** - A LoftLabs license key is required to install vCluster Platform.
+    :::info
+    Contact sales@loft.sh to purchase an offline license key or request a trial license key for offline use.
+    :::
 
-To address image pulling issues from Docker Hub, you can [use a private image
-registry](#offline-images) to host your own copies of the platform images
-accessible to your cluster.
+## Overview 
 
-To address pulling Helm charts from external chart registries, you can use an [OCI compatible private image registry](#offline-helm-charts) to
-host Helm charts.
+There are several artifacts that are typically accessed using an internet connection. Therefore, 
+to complete an air-gapped install, these artifacts need to be accessible by the Kubernetes cluster through a private registry.
 
-## Prerequisites
+- **vCluster Platform Helm chart** - This Helm chart is typically accessed through the LoftLabs charts repository and is used for installing vCluster Platform and connecting hosts (i.e. installing agents). 
+- **vCluster Helm chart** - This Helm chart is typically accessed through the LoftLabs charts repository and is used for deploying virtual clusters. 
+- **Images used in the helm charts**  - These images are typically accessed through different container registries. 
 
-<BasePrerequisites />
+After populating the registry with the artifacts, you'll install vCluster Platform, connect host clusters and then deploy virtual clusters. Each step will require
+additional configuration in order to use your private registry. 
 
--  A private Docker registry accessible to both the installer computer and the air-gapped Kubernetes cluster
+## Populate images to private registry
 
-### Optional prerequisites
+Each [vCluster Platform Github release](https://github.com/loft-sh/loft/releases) and [vCluster Github release](https://github.com/loft-sh/vcluster/releases) have multiple release assets that are available to help you upload images to the private registry. There are text files that contain
+the list of images needed for the release and two scripts that help pull and push these list of images. 
 
-- On the installation computer:
-  - `docker` (verify with `docker version`)
-  - An offline license key for the platform (provided by Loft)
+### Image text files
 
-### Supported Kubernetes versions
+In the [vCluster Platform release](https://github.com/loft-sh/loft/releases), there is a file that contains the names of the images needed to install vCluster Platform.
 
-- A running air-gapped Kubernetes cluster with one of the [supported versions](/docs/vcluster/deploy/upgrade/supported_versions#kubernetes-compatibility-matrix)
+* `images.txt` - The required images to install vCluster Platform.
 
-:::note
-Although the platform might work with other versions, using the supported versions is recommended to avoid potential issues.
+In vCluster v0.25.0+ releases, there are two files that contain the names of the images needed to deploy a vCluster. 
+
+* `images.txt` - The required images to run vCluster, which assumes using the default Kubernetes version.
+* `images-optional.txt` - An optional set of images to run vCluster using a different Kubernetes version.
+
+In vCluster < v0.25.0 releases, there is one file that contains the names of the images needed to deploy a vCluster. 
+
+* `vcluster-images.txt` - The images to run vCluster, which assumes using the default Kubernetes version.
+
+### Scripts to pull and push images
+
+Both product releases contain one script which helps download and package the list of images and another script that pushes images to the private registry. The script from either release can be used 
+to populate the registry. 
+
+The difference between the scripts in the different releases is the default name of the tarball that is created. These instructions will override the defaults to ensure
+the correct image text file and tarball is created. 
+
+* `download-images.sh` - A bash script that quickly iterates over all the images files to pull them and package them into a tarball to a machine that has internet access. 
+* `push-images.sh` - A bash script that takes the tarball generated from the download script to push them to your private registry. 
+
+:::tip 
+Though both releases have `download-images.sh` and `push-images.sh`, you only need to download them once. 
 :::
 
-### Resource requirements
+### Pre-requisites 
 
-- Pod Resource Requirements:
+- Access to the internet
+- Ability to push to your OCI-compliant private registry
+- Logged in to GitHub Container Registry
+- `wget` installed
+- `docker` installed 
+
+### Pull and push images for vCluster Platform 
+
+These steps are populating the registry for the specific images needed for vCluster Platform. 
+
+<Flow id="offline-platform-images">
+  <Step>
+  
+  Set environment variables for the version of vCluster Platform that you want to deploy and the private registry. 
+  
+        ```bash title="Export environment variables"
+        export PLATFORM_VERSION=4.3.0 # Replace with desired version
+        export REGISTRY=ecr.io/myteam # This should be a prefix; do not include any image paths
+        ```
+  </Step>
+  <Step>
+
+  Download the assets from the [vCluster Platform GitHub release](https://github.com/loft-sh/loft/releases) and make the scripts executable.
+
+  :::warning
+  The `images.txt` contains a `vcluster-pro` image for the default vCluster version, but doesn't contain all the images required
+  to deploy vCluster. An additional step is required to retrieve all vCluster images.
+  :::
+
+  ```bash title="Download assets and prepare scripts"
+  wget https://github.com/loft-sh/loft/releases/download/v${PLATFORM_VERSION}/loft-images.txt
+  wget https://github.com/loft-sh/loft/releases/download/v${PLATFORM_VERSION}/download-images.sh
+  wget https://github.com/loft-sh/loft/releases/download/v${PLATFORM_VERSION}/push-images.sh
+
+  chmod +x ./download-images.sh
+  chmod +x ./push-images.sh
+  ```
+
+  </Step>
+  <Step>
+
+  Run `download-images.sh` to pull all images and create a tarball of the images.
+
+  Review the output to confirm all images were pulled successfully and packaged in the tarball. 
+ 
+  ```bash title="Download and package images"
+  ./download-images.sh --image-list loft-images.txt --images loft-images.tar.gz
+  ```
+ 
+  </Step>
+  <Step>
+
+  Run `push-images.sh` to upload all required images to your private registry.
+
+  When pushing images into your private registry, the public private registry is removed and only the repository and image name are pushed. You can configure 
+  vCluster Platform to point to your private registry to use for all images used in installing vCluster Platform and connecting hosts.
+ 
+  
+  ```bash title="Push images to private registry"
+  ./push-images.sh --registry ${REGISTRY} --images loft-images.tar.gz
+  ```
+
+  </Step>
+</Flow>
+
+
+### Pull and push images for vCluster  
+
+These steps are populating the registry for the specific images needed for deploying vCluster. 
+
+<Flow id="offline-vcluster-images">
+  <Step>
+  
+  Set environment variables for the version of vCluster that you want to deploy and the private registry. 
+  
+  :::tip 
+  You can review the `tag` of the `vcluster-pro` image in the
+  `images.txt` to pick the default vCluster version. 
+  :::
+  
+    ```bash title="Export environment variables"
+    export VCLUSTER_VERSION=0.25.0 # Replace with desired version 
+    # Setting the REGISTRY environment is redundant from the steps in populating vCluster Platform images
+    # export REGISTRY=ecr.io/myteam # This should be a prefix; do not include any image paths
+    ```
+  </Step>
+  <Step>
+
+  Download the text files from the [vCluster GitHub release](https://github.com/loft-sh/vcluster/releases).
+  
+  The `images.txt` or `vcluster-images.txt` files contain multiple Kubernetes versions and distributions. You can edit the file and remove the images for any unwanted versions and distributions. 
+
+  ```bash title="Download image text file for vCluster v0.25.0+ versions"
+  wget https://github.com/loft-sh/vcluster/releases/download/v${VCLUSTER_VERSION}/images.txt
+  ```
+
+  ```bash title="Download image text file for vCluster < v0.25.0 versions"
+  wget https://github.com/loft-sh/vcluster/releases/download/v${VCLUSTER_VERSION}/vClusterimages.txt
+  ```
+
+  </Step>
+  <Step>
+
+  **Optional** Download the scripts from the [vCluster GitHub release](https://github.com/loft-sh/vcluster/releases) and make them executable. 
+  
+  If you've already down this as part of populating the vCluster Platform images, you can skip this step.
+
+  ```bash title="Download prepare scripts"
+   wget https://github.com/loft-sh/vcluster/releases/download/v${VCLUSTER_VERSION}/download-images.sh
+   wget https://github.com/loft-sh/vcluster/releases/download/v${VCLUSTER_VERSION}/push-images.sh
+   chmod +x ./download-images.sh
+   chmod +x ./push-images.sh
+  ```
+
+  </Step>
+  <Step>
+
+  Run `download-images.sh` to pull all images and create a tarball of the images.
+  
+  Review the output to confirm all images were pulled successfully and packaged in the tarball. 
+ 
+  ```bash title="Download and package images for vCluster v0.25.0+ versions"
+  ./download-images.sh --image-list images.txt --images vcluster-images.tar.gz
+  ```
+  
+    ```bash title="Download and package images for vCluster < v0.25.0 versions"
+  ./download-images.sh --image-list vcluster-images.txt --images vcluster-images.tar.gz
+  ```
+
+  </Step>
+  <Step>
+
+  Run `push-images.sh` to upload all required images to your private registry.
+  
+  When pushing images into your private registry, the public private registry is removed and only the repository and image name are pushed. You can configure 
+  vCluster to point to your private registry to use for all images used in deploying vCluster.
+  
+  ```bash title="Push images to private registry"
+  ./push-images.sh --registry ${REGISTRY} --images vcluster-images.tar.gz
+  ```
+
+  </Step>
+
+  <Step>
+  **Optional**: If you want to deploy vCluster v0.25.0+ with a different Kubernetes version, download the `images-optional.txt` file from the [vCluster GitHub release](https://github.com/loft-sh/vcluster/releases). It contains additional container images required for that version, which you'll need to pull and push to your private registry.
+    
+  The `images-optional.txt` contains multiple Kubernetes distributions and versions. You can edit the file and remove the images for the unwanted distributions and versions. 
+
+    ```bash title "Pull, package, and push all optional images"
+    wget https://github.com/loft-sh/vcluster/releases/download/v${VCLUSTER_VERSION}/images-optional.txt
+    ./download-images.sh --image-list images-optional.txt --images vcluster-images-optional.tar.gz
+    ./push-images.sh --registry ${REGISTRY} --images vcluster-images-optional.tar.gz
+    ```
+    
+  </Step>
+</Flow>
+
+## Populate the Helm charts to a private registry
+
+You need to push a list of Helm charts to your OCI-compliant private registry. 
+
+- vCluster Platform Helm chart
+- Helm charts for each vCluster version 
+- Helm charts to be used with [apps](../../understand/what-are-apps)
+- Helm charts to be used in virtual cluster `experimental.deploy.vcluster.helm` [configuration](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster)
+
+:::warning
+Detailed steps are only provided for how to pull and push the vCluster Platform and vCluster Helm chart.
+:::
+
+### Prerequisites 
+
+- Access to the internet
+- Ability to push to your OCI-compliant private registry
+- `helm` installed: Helm v3.10+
+
+### Pull and push the vCluster Platform Helm chart
+
+<Flow id="offline-platform-helm-chart">
+  <Step>
+
+  **Optional**: If you haven’t already set the environment variables, set them now before continuing.
+
+  The private registry assumes having a `/charts` folder, which is where to push all the Helm charts. 
+    
+   ```bash title="Export environment variables"
+   export PLATFORM_VERSION=4.3.0 # Replace with desired version
+   export REGISTRY=ecr.io/myteam # A charts folder is expected
+   ```
+
+  </Step>
+  <Step>
+  Pull the vCluster Platform Helm chart and push it into your private registry with the OCI protocol.
+
+  ```bash title="Pull and push the Helm chart to your private registry"
+  helm pull vcluster-platform --repo https://charts.loft.sh --version ${PLATFORM_VERSION}
+  helm push vcluster-platform-${PLATFORM_VERSION}.tgz oci://${REGISTRY}/charts
+  ```
+  </Step>
+</Flow>
+
+### Pull and push the vCluster Helm chart 
+
+<Flow id="offline-helm-chart">
+  <Step>
+
+  **Optional**: If you haven’t already set the environment variables, set them now before continuing.
+
+ The private registry assumes having a `/charts` folder, which is where to push all the Helm charts. 
+ 
+   ```bash title="Export environment variables"
+   export VCLUSTER_VERSION=0.25.0 # Replace with desired version
+   export REGISTRY=ecr.io/myteam # A charts folder is expected
+   ```
+
+  </Step>
+   <Step>
+  Pull the vCluster Helm chart and push it into your private registry with the OCI protocol.
+
+  ```bash title="Pull and push the Helm chart to your private registry"
+  helm pull vcluster --repo https://charts.loft.sh --version ${VCLUSTER_VERSION}
+  helm push vcluster-${VCLUSTER_VERSION}.tgz oci://${REGISTRY}/charts
+  ```
+  </Step>
+</Flow>
+
+## Configure and Install vCluster Platform and Agent
+
+Installing vCluster Platform and connecting hosts to the platform will require you to configure a `vcluster-platform.yaml`.
+This yaml is used as the `values.yaml` of the vCluster Platform helm chart. 
+
+### Prerequisites
+
+- The cluster must have access to pull the **vCluster Platform images** from the private registry.
+<BasePrerequisites />
+- vCluster Platform Pod Resource Requirements
 
   - Requests
     - memory: `256Mi`
@@ -63,194 +316,457 @@ Although the platform might work with other versions, using the supported versio
 
 <NetworkPorts />
 
+### vCluster Platform and Agent Configuration
 
-## Deployment
+The `vcluster-platform.yaml` file contains all configuration settings for your vCluster Platform and connected hosts (i.e. agents) installation. 
 
-### Offline images
+<details>
+  <summary>Reference the offline license key</summary>
 
-For clusters unable to pull images from Docker Hub, you must push the platform images to your private registry. Each platform release includes a `loft-images.txt` file that lists the necessary images.
-
-:::warning
-When using virtual clusters in air-gapped environments, the
-`config.experimental.deploy.vcluster.helm` [configuration setting](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster) does not work with external Helm repositories since they cannot be accessed. This means custom Helm charts from repositories like `charts.bitnami.com` cannot be used for virtual cluster deployments.
-:::
-
-Follow these instructions to download all platform images and import them to your private registry:
-
-<Flow id="offline-images">
-    <Step>
-        <PartialAdminSetVersion/>
-  </Step>
-  <Step>
-
-Set your private registry as a variable:
-
-```bash title="Set private registry"
-REGISTRY=ecr.io/myteam      # This should be a prefix; do not include any LOFT_IMAGE paths
-```
-
-  </Step>
-  <Step>
-
-Download the `loft-images.txt` file and the required scripts `download-images.sh` and `push-images.sh`, then make them executable:
-
-```bash title="Download and prepare scripts"
-wget https://github.com/loft-sh/loft/releases/download/v${VERSION}/loft-images.txt
-wget https://github.com/loft-sh/loft/releases/download/v${VERSION}/download-images.sh
-wget https://github.com/loft-sh/loft/releases/download/v${VERSION}/push-images.sh
-
-chmod +x ./download-images.sh
-chmod +x ./push-images.sh
-```
-
-  </Step>
-  <Step>
-
-Run `download-images.sh` to download all images locally:
-
-```bash title="Download images"
-./download-images.sh --image-list loft-images.txt
-```
-
-  </Step>
-  <Step>
-
-Run `push-images.sh` to push all downloaded images to your private registry:
-
-```bash title="Push images to private registry"
-./push-images.sh --registry ${REGISTRY}
-```
-
-    </Step>
-    <Step>
-
-Edit your existing `vcluster-platform.yaml` file or create a new one with the following content:
-
-```yaml title="vcluster-platform.yaml"
-image: ${REGISTRY}/ghcr.io/loft-sh/loft:${VERSION} # Replace ${REGISTRY} and ${VERSION}
-env:
-  DEFAULT_IMAGE_REGISTRY: ${REGISTRY} # Replace ${REGISTRY}
-```
-
-:::info Example of a fully formed registry path
-If your `REGISTRY` is set to `ecr.io/myteam`, a fully formed registry path might look like:
-`ecr.io/myteam/ghcr.io/loft-sh/loft:3.0.0`
-:::
-
-    </Step>
-    <Step>
-        <PartialAdminUpgrade/>
-    </Step>
-
-</Flow>
-
-### Offline Helm charts
-
-For clusters unable to pull Helm charts from external chart repositories, it is recommended to use an OCI compatible
-private image registry to host the required Helm charts.
-
-Follow these instructions to configure the platform and import the required Helm charts to your private registry:
-
-<!--vale off-->
-<Flow id="offline-charts">
-<Step>
-Set your private registry as a variable:
-
-```bash title="Set private OCI registry"
-CHART_REGISTRY=oci://ecr.io/myteam/charts      # The OCI prefix is required for Helm
-```
-</Step>
-
-<Step>
-Make a list of Helm Charts to be used in the platform. Be sure to include:
-- Helm charts for each vCluster to be used when creating virtual clusters
-[manually](../../use-platform/virtual-clusters/create/create-no-template) or with a [template](../../use-platform/virtual-clusters/create/create-with-template).
-- Helm charts to be used with [apps](../../understand/what-are-apps)
-- Helm charts to be used in virtual cluster `experimental.deploy.vcluster.helm` [configuration](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster)
-
-:::note
-Each platform version supports a default vCluster version that works immediately. While you can use this default version, we recommend importing the vCluster Helm chart to ensure compatibility after platform upgrades.
-:::
-
-</Step>
-
-<Step>
-Run the follow command to pull each required Helm chart as a local `*.tgz` file. The `vcluster` chart is shown as an example:
-
-```bash title="Pull the vcluster Helm chart"
-helm pull vcluster --repo https://charts.loft.sh --version ${VERSION} # Replace ${VERSION}
-```
-</Step>
-
-<Step>
-Run the follow command to push each Helm chart's `*.tgz` file to your OCI registry. The `vcluster` chart is shown as an example:
-
-```bash title="Push the vcluster Helm chart to private registry"
-helm push vcluster-${VERSION}.tgz ${CHART_REGISTRY} # Replace ${VERSION}
-```
-</Step>
-
-<Step>
-To configure the platform to use your private registry as the default Helm repository when creating virtual clusters, edit your existing
-`vcluster-platform.yaml` file or create a new one with the following content:
-```yaml title="vcluster-platform.yaml"
-env:
-  DEFAULT_VCLUSTER_CHART_REPO: ${CHART_REGISTRY} # Replace ${CHART_REGISTRY}
-```
-</Step>
-
-<Step>
-If your OCI registry requires authentication, the platform can be configured to use an image pull
-secret for authenticating the `helm` command. Add this to your `vcluster-platform.yaml`:
-```yaml title="vcluster-platform.yaml"
-volumes:
-  - name: helm-pull-secret
-    secret:
-      secretName: ${IMAGE_PULL_SECRET} # Replace with the name of your image pull secret
-volumeMounts:
-  - name: helm-pull-secret
-    mountPath: /loft/helm
-    readOnly: true
-env:
-  HELM_REGISTRY_CONFIG: /loft/helm/.dockerconfigjson
-```
-
-:::warning
-This only configures the platform authentication for managing virtual clusters with Helm.
-- See [App Reference](../../api/resources/apps#app-reference) to configure the chart [repository URL](../../api/resources/apps#spec-config-chart-repoURL) with [username](../../api/resources/apps#spec-config-chart-usernameRef) and [password](../../api/resources/apps#spec-config-chart-passwordRef) authentication.
-- See `experimental.deploy.vcluster.helm` [configuration](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster) to configure [repository](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster-helm-chart-repo) with [username](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster-helm-chart-username) and [password](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster-helm-chart-password) authentication.
-:::
-</Step>
-
-<Step><PartialAdminUpgrade/>
-</Step>
-</Flow>
-
-<!--vale on-->
-
-## Configuration
-
-#### Offline license key
-
-If your cluster does not allow the platform pod to connect to the platform license server (`https://admin.loft.sh/*`), contact [sales@loft.sh](mailto:sales@loft.sh) to purchase an offline license key or request a trial license key for offline use.
-
-Edit the platform install values as follows to use your offline license key:
+Reference the license key so that the platform can start with all your enterprise features enabled. 
 
 ```yaml title="Offline license configuration"
 env:
   LICENSE_KEY: "YOUR_LICENSE_KEY"
 ```
 
-:::info
-Apply this configuration during the initial installation process or when upgrading the platform. Include it in your `vcluster-platform.yaml` file or pass it as a value to the Helm install or upgrade command.
+</details>
+
+<details>
+  <summary>Use a private registry without credentials</summary>
+
+* Set the **image** to be used by the vCluster Platform Helm chart to the image in the private registry. 
+* Set the **default registry** for pulling images used in installing vCluster Platform or connecting hosts (i.e. deploying agents).
+* Set the **default chart registry** in the `vcluster-platform.yaml` as the 
+default Helm repository when creating virtual clusters. This should prefix with `oci://` to ensure it's being 
+deployed using OCI protocol as well as the `/charts` folder. 
+
+```yaml title="Setting the image for vCluster Platform and the default  private registry"
+image: ecr.io/myteam/loft-sh/loft:v4.3.0 # Replace with the fully formed image name based on your private registry
+
+env:
+  DEFAULT_IMAGE_REGISTRY: ecr.io/myteam
+  DEFAULT_VCLUSTER_CHART_REPO: oci://ecr.io/myteam/charts
+
+# The agent values are needed to keep the agent up to date with the same settings
+agentValues:
+  env:
+    DEFAULT_IMAGE_REGISTRY: ecr.io/myteam
+    DEFAULT_VCLUSTER_CHART_REPO: oci://ecr.io/myteam/charts
+```
+
+</details>
+
+<details>
+  <summary>Use an authenticated private registry</summary>
+
+* Set the **image** to be used by the vCluster Platform Helm chart to the image in the private registry. 
+* Set the **default registry** for pulling images used in installing vCluster Platform or connecting hosts (i.e. deploying agents).
+* Set the **default chart registry** in the `vcluster-platform.yaml` as the 
+default Helm repository when creating virtual clusters. This should prefix with `oci://` to ensure it's being 
+deployed using OCI protocol as well as the `/charts` folder. 
+* For registries that require authentication, create a Kubernetes secret in the namespace where you deploy the vCluster Platform or agent.
+* Reference the **secret** to use those credentials for the registries. 
+
+```yaml title="Setting the image for vCluster Platform and the default  private registry"
+image: ecr.io/myteam/loft-sh/loft:v4.3.0 # Replace with the fully formed image name based on your private registry
+
+env:
+  DEFAULT_IMAGE_REGISTRY: ecr.io/myteam
+  DEFAULT_VCLUSTER_CHART_REPO: oci://ecr.io/myteam/charts
+  HELM_REGISTRY_CONFIG: /loft/helm/.dockerconfigjson
+
+volumes:
+  - name: helm-pull-secret
+    secret:
+      secretName: registry-credentials-secret-name # Replace with the name of the secret deployed on the host cluster of where the Platform is deployed
+
+volumeMounts:
+  - name: helm-pull-secret
+    mountPath: /loft/helm
+    readOnly: true
+
+# The agent values are needed to keep the agent up to date with the same settings
+agentValues:
+  env:
+    DEFAULT_IMAGE_REGISTRY: ecr.io/myteam
+    DEFAULT_VCLUSTER_CHART_REPO: oci://ecr.io/myteam/charts
+    HELM_REGISTRY_CONFIG: /loft/helm/.dockerconfigjson
+  
+  volumes:
+  - name: helm-pull-secret
+    secret:
+      secretName: registry-credentials-secret-name # Replace with the name of the secret deployed on the host cluster of where the Platform is deployed
+  
+  volumeMounts:
+  - name: helm-pull-secret
+    mountPath: /loft/helm
+    readOnly: true
+```
+
+:::warning
+This only configures the registry authentication for managing virtual clusters with Helm.
+- See [App Reference](../../api/resources/apps#app-reference) to configure the chart [repository URL](../../api/resources/apps#spec-config-chart-repoURL) with [username](../../api/resources/apps#spec-config-chart-usernameRef) and [password](../../api/resources/apps#spec-config-chart-passwordRef) authentication.
+- See `experimental.deploy.vcluster.helm` [configuration](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster) to configure [repository](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster-helm-chart-repo) with [username](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster-helm-chart-username) and [password](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster-helm-chart-password) authentication.
 :::
 
-## Log in
+</details>
 
-<LoginAfterHelmInstall />
+<details>
+  <summary>Use different vCluster Platform login credentials</summary>
 
-## Next steps
+If the username and password are not set in your `vcluster-platform.yaml`, the default credentials are:
 
-### Create virtual clusters
+* Username: `admin`
+* Password: `my-password`
 
-<InstallNextSteps />
+```yaml title="Set different vCluster Platform login credentials"
+admin:
+  create: true
+  username: newadmin
+  password: "newpassword"
+```
+
+</details>
+
+### Install vCluster Platform
+
+It is recommended to install vCluster Platform on its own host cluster. 
+
+#### Prerequisites
+- The machine that is running the install commands must have access to pull the Helm chart from the private registry.
+- The host cluster where the vCluster Platform is being installed on must have access to pull images from the private registry.
+<BasePrerequisites />
+
+<Flow id="install-vcluster-platform">
+  <Step>
+  On the host cluster, create the namespace for the vCluster Platform, where vCluster Platform and optionally login credentials are to be deployed in. 
+
+  ```bash title="Create vCluster Platform namespace"
+  export PLATFORM_NAMESPACE=vcluster-platform  
+  kubectl create namespace ${PLATFORM_NAMESPACE}
+  ```
+
+  </Step>
+  <Step>
+  **Optional**: Create a secret to authenticate to your private registry.
+
+  If your private registry requires authentication, create a Kubernetes secret that stores your login credentials.
+  Place this secret in the same namespace where the vCluster Platform is deployed. There are multiple ways to create your registry credentials as a secret. 
+
+  Read more about how to quickly create a [secret from your docker login](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_create/kubectl_create_secret_docker-registry/).
+
+  ```bash title="Example of how to create a Kubernetes secret for login credentials"
+  kubectl create -f - <<EOF
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: registry-credentials-secret-name
+    namespace: ${PLATFORM_NAMESPACE}
+  type: Opaque
+  data:
+    # Credentials based on your private registry
+  EOF
+  ```
+
+  </Step>
+  <Step>
+
+  Deploy vCluster Platform into the same namespace.
+
+  ```bash title="Deploy vCluster with Helm"
+  export PLATFORM_VERSION=4.3.0 # Replace with the chart version that was pushed into your private registry
+  export REGISTRY=myecr.io/team # Replace with the private registry
+  
+  helm upgrade --install vcluster-platform oci://${REGISTRY}/charts/vcluster-platform:${PLATFORM_VERSION} \
+    --version ${PLATFORM_VERSION} \
+    --values vcluster-platform.yaml \
+    --namespace ${PLATFORM_NAMESPACE} \
+  ```
+
+  </Step>
+
+</Flow>
+
+### Connect host clusters
+
+After vCluster Platform is installed, you'll want to connect host clusters to the platform. These host clusters will need to be able to 
+access the domain where vCluster Platform is hosted by deploying an agent onto those hosts. 
+
+Deploying an agent is deploying the vCluster Platform Helm chart and `vcluster-platform.yaml`.  The only difference is when deploying the vCluster Platform Helm
+chart is adding additional variables to figure out how to connect to the platform. 
+
+#### Prerequisites
+
+- The machine that is running the install commands must have access to pull the Helm chart from the private registry.
+- The host cluster where the vCluster Platform is being installed on must have access to pull images from the private registry.
+<BasePrerequisites />
+
+<Flow id="install-agent">
+  <Step>
+  On the host cluster, create the namespace for the agent installation, where the agent and optionally login credentials are to be deployed in. 
+
+  ```bash title="Create vCluster Platform namespace"
+  export AGENT_NAMESPACE=vcluster-platform  
+  kubectl create namespace ${AGENT_NAMESPACE}
+  ```
+
+  </Step>
+  <Step>
+  **Optional**: Create a secret to authenticate to your private registry.
+
+  If your private registry requires authentication, create a Kubernetes secret that stores your login credentials.
+  Place this secret in the same namespace where the agent is deployed. There are multiple ways to create your registry credentials as a secret. 
+
+  Read more about how to quickly create a [secret from your docker login](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_create/kubectl_create_secret_docker-registry/).
+
+  ```bash title="Example of how to create a Kubernetes secret for login credentials"
+  kubectl create -f - <<EOF
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: registry-credentials-secret-name
+    namespace: ${AGENT_NAMESPACE}
+  type: Opaque
+  data:
+    # Credentials based on your private registry
+  EOF
+  ```
+
+  </Step>
+  <Step>
+
+  Deploy the agent into the same namespace.
+
+  ```bash title="Deploy vCluster with Helm"
+  export PLATFORM_VERSION=4.3.0 # Replace with the chart version that was pushed into your private registry
+  export REGISTRY=myecr.io/team # Replace with the private registry
+  
+  export PLATFORM_DOMAIN=https://myvclusterplatform.com
+  export PLATFORM_TOKEN=BWtdYmPyXbaxGAIBTs004mBAP2bJCD2DXvYli2asnZYJeVnIE6sfsU3tCYp5VSPc
+
+  helm upgrade --install vcluster-platform oci://${REGISTRY}/charts/vcluster-platform:${PLATFORM_VERSION} \
+    --version ${PLATFORM_VERSION} \
+    --values vcluster-platform.yaml \
+    --namespace ${AGENT_NAMESPACE} \
+    --set agentOnly=true 
+    --set url=$PLATFORM_DOMAIN
+    --set token=$PLATFORM_TOKEN
+  ```
+
+  </Step>
+
+</Flow>
+
+## Configure and Deploy vCluster 
+
+### Prerequisites
+
+- The host cluster must have access to pull **vCluster** images from the private registry.
+
+### vCluster Configuration
+
+The `vcluster.yaml` file contains all configuration settings for your vCluster deployment. 
+
+<details>
+  <summary>Use a private registry without credentials</summary>
+
+Set the default private registry that doesn't have authentication.
+
+```yaml title="Setting the private registry"
+controlPlane:
+ advanced:
+   defaultImageRegistry: ecr.io/myteam # Replace with your private registry
+```
+
+</details>
+
+<details>
+  <summary>Use an authenticated private registry</summary>
+
+For registries that require authentication, create a Kubernetes secret in the namespace where you deploy the vCluster.
+Assign the secret as an image pull secret for the vCluster control plane to access required images.
+
+Optionally, you can use the same image pull secret for workloads inside the vCluster that pull from the same registry.
+
+```yaml title="Image pull secrets configuration"
+controlPlane:
+  advanced:
+    defaultImageRegistry: ecr.io/myteam # Replace with your private image registry
+    serviceAccount:
+      imagePullSecrets: # Uses credentials for the vCluster control plane
+        - name: registry-credentials-secret-name # Replace with the name of the secret deployed on the host cluster of where the vCluster is deployed
+    workloadServiceAccount: # Uses credentials for any workloads created in the vCluster 
+      imagePullSecrets:
+        - name: registry-credentials-secret-name # Replace with the name of the secret deployed on the host cluster of where your vCluster is deployed
+```
+
+:::warning
+When using virtual clusters in air-gapped environments, the
+`config.experimental.deploy.vcluster.helm` [configuration setting](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster) does not work with external Helm repositories since they cannot be accessed. This means custom Helm charts from repositories like `charts.bitnami.com` cannot be used for virtual cluster deployments.
+:::
+
+</details>
+
+<details>
+  <summary>Use a non-default Kubernetes version</summary>
+
+For vCluster v0.25.0+, if you downloaded `images-optional.txt` to use a different Kubernetes version, configure vCluster to use that version in your deployment.
+
+```yaml title="Specific Kubernetes version configuration"
+controlPlane:
+  distro:
+    k8s:
+      image:
+        tag: v1.31.1 # Replace with the Kubernetes version that you have chosen
+```
+
+For other versions, refer to the vCluster docs on how to set your image versions.
+
+</details>
+
+<details>
+  <summary>Replace the alpine image</summary>
+
+If you use the `sync.toHost.pods.rewriteHosts` feature, manually replace the full path of the [alpine image](https://hub.docker.com/_/alpine) with your private registry path.  
+The `defaultImageRegistry` setting does not apply to this image.
+
+```yaml title="Replace the alpine image"
+sync:
+  toHost:
+    pods:
+      rewriteHosts:
+        initContainer:
+          image: ecr.io/myteam/library/alpine:3.20
+```
+
+</details>
+
+### Deploy vCluster through Platform UI
+
+When deploying vCluster through the Platform UI, you'll need to paste in your `vcluster.yaml`.
+
+#### Use an authenticated private registry
+
+If you are using a private registry with authentication, you'll need to create a Kubernetes secret that stores your login credentials.  Place this secret in the same namespace where the vCluster is deployed so the control plane can pull the required container images.
+
+In the options for the config, there is a section called `Host namespace`, add the yaml for the secret in the `Kubernetes objects` section.
+
+  ```yaml title="Kubernetes secret for login credentials"
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: registry-credentials-secret-name
+    namespace: ${VCLUSTER_NAMESPACE}
+  type: Opaque
+  data:
+    # Credentials based on your private registry
+  ```
+
+### Deploy vCluster through Helm
+
+#### Prerequisites
+
+<BasePrerequisites />
+
+<Flow>
+  <Step>
+  
+  In the platform UI, create an [access key](../../administer/users-permissions/access-keys) to connect vCluster to the platform. Save the **access key**.
+  
+  </Step>
+  <Step> 
+  
+  Create a Kubernetes secret using the **access key** in a namespace on the host cluster. 
+
+ ```bash title="Create platform API key namespace and secret for platform API key"
+  export APIKEY_NAMESPACE=api-key-namespace 
+  kubectl create namespace ${APIKEY_NAMESPACE}
+
+
+  kubectl create -f - <<EOF
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: vcluster-platform-api-key
+    namespace: ${APIKEY_NAMESPACE}
+  type: Opaque
+  data:
+    accessKey: # Access key from the Platform UI
+    host: # domain name of platform
+    insecure: # ???
+  EOF
+```
+
+  </Step>
+
+  <Step>
+  **Optional**: Create a secret to authenticate to your private registry.
+
+  If your private registry requires authentication, create a Kubernetes secret that stores your login credentials.
+  Place this secret in the same namespace where the vCluster is deployed so the control plane can pull the required container images.
+
+  ```bash title="Create Kubernetes secret for login credentials"
+  export VCLUSTER_NAMESPACE=vcluster-my-vcluster  # Replace with the name of the namespace you want to deploy your vCluster into
+  kubectl create namespace ${VCLUSTER_NAMESPACE}
+
+  kubectl create -f - <<EOF
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: registry-credentials-secret-name
+    namespace: ${VCLUSTER_NAMESPACE}
+  type: Opaque
+  data:
+    # Credentials based on your private registry
+  EOF
+  ```
+
+  </Step>
+  <Step>
+  Review your `vcluster.yaml` file.
+
+  ```yaml title="vcluster.yaml configuration"
+  controlPlane:
+    advanced:
+      defaultImageRegistry: ecr.io/myteam # Replace with your private image registry
+      serviceAccount:
+        imagePullSecrets: 
+          - name: registry-credentials-secret-name # Replace with the name of the registry credentials secret
+      workloadServiceAccount: 
+        imagePullSecrets:
+          - name: registry-credentials-secret-name # Replace with the name of the registry credentials secret
+    
+  external:
+    platform:
+      apiKey:
+        namespace: api-key-namespace # Replace with the namespace that the secret of the access key was deployed in
+        secretName: vcluster-platform-api-key # Replace with the name of the secret of the access key 
+        createRBAC: true # Sets up RBAC so that the vcluster can access the secret of the access key
+  ```
+
+  </Step>
+  <Step>
+  Deploy vCluster.
+
+  ```bash title="Deploy vCluster with Helm"
+  export VCLUSTER_NAME="my-vcluster" # Replace with what you want to name your vCluster
+  export VCLUSTER_VERSION=0.25.0 # Replace with the chart version that was pushed into your private registry
+  export REGISTRY=myecr.io/team # Replace with the private registry
+  
+  # Uncomment and create a namespace if you didn't already create one for a secret for the registry
+  # export VCLUSTER_NAMESPACE=vcluster-my-vcluster  # Replace with the name of the namespace you want to deploy your vCluster into
+  # kubectl create namespace ${VCLUSTER_NAMESPACE} 
+  
+  helm upgrade --install "${VCLUSTER_NAME}" oci://${REGISTRY}/charts/vcluster:${VCLUSTER_VERSION} \
+    --version ${VCLUSTER_VERSION} \
+    --values vcluster.yaml \
+    --namespace ${VCLUSTER_NAMESPACE} \
+  ```
+
+  </Step>
+</Flow>
+
+
+
+

--- a/vcluster/deploy/topologies/air-gapped.mdx
+++ b/vcluster/deploy/topologies/air-gapped.mdx
@@ -77,14 +77,11 @@ Each vCluster release includes multiple assets to help you upload the images to 
   </Step>
   <Step>
 
-  Download the assets from the vCluster GitHub release and make the scripts executable.
+  Download the assets from the [vCluster GitHub release](https://github.com/loft-sh/vcluster/releases) and make the scripts executable.
   
-  :::note
-  The `images.txt` contains all distributions for the default Kubernetes version. You can edit the
-  file and remove the images for unused distributions. 
-  :::
-  
-  ```bash title="Download assets and prepare scripts"
+    The `images.txt` file contain the default Kubernetes version and distributions. You can edit the file and remove the images for any unwanted distributions. 
+
+    ```bash title="Download assets and prepare scripts"
   wget https://github.com/loft-sh/vcluster/releases/download/v"${VCLUSTER_VERSION}"/images.txt
   wget https://github.com/loft-sh/vcluster/releases/download/v"${VCLUSTER_VERSION}"/download-images.sh
   wget https://github.com/loft-sh/vcluster/releases/download/v"${VCLUSTER_VERSION}"/push-images.sh
@@ -98,35 +95,28 @@ Each vCluster release includes multiple assets to help you upload the images to 
 
   Run `download-images.sh` to pull all images and create a tarball of the images.
   
+  Review the output to confirm all images were pulled successfully and packaged in the tarball. 
+  
   ```bash title="Download and package images"
   ./download-images.sh --image-list images.txt
   ```
   
-  :::tip
-  Review the output to confirm all images were pulled successfully and packaged in the tarball. 
-  :::
-
   </Step>
   <Step>
 
   Run `push-images.sh` to upload all required images to your private registry.
   
-  ```bash title="Push images to private registry"
+  When pushing images into your private registry, the public private registry is removed and only the repository and image name are pushed. This allows vCluster to set your private registry to use for all images used in deploying vCluster. 
   
+  ```bash title="Push images to private registry"
   ./push-images.sh --registry ${REGISTRY} 
   ```
-
-  :::note 
-  When pushing images into your private registry, the public private registry is removed and only the repository and image name are pushed. This allows vCluster to set your private registry to use for all images used in deploying vCluster. 
-  :::
 
   </Step>
   <Step>
   **Optional**: If you want to deploy vCluster with a different Kubernetes version, download the `images-optional.txt` file. It contains additional container images required for that version, which you'll need to pull and push to your private registry.
     
-    :::note
-    The `images-optional.txt` contains multiple Kubernetes distributions and versions. You can edit the file and remove the images for the unused distributions and versions. 
-    :::
+  The `images-optional.txt` contains multiple Kubernetes distributions and versions. You can edit the file and remove the images for the unwanted distributions and versions. 
 
     ```bash title "Pull, package, and push all optional images"
     wget https://github.com/loft-sh/vcluster/releases/download/v${VCLUSTER_VERSION}/images-optional.txt
@@ -155,14 +145,12 @@ You need to push the vCluster Helm chart to your OCI-compliant private registry.
 
   **Optional**: If you haven’t already set the environment variables, set them now before continuing.
 
+  The private registry assumes having a `/charts` folder, which is where to push all the Helm charts. 
+
    ```bash title="Export environment variables"
    export VCLUSTER_VERSION=0.25.0 # Replace with the desired version
    export REGISTRY=ecr.io/myteam # A charts folder is expected
    ```
-
-   :::note 
-The private registry assumes having a `/charts` folder, which is where to push all the Helm charts. 
-:::
 
   </Step>
    <Step>
@@ -181,9 +169,10 @@ Pull the vCluster Helm chart and push it into your private registry with the OCI
 
 The `vcluster.yaml` file contains all configuration settings for your vCluster deployment. 
 
-### Use a private registry without credentials
+<details>
+  <summary>Use a private registry without credentials</summary>
 
-Set the default private registry in the `vcluster.yaml` file.
+Set the default private registry that doesn't have authentication.
 
 ```yaml title="Setting the private registry"
 controlPlane:
@@ -191,7 +180,10 @@ controlPlane:
    defaultImageRegistry: ecr.io/myteam # Replace with your private registry
 ```
 
-### Use an authenticated private registry {#use-authenticated-private-registry}
+</details>
+
+<details>
+  <summary>Use an authenticated private registry</summary>
 
 For registries that require authentication, create a Kubernetes secret in the namespace where you deploy the vCluster.
 Assign the secret as an image pull secret for the vCluster control plane to access required images.
@@ -210,7 +202,10 @@ controlPlane:
         - name: registry-credentials-secret-name # Replace with the name of the secret deployed on the host cluster of where your vCluster is deployed
 ```
 
-### Use a non-default Kubernetes version
+</details>
+
+<details>
+  <summary>Use a non-default Kubernetes version</summary>
 
 If you downloaded `images-optional.txt` to use a different Kubernetes version, configure vCluster to use that version in your deployment.
 
@@ -222,7 +217,10 @@ controlPlane:
         tag: v1.31.1 # Replace with the Kubernetes version that you have chosen
 ```
 
-### Replace the alpine image {#replace-Alpine-image}
+</details>
+
+<details>
+  <summary>Replace the alpine image</summary>
 
 If you use the `sync.toHost.pods.rewriteHosts` feature, manually replace the full path of the [alpine image](https://hub.docker.com/_/alpine) with your private registry path.  
 The `defaultImageRegistry` setting does not apply to this image.
@@ -236,7 +234,10 @@ sync:
           image: your-registry/library/alpine:3.20
 ```
 
-### Reference the license key {#reference-license-key}
+</details>
+
+<details>
+  <summary>Enable enterprise features with the license key </summary>
 
 The `apiKey` is required to reference the license key to enable enterprise features in vCluster.
 
@@ -261,21 +262,24 @@ external:
       createRBAC: true
 ```
 
+</details>
+
 ## Deploy vCluster {#deploy-vcluster}
 
 ### Prerequisites 
 
-- The host cluster must have access to pull images from the private registry.
+- The machine that is running the install commands must have access to pull the Helm chart from the private registry.
+- The host cluster where the vCluster is being deployed on must have access to pull images from the private registry.
 <BasePrerequisites />
 
 ### Set up the host cluster and deploy
 
 <Flow>
   <Step>
-  On the host cluster, create the namespace for the vCluster, where the secrets and vCluster control plane pod are to be deployed. 
+  On the host cluster, create the namespace for the vCluster, where the secrets and vCluster control plane pod are to be deployed in. 
 
   ```bash title="Create vCluster namespace"
-  export VCLUSTER_NAMESPACE=vcluster-my-vcluster 
+  export VCLUSTER_NAMESPACE=vcluster-my-vcluster  # Replace with the name of the namespace you want to deploy your vCluster into
   kubectl create namespace ${VCLUSTER_NAMESPACE}
   ```
 
@@ -350,25 +354,13 @@ external:
 
   </Step>
   <Step>
-  Pull the vCluster Helm chart from the private registry.
-  
-  ```bash title="Pull the Helm chart"
-  export VCLUSTER_VERSION=0.25.0 # Replace with the chart version that was pushed into your private registry
-  export REGISTRY=myecr.io/team # Replace with the private registry
-  
-  ## Log in to the Helm registry if you haven't
-  helm registry login ${REGISTRY} \
-    --username myuser \
-    --password mypassword
-  
-  helm pull oci://${REGISTRY}/charts/vcluster:${VCLUSTER_VERSION}
-  ```
-  </Step>
-  <Step>
 
   Deploy vCluster into the namespace where you deployed the secrets.
 
   ```bash title="Deploy vCluster with Helm"
+  export VCLUSTER_VERSION=0.25.0 # Replace with the chart version that was pushed into your private registry
+  export REGISTRY=myecr.io/team # Replace with the private registry
+  
   export VCLUSTER_NAME="my-vcluster" # Replace with what you want to name your vCluster
   
   helm upgrade --install "${VCLUSTER_NAME}" oci://${REGISTRY}/charts/vcluster:${VCLUSTER_VERSION} \
@@ -391,7 +383,7 @@ Tags are listed in the `images.txt` and `images-optional.txt` files.
 - `ghcr.io/loft-sh/kubernetes-fips`
 
 
-:::note
+:::tip
 The steps for [pulling, tagging, and pushing these images](#pull-push-images) are the same as for standard images. The only difference is that you reference the FIPS-compliant images instead.
 :::
 

--- a/vcluster_versioned_docs/version-0.24.0/deploy/topologies/air-gapped.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/deploy/topologies/air-gapped.mdx
@@ -1,8 +1,8 @@
 ---
-title: vCluster Pro air-gapped install
+title: Deploy vCluster in an air-gapped environment
 sidebar_label: Air-gapped
 sidebar_position: 5
-description: Learn how to install vCluster Pro in an air-gapped Kubernetes cluster without the vCluster Platform agent.
+description: Learn how to deploy vCluster in an air-gapped Kubernetes cluster.
 sidebar_class_name: pro
 ---
 
@@ -16,241 +16,207 @@ import FipsConfig from '../../_partials/deploy/fips-config.mdx';
 import LicenseKey from '../../_partials/deploy/license_key.mdx';
 import ProAdmonition from '../../_partials/admonitions/pro-admonition.mdx';
 
-# vCluster Pro air-gapped install
+
+# Deploy vCluster in an air-gapped environment
 
 <ProAdmonition/>
 
-This document details the prerequisites and steps to install vCluster Pro into
-an `air-gapped` Kubernetes cluster without the platform agent running on the host
-cluster.
+This document explains how to deploy vCluster in environments without internet access, known as air-gapped environments.
 
 ## Prerequisites
 
-<BasePrerequisites />
-  - `docker` (check with `docker version`)
-  - An offline license key for vCluster Pro (provided by Loft)
+- OCI-compliant private registry with a `/charts` folder - A private registry accessible to both the Kubernetes host cluster and a separate, internet-connected machine.
+- An offline license key for vCluster - A LoftLabs license key is required to enable enterprise features.
     :::info
     <LicenseKey />
     :::
-- Optionally: private docker registry that the installer computer and the
-air-gapped Kubernetes cluster can access (e.g. x-private-registry:5000 or
-gcr.io/x-team)
-  <details>
-    <summary>Example Local Registry Setup</summary>
 
-  ### Local Docker Registry Configuration
+## Overview {#overview}
 
-  It is easy to setup a private Docker registry for testing purposes using KIND
-  cluster. The
-  following steps show how to set up a Docker registry locally:
+When deploying vCluster, there are artifacts that are typically accessed using an internet connection, but without access to internet, these artifacts need to be available to the Kubernetes cluster through a private registry:
 
-  **Basic Setup**:
-Execute the [setup script](https://kind.sigs.k8s.io/docs/user/local-registry/) from the KIND webpage:
+- **vCluster Helm chart** – Typically retrieved from the LoftLabs Helm chart repository.
+- **Container images referenced in the Helm chart** – Usually pulled from various public container registries.
 
-  **Verify & Use**:
-  ```bash
-  # Verify registry
-  curl http://localhost:5001/v2/_catalog
-  ```
-
-  </details>
-
-### Download vCluster Helm chart
-
-Download the `vCluster` Helm chart from the Loft Helm repository.
-
-:::tip
-To retrieve all available versions of the vCluster Helm chart, run the following command:
-
-```bash title="Show latest 10 vCluster chart versions"
-helm repo update
-helm search repo loft/vcluster --versions | grep "^loft/vcluster" | head
-```
-:::
-
-```bash title="Download vCluster Helm chart"
-export CHART_VERSION="0.21.1"  # Replace with the desired version
-curl -O https://charts.loft.sh/charts/vcluster-"${CHART_VERSION}".tgz
-```
-
-:::info
-The `vCluster` Helm chart is a tarball that contains all the necessary images
-to deploy the vCluster control plane.
-:::
-
-### Download and push required container images
-
-For clusters unable to pull images from Docker Hub, you need to push the
-platform images to your private registry. Each vCluster release includes a
-`vcluster-images.txt` file that lists the necessary images.
+After populating your private registry with the artifacts, you'll create the configuration file (`vcluster.yaml`) of your vCluster. Finally, you'll prep your host cluster to deploy your vCluster.
 
 :::warning
 When using virtual clusters in air-gapped environments, the
 `config.experimental.deploy.vcluster.helm` [configuration setting](/docs/vcluster/configure/vcluster-yaml/#experimental-deploy-vcluster) does not work with external Helm repositories since they cannot be accessed. This means custom Helm charts from repositories like `charts.bitnami.com` cannot be used for virtual cluster deployments.
 :::
 
-Follow these instructions to download all vCluster images and import them to your private registry:
+
+## Populate images to a private registry {#populate-images-private-registry}
+
+Each vCluster release includes multiple assets to help you upload the images to your private registry.
+
+- `vcluster-images.txt` - The  images to run vCluster, which includes multiple Kubernetes versions and distributions.
+- `download-images.sh` - A bash script that quickly iterates over all the images files to pull them and package them into a tarball to a machine that has internet access. 
+- `push-images.sh` - A bash script that takes the tarball generated from the download script to push them to your private registry. 
+
+### Prerequisites 
+
+- Access to the internet
+- Ability to push to your OCI-compliant private registry
+- Logged in to GitHub Container Registry
+- `wget` installed
+- `docker` installed 
+
+### Pull and push images {#pull-push-images}
 
 <Flow id="offline-images">
-<Step>
-
-Set environment variables for the setup process:
-
-      ```bash title="Export environment variables"
-      export VCLUSTER_SERVICE="vcluster"
-      export VCLUSTER_NAMESPACE="vcluster"
-      export REGISTRY=ecr.io/myteam      # This should be a prefix; do not include any LOFT_IMAGE paths
-      ```
-  <Tabs>
-    <TabItem value="existing" label="Existing vCluster Installation" default>
-
-      Retrieve the vCluster version and set the `VERSION` variable:
-      ```bash title="Retrieve and set VERSION"
-      CHART=$(kubectl get service "${VCLUSTER_SERVICE}" -n "${VCLUSTER_NAMESPACE}" -o jsonpath={.metadata.labels.chart})
-      export VERSION=${CHART#vcluster-}   # Remove 'vcluster-' prefix
-      ```
-    </TabItem>
-    <TabItem value="fresh" label="No vCluster Installation">
-      Set the `VERSION` variable to the latest vCluster version you want to install:
-
-
-      ```bash title="Set VERSION variable for fresh installation"
-      export VERSION=<latest-version>  # e.g., "0.21.1"
-      ```
-
-    </TabItem>
-
-  </Tabs>
-</Step>
+  <Step>
+  
+  Set environment variables for the version of vCluster that you want to deploy and the private registry. 
+  
+        ```bash title="Export environment variables"
+        export VCLUSTER_VERSION=0.24.0 # Replace with the desired version
+        export REGISTRY=ecr.io/myteam # This should be a prefix; do not include any image paths
+        ```
+  </Step>
   <Step>
 
-Download the `vcluster-images.txt` file and the required scripts
-`download-images.sh` and `push-images.sh`, then make them executable.
+  Download the assets from the [vCluster GitHub release](https://github.com/loft-sh/vcluster/releases) and make the scripts executable.
+  
+    The `vcluster-images.txt` file contain multiple Kubernetes versions and distributions. You can edit the file and remove the images for any unwanted Kubernetes versions and distributions. 
 
-:::tip
-Note that the
-`vcluster-images.txt` contains all the distros and versions. You can edit the
-file and remove images you do not need.
-Each release also has a corresponding `vcluster-images-k8s-[version].txt` file,
-use it to download k8s distro images for the desired version.
-:::
-
-```bash title="Download and prepare scripts"
-wget https://github.com/loft-sh/vcluster/releases/download/v"${VERSION}"/vcluster-images.txt
-wget https://github.com/loft-sh/vcluster/releases/download/v"${VERSION}"/download-images.sh
-wget https://github.com/loft-sh/vcluster/releases/download/v"${VERSION}"/push-images.sh
-
-chmod +x ./download-images.sh
-chmod +x ./push-images.sh
-```
+    ```bash title="Download assets and prepare scripts"
+  wget https://github.com/loft-sh/vcluster/releases/download/v"${VCLUSTER_VERSION}"/images.txt
+  wget https://github.com/loft-sh/vcluster/releases/download/v"${VCLUSTER_VERSION}"/download-images.sh
+  wget https://github.com/loft-sh/vcluster/releases/download/v"${VCLUSTER_VERSION}"/push-images.sh
+  
+  chmod +x ./download-images.sh
+  chmod +x ./push-images.sh
+  ```
 
   </Step>
   <Step>
 
-Run `download-images.sh` to download all images locally:
-
-```bash title="Download images"
-./download-images.sh --image-list vcluster-images.txt
-```
-
-:::tip
-This creates a tarball with all the images and push them to your private registry.
-:::
-
+  Run `download-images.sh` to pull all images and create a tarball of the images.
+  
+  Review the output to confirm all images were pulled successfully and packaged in the tarball. 
+  
+  ```bash title="Download and package images"
+  ./download-images.sh --image-list vcluster-images.txt
+  ```
+  
   </Step>
   <Step>
 
-Run `push-images.sh` to push all downloaded images to your private registry:
+  Run `push-images.sh` to upload all required images to your private registry.
+  
+  When pushing images into your private registry, the public private registry is removed and only the repository and image name are pushed. This allows vCluster to set your private registry to use for all images used in deploying vCluster. 
+  
+  ```bash title="Push images to private registry"
+  ./push-images.sh --registry ${REGISTRY} 
+  ```
 
-```bash title="Push images to private registry"
-./push-images.sh --registry ${REGISTRY}
-```
-
-:::info
-vCluster prepends the image registry to all images used by vCluster, such as syncer and Kubernetes. For example, `registry.k8s.io/kube-apiserver:v1.30.2` becomes `my-private-registry:5000/vcluster/kube-apiserver:v1.30.2`.
-:::
-
-    </Step>
-
+  </Step>
 </Flow>
-## Configure vCluster for air-gapped install
 
-The `vcluster.yaml` file holds your vCluster configuration and allows overriding the vCluster Helm chart default values.
+## Populate the vCluster Helm chart to a private registry {#populate-vCluster-Helm-chart-private-registry}
 
-Edit your existing `vcluster.yaml` file or create a new one with the following content:
+You need to push the vCluster Helm chart to your OCI-compliant private registry. 
 
-:::tip
-To retrieve supported Kubernetes versions:
+### Prerequisites 
 
-```bash title="Show supported Kubernetes versions"
-curl http://"${REGISTRY}"/v2/kube-controller-manager/tags/list
-```
+- Access to the internet
+- Ability to push to your OCI-compliant private registry
+- `helm` installed: Helm v3.10+
 
-```bash title="create vcluster.yaml configuration"
-export KUBERNETES_VERSION="v1.31.1"  # Replace with the desired version
-cat <<EOF > vcluster.yaml
+### Pull and push the vCluster Helm chart {#download-push-vCluster-Helm-chart}
+
+<Flow id="offline-helm-chart">
+  <Step>
+
+  **Optional**: If you haven’t already set the environment variables, set them now before continuing.
+
+  The private registry assumes having a `/charts` folder, which is where to push all the Helm charts. 
+
+   ```bash title="Export environment variables"
+   export VCLUSTER_VERSION=0.24.0 # Replace with the desired version
+   export REGISTRY=ecr.io/myteam # A charts folder is expected
+   ```
+
+  </Step>
+   <Step>
+Pull the vCluster Helm chart and push it into your private registry with the OCI protocol.
+
+  ```bash title="Pull and push the Helm chart to your private registry"
+  helm pull vcluster --repo https://charts.loft.sh --version ${VCLUSTER_VERSION}
+  helm push vcluster-${VCLUSTER_VERSION}.tgz oci://${REGISTRY}/charts
+  ```
+  </Step>
+</Flow>
+
+<!--vale off-->
+
+## Configure vCluster {#configure-vCluster}
+
+The `vcluster.yaml` file contains all configuration settings for your vCluster deployment. 
+
+<details>
+  <summary>Use a private registry without credentials</summary>
+
+Set the default private registry that doesn't have authentication.
+
+```yaml title="Setting the private registry"
 controlPlane:
  advanced:
-   defaultImageRegistry: ${REGISTRY}
- distro:
-   k8s:
-     version: ${KUBERNETES_VERSION}
-EOF
+   defaultImageRegistry: ecr.io/myteam # Replace with your private registry
 ```
 
-:::info Example of a fully formed registry path
-If your `REGISTRY` is set to `ecr.io/myteam`, a fully formed registry path might look like:
-`ecr.io/myteam/ghcr.io/loft-sh/vcluster:0.21.0`
-:::
+</details>
 
+<details>
+  <summary>Use an authenticated private registry</summary>
 
-:::info Note on alpine image replacement
-The `alpine` image may be replaced with any similar image with the following `vcluster.yaml` configuration:
+For registries that require authentication, create a Kubernetes secret in the namespace where you deploy the vCluster.
+Assign the secret as an image pull secret for the vCluster control plane to access required images.
 
-```yaml title="vcluster.yaml configuration for custom image"
+Optionally, you can use the same image pull secret for workloads inside the vCluster that pull from the same registry.
+
+```yaml title="Image pull secrets configuration"
+controlPlane:
+  advanced:
+    defaultImageRegistry: ecr.io/myteam # Replace with your private image registry
+    serviceAccount:
+      imagePullSecrets: # Uses credentials for the vCluster control plane
+        - name: registry-credentials-secret-name # Replace with the name of the secret deployed on the host cluster of where the vCluster is deployed
+    workloadServiceAccount: # Uses credentials for any workloads created in the vCluster 
+      imagePullSecrets:
+        - name: registry-credentials-secret-name # Replace with the name of the secret deployed on the host cluster of where your vCluster is deployed
+```
+
+</details>
+
+<details>
+  <summary>Replace the alpine image</summary>
+
+If you use the `sync.toHost.pods.rewriteHosts` feature, manually replace the full path of the [alpine image](https://hub.docker.com/_/alpine) with your private registry path.  
+The `defaultImageRegistry` setting does not apply to this image.
+
+```yaml title="Replace the alpine image"
 sync:
   toHost:
     pods:
       rewriteHosts:
         initContainer:
-          image: your-registry/your-image:1.0.0
+          image: your-registry/library/alpine:3.20
 ```
 
-The image that is used to replace the default image must be able to run the following command:
+</details>
 
-```yaml
-Command: []string{"sh"},
-Args:    []string{"-c", "sed -E -e 's/^(\\d+.\\d+.\\d+.\\d+\\s+)" + fromHost + "$/\\1 " + toHostnameFQDN + " " + toHostname + "/' /etc/hosts > /hosts/hosts"}
-```
-:::
+<details>
+  <summary>Enable enterprise features with the license key </summary>
 
-## Optionally create image pull secret
-
-    The `imagePullSecrets` setting defines extra image pull secrets for the vCluster control plane `ServiceAccount`.
-
-:::info
-This configuration is only necessary if your registry requires
-authentication.
-:::
-
-```yaml title="Image Pull Secrets configuration"
-controlPlane:
-  advanced:
-    serviceAccount:
-      imagePullSecrets:
-        - name-of-your-image-pull-secret
-```
-
-## Configure API key
-
-The `apiKey` provides a way to deploy vCluster with Pro features without the platform agent installed on the host cluster.
+The `apiKey` is required to reference the license key to enable enterprise features in vCluster.
 
 :::note
-Although the config appears similar to when using the platform, the `apiKey` secret's actual value is your air-gapped license key.
+Although the config appears similar to when connecting a virtual cluster to the platform, the `apiKey` secret's actual value is your air-gapped license key.
 :::
 
-```bash title="API Key configuration"
-cat <<EOF > platform-api-key.yaml
+```bash title="API key configuration to activate enterprise features"
 external:
   platform:
     apiKey:
@@ -265,101 +231,136 @@ external:
       # Default enabled to create the necessary RBAC roles
       # and role bindings in order to find the secret
       createRBAC: true
-EOF
 ```
 
-## Deploy vCluster Pro
+</details>
+
+## Deploy vCluster {#deploy-vcluster}
+
+### Prerequisites 
+
+- The machine that is running the install commands must have access to pull the Helm chart from the private registry.
+- The host cluster where the vCluster is being deployed on must have access to pull images from the private registry.
+<BasePrerequisites />
+
+### Set up the host cluster and deploy
 
 <Flow>
   <Step>
-License Setup
+  On the host cluster, create the namespace for the vCluster, where the secrets and vCluster control plane pod are to be deployed in. 
 
-Create a Kubernetes `Secret` from the License Key provided by Loft in the `Namespace` where you are installing the air-gapped vCluster instance:
+  ```bash title="Create vCluster namespace"
+  export VCLUSTER_NAMESPACE=vcluster-my-vcluster  # Replace with the name of the namespace you want to deploy your vCluster into
+  kubectl create namespace ${VCLUSTER_NAMESPACE}
+  ```
 
-:::tip
-License secret is already `base64` encoded.
-:::
+  </Step>
+  <Step>
 
-```bash title="Create Kubernetes Secret"
-#!/bin/bash
+  Create the secret to validate the license. 
 
-# Set the license key as an environment variable (already base64 encoded)
-export VCLUSTER_LICENSE_KEY="YOUR_BASE64_ENCODED_LICENSE_KEY_HERE"
+  Create a Kubernetes secret using the LoftLabs license key in the namespace where you deploy the vCluster.
 
-# Optionally create the namespace
-kubectl create namespace vcluster-ns
+  :::note
+  The license secret is already base64-encoded.
+  :::
 
-# Create secret
-kubectl create -f - <<EOF
-apiVersion: v1
-kind: Secret
-metadata:
-  name: vcluster-platform-api-key
-  namespace: vcluster-ns
-type: Opaque
-data:
-  license: ${VCLUSTER_LICENSE_KEY}
-EOF
-```
+  ```bash title="Create a Kubernetes secret for license Key"
+  # Set the license key as an environment variable (already base64 encoded)
+  export VCLUSTER_LICENSE_KEY="YOUR_BASE64_ENCODED_LICENSE_KEY_HERE"
+  
+  # Create secret
+  kubectl create -f - <<EOF
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: vcluster-platform-license-key
+    namespace: ${VCLUSTER_NAMESPACE}
+  type: Opaque
+  data:
+    license: ${VCLUSTER_LICENSE_KEY}
+  EOF
+  ```
+  </Step>
+  <Step>
+  **Optional**: Create a secret to authenticate to your private registry.
+
+  If your private registry requires authentication, create a Kubernetes secret that stores your login credentials.
+  Place this secret in the same namespace where the vCluster is deployed so the control plane can pull the required container images.
+
+  ```bash title="Create Kubernetes secret for login credentials"
+  kubectl create -f - <<EOF
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: registry-credentials-secret-name
+    namespace: ${VCLUSTER_NAMESPACE}
+  type: Opaque
+  data:
+    # Credentials based on your private registry
+  EOF
+  ```
+
   </Step>
 
   <Step>
-Configuration File
+  Review your `vcluster.yaml` file.
 
-At this point, you should have a `vcluster.yaml` file with the necessary
-configuration for your air-gapped vCluster Pro installation. It could look
-something like this:
-
-Create a `vcluster.yaml` file (Helm chart values file) based on the configuration examples from above:
-
-```yaml title="vcluster.yaml configuration"
-controlPlane:
-  advanced:
-    defaultImageRegistry: my-private-registry:5000/vcluster/
-    serviceAccount:
-      imagePullSecrets:
-        - name-of-your-image-pull-secret
-  backingStore:
-    etcd:
-      embedded:
-        enabled: true
-  coredns:
-    embedded: true
-
-external:
-  platform:
-    apiKey:
-      secretName: vcluster-platform-api-key
-```
+  ```yaml title="vcluster.yaml configuration"
+  controlPlane:
+    advanced:
+      defaultImageRegistry: ecr.io/myteam # Replace with your private image registry
+      serviceAccount:
+        imagePullSecrets: 
+          - name: registry-credentials-secret-name # Replace with the name of the registry credentials secret
+      workloadServiceAccount: 
+        imagePullSecrets:
+          - name: registry-credentials-secret-name # Replace with the name of the registry credentials secret
+    
+  external:
+    platform:
+      apiKey:
+        secretName: vcluster-platform-license-key
+  ```
 
   </Step>
+  <Step>
 
-<Step>
-Install vCluster Pro
+  Deploy vCluster into the namespace where you deployed the secrets.
 
-Use Helm to install the vCluster Pro instance into the `namespace` where you installed the license `secret`:
+  ```bash title="Deploy vCluster with Helm"
+  export VCLUSTER_VERSION=0.24.0 # Replace with the chart version that was pushed into your private registry
+  export REGISTRY=myecr.io/team # Replace with the private registry
+  
+  export VCLUSTER_NAME="my-vcluster" # Replace with what you want to name your vCluster
+  
+  helm upgrade --install "${VCLUSTER_NAME}" oci://${REGISTRY}/charts/vcluster:${VCLUSTER_VERSION} \
+    --version ${VCLUSTER_VERSION} \
+    --values vcluster.yaml \
+    --namespace ${VCLUSTER_NAMESPACE} \
+  ```
 
-```bash title="Install vCluster Pro with Helm"
-export VCLUSTER_PRO_NAME="vcluster-pro"
-export VCLUSTER_PRO_NAMESPACE="vcluster-ns"
-helm upgrade --install "${VCLUSTER_PRO_NAME}" vcluster-${VERSION}.tgz \
-  --version ${VERSION} \
-  --values vcluster.yaml \
-  --namespace ${VCLUSTER_PRO_NAMESPACE} \
-```
-
-</Step>
-
+  </Step>
 </Flow>
-## Air-gapped vCluster Pro with FIPS images
 
-To run vCluster in a FIPS compliant environment, the `vcluster.yaml` needs to be configured to use the Loft GitHub Container Registry with the FIPS compliant images for the syncer (vCluster control plane `StatefulSet`) and the Kubernetes distro images and configured to use the vCluster Pro embedded CoreDNS.
+## Air-gapped vCluster with FIPS images {#air-gapped-vCluster-FIPS-images}
 
-:::info
-Refer to the [FIPS configuration guide](/vcluster/deploy/security/fips) for more details.
+To run vCluster in a FIPS-compliant environment, you must push FIPS-compliant images to your private registry.
+
+Push the following images, using the appropriate Kubernetes version as the tag.  
+Tags are listed in the `images.txt` and `images-optional.txt` files.
+
+- `ghcr.io/loft-sh/vcluster-pro-fips`
+- `ghcr.io/loft-sh/kubernetes-fips`
+
+
+:::tip
+The steps for [pulling, tagging, and pushing these images](#pull-push-images) are the same as for standard images. The only difference is that you reference the FIPS-compliant images instead.
 :::
 
-The following is an example `vcluster.yaml` configuration of air-gapped vCluster Pro with FIPS compliant images and assumes you have created a `Secret` named `vcluster-platform-api-key` with the air-gapped license key provided by Loft in the same `Namespace` where you are deploying the vCluster instance
+For more details on FIPS, refer to the [FIPS configuration guide](/vcluster/deploy/security/fips).
+
+The following is an example `vcluster.yaml` configuration with the FIPS compliant images. 
 
 <details>
   <summary>FIPS configuration</summary>


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

