### PR TITLE
document what's translated and not supported in the istio CRs

### DIFF
--- a/vcluster/_fragments/integrations/istio.mdx
+++ b/vcluster/_fragments/integrations/istio.mdx
@@ -293,7 +293,7 @@ You can find your contexts by running `kubectl config get-contexts`
         app: nginx
     ```
 
-    The istio.io/use-waypoint: waypoint label directs Istio to route traffic for the labeled resource through the waypoint proxy within the same namespace. This configuration enables [Layer 7 (L7) policy](https://istio.io/latest/docs/ambient/usage/l7-features/) enforcement and observability features provided by the waypoint proxy. Applying this label to a namespace ensures that all Pods and Services within that namespace use the specified waypoint proxy. 
+    The istio.io/use-waypoint: waypoint label directs Istio to route traffic for the labeled resource through the waypoint proxy within the same namespace. This configuration enables [Layer 7 (L7) policy](https://istio.io/latest/docs/ambient/usage/l7-features/) enforcement and observability features provided by the waypoint proxy. Applying this label to a namespace ensures that all Pods and Services within that namespace use the specified waypoint proxy.
 
     To deploy a Service defined in the `service.yaml` file within the `test` namespace of the Kubernetes cluster specified by the `${VCLUSTER_CTX}` context, use the following command:
 
@@ -463,6 +463,44 @@ You can find your contexts by running `kubectl config get-contexts`
   </Step>
 </Flow>
 
+## Fields translated during the sync to host
+
+Following fields of `Gateway` are modified by vCluster during the sync to host:
+ - reference to the TLS Secret is re-written `spec.servers[*].tls.credentialName`. Secret is automatically synced to the host cluster.
+ - namespace, `.` and `*` prefix, followed by `/` is stripped from `spec.servers[*].hosts[*]`, so e.g. `foo-namespace/loft.sh` becomes `loft.sh` in the host object.
+ - additional labels `vcluster.loft.sh/managed-by: [YOUR VIRTUAL CLUSTER NAME]` and `vcluster.loft.sh/namespace: [VIRTUAL NAMESPACE]` are automatically added to the `spec.subsets[*].labels`
+
+For additional information how Secret and Service references are translated, read [How does syncing work?](../../configure/vcluster-yaml/sync/README.mdx#how-does-syncing-work)
+
+Following fields of `DestinationRule` are modified by vCluster during the sync to host:
+  - reference to the virtual Kubernetes Service is re-written for `spec.host`
+  - reference to the TLS Secret in `spec.trafficPolicy.portLevelSettings[*].tls.credentialName` & `spec.trafficPolicy.tls.credentialName` is re-written. Secrets are automatically synced to the host cluster.
+  - additional labels
+
+Following fields of `VirtualService` are modified by vCluster during the sync to host:
+ - reference to the virtual Kubernetes Service is re-written for:
+- `spec.hosts[*]`
+- `spec.http[*].route[*].destination.host`
+- `spec.http[*].mirrors[*].destination.host`
+- `spec.tcp[*].route[*].destination.host`
+- `spec.tls[*].route[*].destination.host`
+
+  - reference to the `networking.istio.io/v1` kind: `Gateway` is re-written for:
+- `spec.gateways[*]`
+- `spec.http[*].match[*].gateways[*]`
+- `spec.tls[*].match[*].gateways[*]`
+- `spec.tcp[*].match[*].gateways[*]`
+  - reference to the `networking.istio.io/v1` kind: `VirtualService` is re-written for:
+- `spec.http[*].delegate`
+
+Fields not supported in `VirtualService`:
+ - `spec.exportTo`
+ - `spec.http[*].match[*].sourceLabels`
+ - `spec.http[*].match[*].sourceNamespace`
+ - `spec.tcp[*].match[*].sourceLabels`
+ - `spec.tcp[*].match[*].sourceNamespace`
+ - `spec.tls[*].match[*].sourceLabels`
+ - `spec.tls[*].match[*].sourceNamespace`
 
 ## Config reference
 


### PR DESCRIPTION
# Content Description
added a note about what's being translated in the sync of istio resources and what is not supported.


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
Closes ENG-6861

