### PR TITLE
correct base64 Encode CA certificate

### DIFF
--- a/platform/configure/domain.mdx
+++ b/platform/configure/domain.mdx
@@ -254,7 +254,7 @@ ingress:
 If you want to [configure the platform with additionalCA](/platform/configure/config.mdx#using-a-custom-certificate-authority), the Certificate Authority used for signing this certificate has to be added as a base64 encoded value:
 
 ```bash title="Encode CA certificate"
-cat ca.crt | base64 -d
+cat ca.crt | base64
 ```
 
 Use this output in the `.additionalCA` helm value.
@@ -403,7 +403,7 @@ kubectl create secret generic tls-vcluster-platform -n vcluster-platform --type=
 If you want to [configure the platform with additionalCA](/platform/configure/config.mdx#using-a-custom-certificate-authority), use:
 
 ```bash title="Encode CA certificate"
-cat ca.crt | base64 -d
+cat ca.crt | base64
 ```
 
 as an input for the `.additionalCA` helm value.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
There are 2 Encode CA Certificate sections where the base64 command has the -d flag so is decoding not encoding


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

