### PR TITLE
feat: Add platform permalink for ownedaccesskeys

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -104,6 +104,15 @@ command = """
   from = "/docs/platform-ui-link/platform/crd/clusterroletemplate/:version"
   to = "/docs/platform/:version/api/resources/clusterroletemplate"
 
+# Owned Access Key
+[[redirects]]
+from = "/docs/platform-ui-link/platform/crd/ownedaccesskey"
+to = "/docs/platform/api/resources/ownedaccesskey"
+
+[[redirects]]
+from = "/docs/platform-ui-link/platform/crd/ownedaccesskey/:version"
+to = "/docs/platform/:version/api/resources/ownedaccesskey"
+
 ## Misc. platform links
 
 # Database connector
@@ -225,12 +234,12 @@ to = "/docs/vcluster/:version/manage/backup-restore#migrate-and-override-vcluste
   from = "/docs/platform-ui-link/vcluster/control-plane/:version"
   to = "/docs/vcluster/:version/category/components"
 
-[[redirects]]  
-  from = "/docs/platform-ui-link/vcluster/backing-store"  
-  to = "/docs/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/"  
+[[redirects]]
+  from = "/docs/platform-ui-link/vcluster/backing-store"
+  to = "/docs/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/"
 
-[[redirects]]  
-  from = "/docs/platform-ui-link/vcluster/backing-store/:version"  
+[[redirects]]
+  from = "/docs/platform-ui-link/vcluster/backing-store/:version"
   to = "/docs/vcluster/:version/configure/vcluster-yaml/control-plane/components/backing-store/"
 
 # Resource quota


### PR DESCRIPTION

# Content Description
This adds a new permalink for the platform:
`/docs/platform-ui-link/platform/crd/ownedaccesskey` -> `/docs/platform/api/resources/ownedaccesskey`
