### PR TITLE
add patches fragment to sync.fromHost.nodes

### DIFF
--- a/vcluster/_fragments/patches.mdx
+++ b/vcluster/_fragments/patches.mdx
@@ -3,7 +3,7 @@ import CodeBlock from '@theme/CodeBlock';
 
 <ProAdmonition/>
 
-Patches override the default resource syncing rules in your vCluster YAML configurations.
+Patches override the default resource syncing rules in your vCluster yaml configurations.
 
 By default, vCluster [syncs specific resources](https://www.vcluster.com/docs/vcluster/next/configure/vcluster-yaml/sync/) between virtual and host clusters. To modify the sync behavior, you can use patches to specify which fields to edit, exclude, or override during syncing.
 
@@ -16,20 +16,20 @@ vCluster supports two patch types:
 
 :::info Using wildcards in patches
 You can apply a wildcard, using an asterisk (`*`) in a specified path, to modify all elements of an array or object.
-For instance, `spec.containers[*].name` selects the `name` field of every container in the `spec.containers` array, and `spec.containers[*].volumeMounts[*]` selects all `volumeMounts` for each container. 
+For instance, `spec.containers[*].name` selects the `name` field of every container in the `spec.containers` array, and `spec.containers[*].volumeMounts[*]` selects all `volumeMounts` for each container.
 When using the asterisk (`*`) notation, vCluster applies changes individually to every element that matches the path.
 :::
 
 ### JavaScript expression patch
 
-A JavaScript expression patch allows you to use JavaScript ES6 expressions to change specific fields when syncing between virtual and host clusters. 
+A JavaScript expression patch allows you to use JavaScript ES6 expressions to change specific fields when syncing between virtual and host clusters.
 This is useful when modifying resource configurations to align with differing environments or naming conventions between clusters. If your clusters use different container name prefixes, a JavaScript expression patch can automatically update them.
 
 You can define a path for <code>{props.path}</code> field in `vcluster.yaml` using the following configuration:
 
 <CodeBlock language="yaml">
 {`sync:
-  toHost:
+  ${props.direction}:
     ${props.resource}:
       enabled: true
       patches:
@@ -49,6 +49,18 @@ You can use the `reverseExpression` field to define how to revert changes when s
 For example, add `reverseExpression: {"value.slice('my-prefix'.length)"}` to `vcluster.yaml` to remove the `"my-prefix-"` prefix when syncing back from the host cluster to the virtual cluster in the previous example.
 :::
 
+To replace value with a hardcoded one, put the desired value in the quotation marks:
+<CodeBlock language="yaml">
+  {`sync:
+  ${props.direction}:
+    ${props.resource}:
+      enabled: true
+      patches:
+      - path: ${props.path}
+        expression: '"my-value"'
+`}
+</CodeBlock>
+
 #### Context variable
 
 The context variable is an object supported in JavaScript expression patches, that provides access to virtual cluster data during syncing. The context object includes the following properties:
@@ -66,7 +78,7 @@ A reference patch links a field in one resource to another resource. During sync
 
 You can use reference patches to share resources, such as `Secrets` or `ConfigMaps`, between clusters without manually recreating or duplicating them.
 
-For example, if the host cluster contains a secret named `"my-example-secret"`, vCluster automatically imports it into the virtual cluster. 
+For example, if the host cluster contains a secret named `"my-example-secret"`, vCluster automatically imports it into the virtual cluster.
 
 Workloads in the virtual cluster can then use the secret without manual syncing.
 
@@ -86,7 +98,7 @@ You can sync between the virtual cluster and the host cluster by mapping `spec.s
 
 In the example:
 
-- The code uses a patch to add `metadata.annotations["my-secret-ref"]` 
+- The code uses a patch to add `metadata.annotations["my-secret-ref"]`
 - It references a `Secret` in the host cluster using the patch and ensures <code>{props.resource}</code> in the host cluster links to the correct `Secret`.
 
 :::info Multi namespace mode

--- a/vcluster/configure/vcluster-yaml/sync/from-host/nodes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/nodes.mdx
@@ -6,6 +6,7 @@ description: Configuration for ...
 ---
 
 import SyncNodes from '../../../../_partials/config/sync/fromHost/nodes.mdx'
+import Patches from '../../../../_fragments/patches.mdx'
 
 {/*
 `nodes.enabled`:
@@ -126,6 +127,10 @@ sync:
       enabled: true
       clearImageStatus: true
 ```
+
+### Patches
+
+<Patches resource="nodes" path="status.nodeInfo.operatingSystem" direction="fromHost"  />
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/advanced/pod-disruption-budgets.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/advanced/pod-disruption-budgets.mdx
@@ -29,7 +29,7 @@ sync:
 
 ## Patches
 
-<Patches resource="podDisruptionBudgets" path="metadata.annotations[*]" />
+<Patches resource="podDisruptionBudgets" path="metadata.annotations[*]" direction="toHost"  />
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/config-maps.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/config-maps.mdx
@@ -46,7 +46,7 @@ sync:
 
 ## Patches
 
-<Patches resource="configMaps" path="metadata.annotations[*]" />
+<Patches resource="configMaps" path="metadata.annotations[*]" direction="toHost"  />
 
 ## Config reference
 <DisableResourceWarning/>

--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/pods.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/pods.mdx
@@ -77,7 +77,7 @@ sync:
 
 ## Patches
 
-<Patches resource="pods" path="spec.containers[*].name" />
+<Patches resource="pods" path="spec.containers[*].name" direction="toHost"  />
 
 ## Use secrets for ServiceAccount tokens
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/secrets.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/secrets.mdx
@@ -42,7 +42,7 @@ sync:
 
 ## Patches
 
-<Patches resource="secrets" path="metadata.annotations[*]" />
+<Patches resource="secrets" path="metadata.annotations[*]" direction="toHost"  />
 
 ## Config reference
 <DisableResourceWarning/>

--- a/vcluster/configure/vcluster-yaml/sync/to-host/networking/endpoints.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/networking/endpoints.mdx
@@ -28,7 +28,7 @@ sync:
 
 ## Patches
 
-<Patches resource="endpoints" path="metadata.annotations[*]" />
+<Patches resource="endpoints" path="metadata.annotations[*]" direction="toHost"  />
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/networking/ingresses.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/networking/ingresses.mdx
@@ -31,7 +31,7 @@ sync:
 
 ## Patches
 
-<Patches resource="ingresses" path="spec.rules[*].host" />
+<Patches resource="ingresses" path="spec.rules[*].host" direction="toHost"  />
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/networking/network-policies.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/networking/network-policies.mdx
@@ -33,7 +33,7 @@ NetworkPolicy resources inside virtual clusters rely on the host cluster's suppo
 
 ## Patches
 
-<Patches resource="networkPolicies" path="metadata.annotations[*]" />
+<Patches resource="networkPolicies" path="metadata.annotations[*]" direction="toHost"  />
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/networking/services.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/networking/services.mdx
@@ -21,7 +21,7 @@ Sync all [Service](https://kubernetes.io/docs/concepts/services-networking/servi
 
 ## Patches
 
-<Patches resource="services" path="spec.ports[*].name" />
+<Patches resource="services" path="spec.ports[*].name" direction="toHost" />
 
 ## Config reference
 <DisableResourceWarning/>

--- a/vcluster/configure/vcluster-yaml/sync/to-host/storage/persistent-volume-claims.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/storage/persistent-volume-claims.mdx
@@ -29,7 +29,7 @@ sync:
 
 ## Patches
 
-<Patches resource="persistentVolumeClaims" path="spec.storageClassName" />
+<Patches resource="persistentVolumeClaims" path="spec.storageClassName" direction="toHost"  />
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/storage/persistent-volumes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/storage/persistent-volumes.mdx
@@ -31,7 +31,7 @@ sync:
 
 ## Patches
 
-<Patches resource="persistentVolumes" path="metadata.annotations[*]" />
+<Patches resource="persistentVolumes" path="metadata.annotations[*]" direction="toHost"  />
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/storage/storage-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/storage/storage-classes.mdx
@@ -29,7 +29,7 @@ sync:
 
 ## Patches
 
-<Patches resource="storageClasses" path="metadata.annotations[*]" />
+<Patches resource="storageClasses" path="metadata.annotations[*]" direction="toHost" />
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/storage/volume-snapshots.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/storage/volume-snapshots.mdx
@@ -36,7 +36,7 @@ sync:
 
 ## Patches
 
-<Patches resource="volumeSnapshots" path="metadata.annotations[*]" />
+<Patches resource="volumeSnapshots" path="metadata.annotations[*]" direction="toHost" />
 
 ## Config reference
 


### PR DESCRIPTION
; add direction prop to the patches code block

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENG-6905

