### PR TITLE
refactor(vcluster): move Gateway API and remove cert-manager examples

### DIFF
--- a/platform/install/advanced/air-gapped.mdx
+++ b/platform/install/advanced/air-gapped.mdx
@@ -280,7 +280,7 @@ Detailed steps are only provided for how to pull and push the vCluster Platform 
 <Flow id="offline-helm-chart">
   <Step>
 
-  :::notes
+  :::note
   If you haven’t already set the environment variables, set them now before continuing.
   :::
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/nodes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/nodes.mdx
@@ -2,7 +2,7 @@
 title: Nodes
 sidebar_label:  nodes
 sidebar_position: 2
-description: Configuration for ...
+description: Configuration for node synchronization in vCluster, including pseudo and real node syncing options.
 ---
 
 import SyncNodes from '../../../../_partials/config/sync/fromHost/nodes.mdx'
@@ -15,10 +15,12 @@ vCluster syncs pseudo nodes from the host cluster where there are virtual cluste
 However, when you need to access specific node information, you can choose to sync real nodes from the host cluster to the virtual cluster. This requires a cluster role.
 
 :::info Node IP obfuscation
-By default, vCluster obfuscates node IP addresses—replacing real IPs with placeholder values—when syncing real nodes. This prevents internal network details from being exposed within the virtual cluster. For more information, see [Control node IP visibility](../../../../learn-how-to/control-node-ip-visibility.mdx).
+By default, vCluster obfuscates node IP addresses when syncing real nodes to protect sensitive information. Learn how to [control node IP visibility](../../../../learn-how-to/control-node-ip-visibility.mdx) for your use case.
 :::
 
-### Sync pseudo nodes 
+### Sync pseudo nodes (default)
+
+### Sync pseudo nodes
 
 Sync pseudo nodes to the virtual cluster. This is enabled by default. This default configuration does not require a cluster role.
 
@@ -29,7 +31,7 @@ sync:
       enabled: false
 ```
 
-vCluster ignores the `selector.all` and `selector.labels` fields. However, if a pod is created with `spec.nodeSelector`, the syncer generates a pseudo node in the virtual cluster. This pseudo node includes annotations and labels from the real node, allowing the pod’s node selector to match a corresponding node within the virtual cluster.
+vCluster ignores the `selector.all` and `selector.labels` fields. However, if a pod is created with `spec.nodeSelector`, the syncer generates a pseudo node in the virtual cluster. This pseudo node includes annotations and labels from the real node, allowing the pod's node selector to match a corresponding node within the virtual cluster.
 
 For more information, see the Kubernetes documentation on [`spec.nodeSelector`](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).
 
@@ -146,4 +148,3 @@ For more advanced use cases, such as controlling node IP visibility, see the [co
 ## Config reference
 
 <SyncNodes/>
-

--- a/vcluster/configure/vcluster-yaml/sync/to-host/advanced/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/advanced/custom-resources.mdx
@@ -159,13 +159,43 @@ spec:
     - other-domain.com # the patch removed the www. from www.other-domain.com
 ```
 
-## Full Example: Using cert-manager custom resource in Single-Namespace-Mode (default)
+## Configure Kubernetes Gateway API sync
 
-<CertManagerExample singleNamespace />
+To use the Kubernetes Gateway API with custom resources, follow these steps:
 
-## Full Example: Using cert-manager custom resource in Multi-Namespace-Mode
+### Install Gateway CRD in the host
 
-<CertManagerExample />
+```bash title="Install Gateway CRD"
+kubectl --context="${HOST_CTX}" get crd gateways.gateway.networking.k8s.io &> /dev/null || \
+kubectl --context="${HOST_CTX}" apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
+```
+
+### Create Waypoint Gateway
+
+Create a waypoint gateway configuration:
+
+```yaml title="waypoint-gateway.yaml"
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: waypoint
+  labels:
+    istio.io/waypoint-for: service
+spec:
+  gatewayClassName: istio-waypoint
+  listeners:
+  - name: mesh
+    port: 15008
+    protocol: HBONE
+```
+
+Apply it to your host cluster:
+
+```bash title="Create Waypoint Gateway"
+kubectl --context="${HOST_CTX}" create -f waypoint-gateway.yaml --namespace="${VCLUSTER_HOST_NAMESPACE}"
+```
+
+Once configured, you can configure your custom resources to sync Gateway API resources between the virtual and host clusters.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/advanced/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/advanced/custom-resources.mdx
@@ -79,7 +79,8 @@ With multi-namespace-mode you only need to rewrite references that include a nam
 ### JavaScript expression patches {#javascript-expression-patches}
 <!-- vale on -->
 
-These are powerful JavaScript ES6 compatible expression patches that can be used to change a field while syncing. You define how it changes when syncing from the virtual cluster into the host cluster or when syncing from the host cluster into the virtual cluster. To add a suffix to certificate DNS names you can do:
+These are JavaScript ES6 compatible expression patches that can be used to change a field while syncing. You define how it changes when syncing from the virtual cluster into the host cluster or when syncing from the host cluster into the virtual cluster. To add a suffix to certificate DNS names you can:
+
 ```yaml
 sync:
   toHost:
@@ -95,14 +96,15 @@ sync:
 ```
 
 There is also a variable called `context` besides `value` that can be used to access vCluster specific data:
-* `context.vcluster.name`: Name of the virtual cluster
-* `context.vcluster.namespace`: Namespace of the virtual cluster
-* `context.vcluster.config`: Config of the virtual cluster, basically `vcluster.yaml` merged with the defaults
-* `context.hostObject`: Host object (can be null if not available)
-* `context.virtualObject`: Virtual object (can be null if not available)
-* `context.path`: The matched path on the object, useful when using wildcard path selectors (*)
+- `context.vcluster.name`: Name of the virtual cluster
+- `context.vcluster.namespace`: Namespace of the virtual cluster
+- `context.vcluster.config`: Config of the virtual cluster, basically `vcluster.yaml` merged with the defaults
+- `context.hostObject`: Host object (can be null if not available)
+- `context.virtualObject`: Virtual object (can be null if not available)
+- `context.path`: The matched path on the object, useful when using wildcard path selectors (*)
 
 For example, to add `www.` to every DNS name specified in a cert-manager certificate in the path `spec.dnsNames`, you can use the following patch:
+
 ```yaml
 sync:
   toHost:
@@ -117,7 +119,8 @@ sync:
           reverseExpression: "value.startsWith('www.') ? value.slice(4) : value"
 ```
 
-With that patch, creating a new certificate within the vCluster like this:
+The patch creates a new certificate within the vCluster:
+
 ```yaml
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -128,7 +131,8 @@ spec:
     - example.com
 ```
 
-Would create the following certificate in the host cluster:
+vCluster syncs the host cluster and applies your patch, creating this modified certificate:
+
 ```yaml
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -139,7 +143,8 @@ spec:
     - www.example.com # the patch added www. to this field
 ```
 
-When you change now the certificate in the host cluster like this:
+If you directly edit the certificate in the host cluster and change the domain:
+
 ```yaml
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -150,7 +155,8 @@ spec:
     - www.other-domain.com # changed from www.example.com
 ```
 
-vCluster would sync back the certificate like this:
+vCluster detects the change, applies the reverse patch, and updates the certificate in your virtual cluster:
+
 ```yaml
 apiVersion: cert-manager.io/v1
 kind: Certificate

--- a/vcluster/configure/vcluster-yaml/sync/to-host/advanced/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/advanced/custom-resources.mdx
@@ -16,9 +16,9 @@ import CertManagerConfig from '!!raw-loader!@site/vcluster/configure/vcluster-ya
 
 vCluster allows you to sync custom resources from the virtual cluster to the host cluster. This allows you to sync arbitrary resources that are by default not synced by vCluster. This only works for resources that have a custom resource definition in the host cluster.
 
-If those custom resources will create other resources inside the host cluster, vCluster will try to find them and sync them back to the host cluster as well. E.g. a [cert-manager](https://cert-manager.io/) certificate creates a secret which will be synced back automatically into the virtual cluster.
+If those custom resources create other resources inside the host cluster, vCluster tries to find them and syncs them back to the host cluster as well. E.g. a [cert-manager](https://cert-manager.io/) certificate creates a secret which syncs back automatically into the virtual cluster.
 
-vCluster will automatically add the required cluster and namespace RBAC permissions for retrieving the custom resource definition and syncing the resources from the virtual cluster to the host cluster.
+vCluster automatically adds the required cluster and namespace RBAC permissions for retrieving the custom resource definition and syncing the resources from the virtual cluster to the host cluster.
 <br />
 
 :::info Only Namespace-Scoped Resource
@@ -29,7 +29,7 @@ This feature currently only works for namespace-scoped resources only.
 If you want to sync many custom resources, consider using [multi-namespace-mode](../../../experimental/multi-namespace-mode).
 :::
 
-## Enable Custom Resource Syncing
+## Enable custom resource syncing {#enable-custom-resource-syncing}
 
 To enable custom resource syncing from the virtual cluster to the host cluster, figure out what CRDs you want to sync via `kubectl get crds`. Add the name into the `customResources` section in the sync section. Even though vCluster syncs custom resources from the virtual cluster to the host cluster, the CRDs are also copied from the host cluster to the virtual cluster. 
 
@@ -45,7 +45,7 @@ sync:
 
 ## Patches
 
-You can modify the sync behaviour with patches that target specific paths. Currently there is 2 different kinds of patches supported.
+You can modify the sync behavior with patches that target specific paths. Currently there are 2 different kinds of patches supported.
 
 :::info Wildcard patches
 You can use `*` in paths to select all entries of an array or object, e.g. `spec.containers[*].name` or `spec.containers[*].volumeMounts[*]`. vCluster calls the patch multiple times.
@@ -75,7 +75,9 @@ vCluster translates the path `spec.secretName` as it points to a secret. If the 
 With multi-namespace-mode you only need to rewrite references that include a namespace. You can use the `namespacePath` option to specify the path of the namespace of the reference.
 :::
 
-### JavaScript Expression Patches
+<!-- vale off -->
+### JavaScript expression patches {#javascript-expression-patches}
+<!-- vale on -->
 
 These are powerful JavaScript ES6 compatible expression patches that can be used to change a field while syncing. You define how it changes when syncing from the virtual cluster into the host cluster or when syncing from the host cluster into the virtual cluster. To add a suffix to certificate DNS names you can do:
 ```yaml
@@ -100,7 +102,7 @@ There is also a variable called `context` besides `value` that can be used to ac
 * `context.virtualObject`: Virtual object (can be null if not available)
 * `context.path`: The matched path on the object, useful when using wildcard path selectors (*)
 
-For example, let's assume you want to add `www.` to every DNS name specified in a cert-manager certificate in the path `spec.dnsNames`, you could use the following patch:
+For example, to add `www.` to every DNS name specified in a cert-manager certificate in the path `spec.dnsNames`, you can use the following patch:
 ```yaml
 sync:
   toHost:
@@ -170,7 +172,7 @@ kubectl --context="${HOST_CTX}" get crd gateways.gateway.networking.k8s.io &> /d
 kubectl --context="${HOST_CTX}" apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
 ```
 
-### Create Waypoint Gateway
+### Create waypoint gateway {#create-waypoint-gateway}
 
 Create a waypoint gateway configuration:
 

--- a/vcluster/learn-how-to/control-node-ip-visibility.mdx
+++ b/vcluster/learn-how-to/control-node-ip-visibility.mdx
@@ -9,6 +9,12 @@ import ProAdmonition from '../_partials/admonitions/pro-admonition.mdx'
 
 When vCluster syncs real nodes from the host cluster, it obfuscates node IP addresses by default. This behavior protects sensitive information in multi-tenant environments while still providing node features.
 
+Node IP obfuscation provides several benefits:
+
+- **Security**: Prevents exposure of host cluster network topology in multi-tenant environments
+- **Privacy**: Protects sensitive infrastructure information from virtual cluster users
+- **Isolation**: Maintains logical separation between virtual and host clusters
+
 ## Default behavior
 
 By default, when you enable real node syncing:
@@ -21,14 +27,6 @@ sync:
 ```
 
 vCluster automatically replaces the actual node IP addresses with obfuscated values. For example, if a host node has IP `192.168.1.100`, it appears in the virtual cluster with a generated IP like `10.0.0.1`.
-
-## Why IP obfuscation matters
-
-Node IP obfuscation provides several benefits:
-
-- **Security**: Prevents exposure of host cluster network topology in multi-tenant environments
-- **Privacy**: Protects sensitive infrastructure information from virtual cluster users
-- **Isolation**: Maintains logical separation between virtual and host clusters
 
 ## Control IP visibility with patches
 
@@ -130,7 +128,7 @@ vcluster connect my-vcluster -- kubectl describe node <node-name>
 
 ## Best practices
 
-1. **Default to obfuscation**: Keep IP obfuscation enabled unless you have specific requirements for real IPs.
-2. **Use labels**: Rely on node labels rather than IPs for workload scheduling and management.
-3. **Document changes**: Clearly document any modifications to default obfuscation behavior.
-4. **Test thoroughly**: Verify that your applications work correctly with obfuscated IPs before production deployment.
+- **Default to obfuscation**: Keep IP obfuscation enabled unless you have specific requirements for real IPs.
+- **Use labels**: Rely on node labels rather than IPs for workload scheduling and management.
+- **Document changes**: Clearly document any modifications to default obfuscation behavior.
+- **Test thoroughly**: Verify that your applications work correctly with obfuscated IPs before production deployment.

--- a/vcluster/learn-how-to/control-node-ip-visibility.mdx
+++ b/vcluster/learn-how-to/control-node-ip-visibility.mdx
@@ -11,9 +11,9 @@ When vCluster syncs real nodes from the host cluster, it obfuscates node IP addr
 
 Node IP obfuscation provides several benefits:
 
-- **Security**: Prevents exposure of host cluster network topology in multi-tenant environments
-- **Privacy**: Protects sensitive infrastructure information from virtual cluster users
-- **Isolation**: Maintains logical separation between virtual and host clusters
+- **Security**: Prevents exposure of host cluster network topology in multi-tenant environments.
+- **Privacy**: Protects sensitive infrastructure information from virtual cluster users.
+- **Isolation**: Maintains logical separation between virtual and host clusters.
 
 ## Default behavior
 

--- a/vcluster/learn-how-to/control-node-ip-visibility.mdx
+++ b/vcluster/learn-how-to/control-node-ip-visibility.mdx
@@ -9,12 +9,6 @@ import ProAdmonition from '../_partials/admonitions/pro-admonition.mdx'
 
 When vCluster syncs real nodes from the host cluster, it obfuscates node IP addresses by default. This behavior protects sensitive information in multi-tenant environments while still providing node features.
 
-Node IP obfuscation provides several benefits:
-
-- **Security**: Prevents exposure of host cluster network topology in multi-tenant environments.
-- **Privacy**: Protects sensitive infrastructure information from virtual cluster users.
-- **Isolation**: Maintains logical separation between virtual and host clusters.
-
 ## Default behavior
 
 By default, when you enable real node syncing:
@@ -27,6 +21,14 @@ sync:
 ```
 
 vCluster automatically replaces the actual node IP addresses with obfuscated values. For example, if a host node has IP `192.168.1.100`, it appears in the virtual cluster with a generated IP like `10.0.0.1`.
+
+## Why IP obfuscation matters
+
+Node IP obfuscation provides several benefits:
+
+- **Security**: Prevents exposure of host cluster network topology in multi-tenant environments
+- **Privacy**: Protects sensitive infrastructure information from virtual cluster users
+- **Isolation**: Maintains logical separation between virtual and host clusters
 
 ## Control IP visibility with patches
 
@@ -128,7 +130,7 @@ vcluster connect my-vcluster -- kubectl describe node <node-name>
 
 ## Best practices
 
-- **Default to obfuscation**: Keep IP obfuscation enabled unless you have specific requirements for real IPs.
-- **Use labels**: Rely on node labels rather than IPs for workload scheduling and management.
-- **Document changes**: Clearly document any modifications to default obfuscation behavior.
-- **Test thoroughly**: Verify that your applications work correctly with obfuscated IPs before production deployment.
+1. **Default to obfuscation**: Keep IP obfuscation enabled unless you have specific requirements for real IPs.
+2. **Use labels**: Rely on node labels rather than IPs for workload scheduling and management.
+3. **Document changes**: Clearly document any modifications to default obfuscation behavior.
+4. **Test thoroughly**: Verify that your applications work correctly with obfuscated IPs before production deployment.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
This PR rebases on top of #698 which should be merged first.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-614

