### PR TITLE
feat: consolidated k8s disro image setting

### DIFF
--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
@@ -23,7 +23,7 @@ After deploying your vCluster, changing the Kubernetes distribution of vCluster 
 
 ## Configure Kubernetes version and image options {#setting-kubernetes-version}
 
-When using the K8s distribution, you can configure the container image used for the Kubernetes components. The K8s distribution deploys the API server, controller manager, and scheduler as a single container from the [loft-sh/kubernetes](https://github.com/loft-sh/kubernetes) repository.
+When using the K8s distribution, you can configure the container image for the Kubernetes components. The K8s distribution deploys the API server, controller manager, and scheduler as a single container from the [loft-sh/kubernetes](https://github.com/loft-sh/kubernetes) repository.
 
 You can customize the container image by specifying the registry, repository, and tag in your vCluster configuration:
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
@@ -6,8 +6,8 @@ description: Configure Kubernetes as the distro for the virtual cluster.
 ---
 
 import DistroK8s from '../../../../../_partials/config/controlPlane/distro/k8s.mdx'
-import K8sCompat from '@site/vcluster/_fragments/distro/compat-k8s.mdx'
-import DefaultDistroNote from '@site/vcluster/_fragments/default-distro-note.mdx'
+import K8sCompat from '../../../../../_fragments/distro/compat-k8s.mdx'
+import DefaultDistroNote from '../../../../../_fragments/default-distro-note.mdx'
 
 <DefaultDistroNote/>
 
@@ -20,6 +20,28 @@ After deploying your vCluster, changing the Kubernetes distribution of vCluster 
 ## Compatibility matrix
 
 <K8sCompat/>
+
+## Configure Kubernetes version and image options {#setting-kubernetes-version}
+
+When using the K8s distribution, you can configure the container image used for the Kubernetes components. The K8s distribution deploys the API server, controller manager, and scheduler as a single container from the [loft-sh/kubernetes](https://github.com/loft-sh/kubernetes) repository.
+
+You can customize the container image by specifying the registry, repository, and tag in your vCluster configuration:
+
+```yaml title="vcluster.yaml"
+controlPlane:
+  distro:
+    k8s:
+      image:
+        registry: ghcr.io           # Default: ghcr.io (can be overridden globally with controlPlane.advanced.defaultImageRegistry)
+        repository: loft-sh/kubernetes  # Default: loft-sh/kubernetes
+        tag: v1.32.1                # Default: v1.32.1 (or matches host Kubernetes version)
+```
+
+The `tag` field specifies the Kubernetes version to use. By default, it uses v1.32.1 or matches the host cluster's Kubernetes version.
+
+:::note
+The `controlPlane.distro.k8s.version` field is deprecated. Use `controlPlane.distro.k8s.image.tag` instead to specify the Kubernetes version.
+:::
 
 ## Config reference
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-677--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/control-plane/components/distro/k8s

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-601

