### PR TITLE
chore: vale rule to prevent admonitions indentaiton in Step tags

### DIFF
--- a/.github/styles/Loft/no-indented-admonitions-in-steps.yml
+++ b/.github/styles/Loft/no-indented-admonitions-in-steps.yml
@@ -1,0 +1,9 @@
+extends: existence
+message: "Admonitions inside <Step> components must have zero indentation to avoid MDX parsing errors"
+level: error
+scope: raw
+nonword: true
+tokens:
+  # This pattern specifically matches indented admonitions that appear within <Step> components
+  # It captures the indented ::: line itself, which will position the error correctly
+  - '(?ms)^(?=.*<Step[^>]*>)(?=.*</Step>)[ \t]+:::(note|tip|info|warning|danger|caution|important|success)\b'


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
![image](https://github.com/user-attachments/assets/31be28b2-36f9-41c4-b25a-20a53ee8a1f3)


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-627

