### PR TITLE
fix: add EOL to v21

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -21,7 +21,7 @@ Write your content here...
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: "vcluster docs | Virtual Clusters for Kubernetes",
+  title: "vCluster docs | Virtual Clusters for Kubernetes",
   tagline: "Virtual Clusters for Kubernetes",
   url: "https://vcluster.com",
   baseUrl: __webpack_public_path__,
@@ -59,7 +59,7 @@ const config = {
           lastVersion: "current",
           versions: {
             current: {
-              label: "v0.24",
+              label: "v0.25",
               banner: "none",
               badge: false,
             },
@@ -212,7 +212,7 @@ const config = {
       },
       navbar: {
         logo: {
-          alt: "vcluster",
+          alt: "vCluster",
           src: "/media/rebranding/vCluster_horizontal-orange.svg",
           href: "https://vcluster.com/docs",
           target: "_self",
@@ -287,7 +287,7 @@ const config = {
       announcementBar: {
         id: "platform-upgrade",
         content:
-          '🚀 <strong>New releases: <a href="https://www.vcluster.com/releases/en/changelog?hideLogo=true&hideMenu=true&theme=dark&embed=true&c=vCluster" target="_blank">platform 4.2 and vCluster 0.25</a></strong>',
+          '🚀 <strong>New releases: <a href="https://www.vcluster.com/releases/en/changelog?hideLogo=true&hideMenu=true&theme=dark&embed=true&c=vCluster" target="_blank">vCluster Platform 4.2 and vCluster 0.25</a></strong>',
         backgroundColor: "#4a90e2",
         textColor: "#ffffff",
         isCloseable: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -136,7 +136,7 @@ const config = {
             badge: true,
           },
           "0.21.0": {
-            label: "v0.21 (EOl)",
+            label: "v0.21 (EOL)",
             banner: "unmaintained",
             badge: true,
           },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -136,7 +136,7 @@ const config = {
             badge: true,
           },
           "0.21.0": {
-            label: "v0.21 (EOS)",
+            label: "v0.21 (EOl)",
             banner: "unmaintained",
             badge: true,
           },


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Add the EOL to the nav for v21


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

[Link to Preview](https://deploy-preview-695--vcluster-docs-site.netlify.app/docs/vcluster)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-624

