### PR TITLE
fix: transfer docs on Rancher integration

### DIFF
--- a/platform/integrations/rancher/rancher-integration.mdx
+++ b/platform/integrations/rancher/rancher-integration.mdx
@@ -12,58 +12,194 @@ import Label from '@site/src/components/Label'
 
 import PartialRancher from "../../api/_partials/resources/projects/spec/rancher.mdx";
 
-Once Rancher is configured on vCluster Platform, virtual clusters can be imported into Rancher and started using as a cluster in Rancher. In order to enable this integration on each virtual cluster, the vCluster Platform project must be enabled with the Rancher integration first. 
+Deploying a virtual cluster (vCluster) in Rancher is similar to setting up any other Kubernetes cluster. The vCluster Rancher Operator helps by automatically creating a matching Rancher cluster for each vCluster, so you don't have to do it manually. Rancher users can deploy vClusters without requiring cluster management permissions, as the operator handles the necessary configurations. Additionally, project owners, project members of the virtual cluster's project, and the cluster owner are automatically assigned as cluster owners in the new Rancher cluster.
 
-## Enable Rancher Integration on a vCluster Platform project
+After configuring Rancher within the vCluster Platform, you can import virtual clusters into Rancher and manage them as standard clusters. To enable this integration for each virtual cluster, first activate the Rancher integration at the project level within the vCluster Platform.
 
-### Limitations
+## Enable the Rancher integration on a vCluster Platform project
 
-Only one Rancher project can be connected to a single vCluster Platform project. You should not configure a Rancher project to connect to multiple vCluster Platform projects, as the integration will not work in that case.
+<details>
+  <summary><strong>vCluster Rancher Operator</strong></summary>
 
-### Using the UI
+  ## Develop and Deploy the vCluster Rancher Operator
+  
+  This section outlines how to develop and deploy the vCluster Rancher Operator using DevSpace and Helm. These instructions are intended for contributors or advanced users customizing the operator.
+  
+  ### Deploy with DevSpace
+  
+  This is the preferred workflow for local development.
+  
+  ```bash
+  devspace dev
+  ````
+  
+  ### Build and push a custom image
+  
+  Build and push your image to the specified registry:
+  
+  ```bash
+  make docker-build docker-push IMG=<your-registry>/vcluster-rancher-operator:<tag>
+  ```
+  - Replace `<your-registry>` and `<tag>` with your container registry path and desired version tag.
+  
+  ### Deploy with Helm
+  
+  #### Basic Helm deployment
+  
+  Install the operator using Helm with your kubeconfig file:
+  
+  ```bash
+  KUBECONFIG=/path/to/kubeconfig.yaml helm install chart --generate-name --create-namespace
+  ```
+  
+  #### Helm deployment with a custom Iimage
+  
+  Specify a custom registry, repository, and tag:
+  
+  ```bash
+  KUBECONFIG=/path/to/kubeconfig.yaml helm install chart --generate-name --create-namespace \
+    --set image.registry=<REGISTRY> \
+    --set image.repository=<REPO/REPO> \
+    --set image.tag=<TAG>
+  ```
+  
+  ### Update RBAC configuration
+  
+  If you make changes to controller roles, update the manifests as follows:
+  
+  1. Modify the `controller-gen` tags in `controller/cluster-controller.go`.
+  2. Regenerate RBAC manifests:
+  
+  ```bash
+  make manifests
+  ```
+</details> 
+
+<details>
+  <summary><strong>Uninstall the vCluster Rancher Operator</strong></summary>
+
+  ### DevSpace Uninstall
+  
+  ```bash
+  devspace purge
+  rm -rf .devspace/*
+  ```
+  
+  ### Helm Uninstall
+  
+  ```bash
+  helm delete <release-name>
+  ```
+  
+  Replace `<release-name>` with the name of your Helm release.
+  
+  </details>
+  ```
+</details> 
+
+
+
+
+
+### Prerequisites
+
+- Docker is installed. 
+- DevSpace for deploying and managing applications. 
+- Rancher installed.
+- Access to a local Kubernetes cluster within Rancher.
+
+### Install 
 
 Before being able to enable virtual clusters with the Rancher integration, it must be enabled on the project. When vCluster Platform projects are enabled with Rancher integration, a label `loft.sh/loft-project-name: <VCLUSTER_PLATFORM_PROJECT_NAME>` is added to the Rancher project resource. 
 
-<Flow id="rancher-project-setup">
+To install the vCluster Rancher Operator using the Rancher UI:
+
+<Flow id="vcluster-rancher-operator-install">
+
   <Step>
-    In the settings of a project, click on <NavStep>Rancher</NavStep> and toggle the <Label>Enable Rancher Integration</Label> switch to enable synchronization for this project. Additional configuration options will appear.
+  In the Rancher UI, navigate to the clusters overview page and select the **local** cluster.
   </Step>
+
   <Step>
-    Input the <Label>Rancher Project ID</Label> and <Label>Rancher Cluster ID</Label> of the Rancher project you want to connect. Note that these are the IDs and are different from the project name and cluster name. The cluster ID has a `c-x-xxxx` format and the project ID has a `p-xxxx` format. 
+  In the sidebar, go to **Apps** → **Repositories**.
+  Click **Create**, set a name (for example `loft-charts`), and enter the **Index URL**:
+  `https://charts.loft.sh`
   </Step>
+
   <Step>
-    <b>[Optional]</b> Toggle the <Label>Enable Member Synchronization</Label> switch if you wish to sync the Rancher project member roles into vCluster Platform's project member roles.
+  **Optional**: Click the user icon in the top-right corner, select **Preferences** and enable **Include Prerelease Versions**.
   </Step>
+
   <Step>
-    Click <Button>Save Changes</Button> to save the vCluster Platform project settings.
+  Navigate to **Apps** → **Charts**.
+  Search for **vCluster Rancher Operator**, select it, and follow the installation prompts.
+  </Step>
+
+  <Step>
+  After installation, navigate to **Workloads** → **Deployments**.
+  Ensure that the deployment named `vcluster-rancher-operator` has the state **Active**.
+  </Step>
+
+</Flow>
+
+After it is installed, the vCluster Rancher Operator automatically integrates vCluster deployments with Rancher.
+
+### 🔍 Retrieve Rancher Cluster ID and Project ID
+
+<Flow id="rancher-id-lookup">
+
+  <Step>
+  In the Rancher UI, navigate to **Cluster Management**.
+  </Step>
+
+  <Step>
+  Select the desired cluster. Click on the name of the cluster you want to identify.
+  </Step>
+
+  <Step>
+  Click the **ellipsis (⋮)** to the cluster name and select **View YAML**.
+  </Step>
+
+  <Step>
+  In the displayed YAML, find the `metadata.name` field. This value is your **Cluster ID**.
+  </Step>
+
+  <Step>
+  Click **Explore** on the cluster containing the project you're interested in.
+  </Step>
+
+  <Step>
+  In the cluster navigation menu, click **Projects/Namespaces**.
+  </Step>
+
+  <Step>
+  Locate the project, click the **ellipsis (⋮)** next to it, and select **View YAML**.
+  </Step>
+
+  <Step>
+  In the displayed YAML, find the `metadata.name` field. This value is your **Project ID**.
   </Step>
 </Flow>
 
-:::info Finding your Rancher Project and Cluster IDs
-To find the <Label>Rancher Cluster ID</Label>, in the Rancher UI, click on 'Cluster Management' in the left side menu, and then select the desired cluster, click on the ellipsis button on the right side and select <Label>View YAML</Label>. The <code>metadata.name</code> is the Cluster ID. 
-
-To get the <Label>Rancher Project ID</Label>, in the Rancher UI, click on 'Cluster Management' in the left side menu, click <Button>Explore</Button> on the cluster that has the project you want to connect to. In the cluster explorer, click on  <NavStep>Projects/Namespaces</NavStep> in the cluster navigation. Click the ellipsis button on the right side of the desired project name and select the <Label>View YAML</Label> option. The <code>metadata.name</code> is the <Label>Rancher Project ID</Label>.
-:::
-
-### On the Project Resource
+### Project resource
 
 If you are creating a project resource into vCluster Platform directly, you can configure the Rancher integration directly on the <code>projects.managementv1.loft.sh</code> resource.
 
 <PartialRancher />
 
-## Managing Virtual Clusters in Rancher UI
+## Manage virtual clusters in the Rancher UI
 
 ### Creating a virtual cluster in the Rancher UI
 
 <Flow id="rancher-plugin-create-vcluster">
   <Step>
-    In the Rancher home page, click on the <Button>Create Virtual Cluster</Button> button.
+    In the Rancher home page, click **Create Virtual Cluster**.
   </Step>
   <Step>
     Enter a name for the virtual cluster and select the Rancher project in which you wish to create the virtual cluster. Only those projects which have the Rancher Integration enabled are displayed in the list.
   </Step>
   <Step>
-    Click the <Button>Create</Button> button which will take you to the <Label>Create VirtualClusterInstance</Label> page in the vCluster Platform to get ready to create a virtual cluster.
+    Click **Create** which takes you to the <Label>Create VirtualClusterInstance</Label> page in the vCluster Platform to get ready to create a virtual cluster.
   </Step>
   <Step>
     Click the <Label>Rancher</Label> configuration tab.
@@ -72,24 +208,24 @@ If you are creating a project resource into vCluster Platform directly, you can 
     Slide the <Label>Add to Rancher</Label> toggle to enable.
   </Step>
   <Step>
-    Click on the <Button>Create</Button>button once you have configured the rest of the virtual cluster as per your preference.
+    Click **Create** after you have configured the rest of the virtual cluster based on your preferences.
   </Step>
   <Step>
-    Navigate back to the Rancher UI and the virtual cluster should be available and in <Label>Active</Label> state.
+   In the Rancher UI, navigate to **☰ > Cluster Management**, locate your virtual cluster in the list, and confirm that its status is labeled as **Active**.
   </Step>
 </Flow>
 
-### Deleting a virtual cluster in the Rancher UI
+### Delete a virtual cluster in the Rancher UI
 
 <Flow id="rancher-plugin-delete-vcluster">
   <Step>
-    In the Rancher home page, click on the Delete icon for the virtual cluster you want to delete.
+    In the Rancher home page, click the **Delete** icon for the virtual cluster you want to delete.
   </Step>
   <Step>
-    You will be re-directed to the VirtualClusterInstance Page in the vCluster Platform UI for confirmation.
+    You are redirected to the **VirtualClusterInstance** Page in vCluster Platform for confirmation.
   </Step>
   <Step>
-    Click on the <Button>Delete</Button> to confirm in the vCluster Platform UI. The virtual cluster will be deleted from Rancher.
+    Click **Delete** to confirm in the platform UI. The virtual cluster is then deleted from Rancher.
   </Step>
 </Flow>
 
@@ -147,7 +283,7 @@ will not see the "Add to Rancher" options in the virtual cluster configuration.
     </TabItem>
 </Tabs>
 
-## Hiding Nodes in Rancher
+## Hiding nodes in Rancher
 
 Since virtual clusters are not using physical nodes, you can hide the nodes from Rancher in order for the
 virtual nodes to not be counted in your Rancher node count. In order to hide the nodes of your virtual cluster, you need to enable our Rancher nodeless plugin on the virtual cluster. 
@@ -164,10 +300,42 @@ plugins:
 You can enforce that all virtual clusters enable the plugin by enforcing template usage in the project. 
 :::
 
-##  Disabling Rancher Integration
+## Disabe Rancher integration
 
-You may disable the Rancher integration at a per virtual cluster or per project level by toggling the same sliders
-used to enable it. Disabling the integration at the virtual cluster level simply removes the virtual cluster from the Rancher UI, but the virtual cluster is still running.
+You can disable the Rancher integration at either the virtual cluster or project level. This is done by toggling the same options used to enable the integration in the UI.
 
-Disabling the integration at the project level removes **all** virtual clusters from Rancher, so be careful
-when disabling at this level. 
+### Disable at the virtual cluster level
+
+Disabling integration at the virtual cluster level removes the cluster from the Rancher UI, but the virtual cluster itself continues running in the background. This is useful if you want to stop managing a specific vCluster through Rancher without deleting it.
+
+### Disable at the project level
+
+:::note
+Use caution when disabling integration at the project level, as this impacts all associated virtual clusters.
+:::
+
+Disabling integration at the project level removes all virtual clusters in that project from the Rancher UI. The virtual clusters remain active, but they are no longer visible or manageable through Rancher.
+
+
+<details>
+  <summary><strong>Uninstall the vCluster Rancher Operator</strong></summary>
+
+  ## Uninstall the vCluster Rancher Operator
+  
+  To remove the vCluster Rancher Operator from your environment:
+  
+  ### DevSpace uninstall
+  
+  ```bash
+  devspace purge
+  rm -rf .devspace/*
+  ````
+  
+  ### Helm uninstall
+  
+  ```bash
+  helm delete <release-name>
+  ```
+  - Replace `<release-name>` with the name of your Helm release.
+
+</details> 

--- a/platform/integrations/rancher/rancher-integration.mdx
+++ b/platform/integrations/rancher/rancher-integration.mdx
@@ -12,7 +12,7 @@ import Label from '@site/src/components/Label'
 
 import PartialRancher from "../../api/_partials/resources/projects/spec/rancher.mdx";
 
-Deploying a virtual cluster (vCluster) in Rancher is similar to setting up any other Kubernetes cluster. The vCluster Rancher Operator helps by automatically creating a matching Rancher cluster for each vCluster, so you don't have to do it manually. Rancher users can deploy vClusters without requiring cluster management permissions, as the operator handles the necessary configurations. Additionally, project owners, project members of the virtual cluster's project, and the cluster owner are automatically assigned as cluster owners in the new Rancher cluster.
+The vCluster Rancher Operator automatically imports vCluster installations as Rancher clusters. Rancher users can deploy vClusters without possessing cluster create permissions, as the operator handles the necessary setup. Additionally, project owners of the project vCluster is installed in and the cluster owners of the host cluster are automatically assigned as cluster owners in the new Rancher cluster.
 
 After configuring Rancher within the vCluster Platform, you can import virtual clusters into Rancher and manage them as standard clusters. To enable this integration for each virtual cluster, first activate the Rancher integration at the project level within the vCluster Platform.
 

--- a/platform/integrations/rancher/rancher-integration.mdx
+++ b/platform/integrations/rancher/rancher-integration.mdx
@@ -14,96 +14,12 @@ import PartialRancher from "../../api/_partials/resources/projects/spec/rancher.
 
 The vCluster Rancher Operator automatically imports vCluster installations as Rancher clusters. Rancher users can deploy vClusters without possessing cluster create permissions, as the operator handles the necessary setup. Additionally, project owners of the project vCluster is installed in and the cluster owners of the host cluster are automatically assigned as cluster owners in the new Rancher cluster.
 
-After configuring Rancher within the vCluster Platform, you can import virtual clusters into Rancher and manage them as standard clusters. To enable this integration for each virtual cluster, first activate the Rancher integration at the project level within the vCluster Platform.
-
-## Enable the Rancher integration on a vCluster Platform project
+After configuring Rancher within the vCluster Platform, you can import virtual clusters into Rancher and manage them as standard clusters.
 
 <details>
   <summary><strong>vCluster Rancher Operator</strong></summary>
 
-  ## Develop and Deploy the vCluster Rancher Operator
-  
-  This section outlines how to develop and deploy the vCluster Rancher Operator using DevSpace and Helm. These instructions are intended for contributors or advanced users customizing the operator.
-  
-  ### Deploy with DevSpace
-  
-  This is the preferred workflow for local development.
-  
-  ```bash
-  devspace dev
-  ````
-  
-  ### Build and push a custom image
-  
-  Build and push your image to the specified registry:
-  
-  ```bash
-  make docker-build docker-push IMG=<your-registry>/vcluster-rancher-operator:<tag>
-  ```
-  - Replace `<your-registry>` and `<tag>` with your container registry path and desired version tag.
-  
-  ### Deploy with Helm
-  
-  #### Basic Helm deployment
-  
-  Install the operator using Helm with your kubeconfig file:
-  
-  ```bash
-  KUBECONFIG=/path/to/kubeconfig.yaml helm install chart --generate-name --create-namespace
-  ```
-  
-  #### Helm deployment with a custom Iimage
-  
-  Specify a custom registry, repository, and tag:
-  
-  ```bash
-  KUBECONFIG=/path/to/kubeconfig.yaml helm install chart --generate-name --create-namespace \
-    --set image.registry=<REGISTRY> \
-    --set image.repository=<REPO/REPO> \
-    --set image.tag=<TAG>
-  ```
-  
-  ### Update RBAC configuration
-  
-  If you make changes to controller roles, update the manifests as follows:
-  
-  1. Modify the `controller-gen` tags in `controller/cluster-controller.go`.
-  2. Regenerate RBAC manifests:
-  
-  ```bash
-  make manifests
-  ```
-</details> 
-
-<details>
-  <summary><strong>Uninstall the vCluster Rancher Operator</strong></summary>
-
-  ### DevSpace Uninstall
-  
-  ```bash
-  devspace purge
-  rm -rf .devspace/*
-  ```
-  
-  ### Helm Uninstall
-  
-  ```bash
-  helm delete <release-name>
-  ```
-  
-  Replace `<release-name>` with the name of your Helm release.
-</details> 
-
-### Prerequisites
-
-- Docker is installed. 
-- DevSpace for deploying and managing applications. 
-- Rancher installed.
-- Access to a local Kubernetes cluster within Rancher.
-
-### Install 
-
-Before being able to enable virtual clusters with the Rancher integration, it must be enabled on the project. When vCluster Platform projects are enabled with Rancher integration, a label `loft.sh/loft-project-name: <VCLUSTER_PLATFORM_PROJECT_NAME>` is added to the Rancher project resource. 
+## Develop and Deploy the vCluster Rancher Operator
 
 To install the vCluster Rancher Operator using the Rancher UI:
 
@@ -224,13 +140,12 @@ If you are creating a project resource into vCluster Platform directly, you can 
 
 ## Import virtual clusters into Rancher through vCluster Platform UI
 
-Once a vCluster Platform project has the Rancher integration enabled, virtual clusters within that project are eligible to be
-synced into Rancher as an imported cluster in Rancher UI. In the vCluster Platform UI, you can enable virtual cluster import into Rancher during the virtual cluster creation step, or by enabling this feature on existing
+After a vCluster Platform project has the Rancher integration enabled, virtual clusters within that project can be synced into Rancher as an imported cluster in Rancher UI. In the vCluster Platform UI, you can enable virtual cluster import into Rancher during the virtual cluster creation step, or by enabling this feature on existing
 virtual clusters.
 
 :::info Make Sure Your Project Has Rancher Enabled
 If the project does *not* have Rancher integration enabled, you
-will not see the "Add to Rancher" options in the virtual cluster configuration.
+might not see the **Add to Rancher** options in the virtual cluster configuration.
 :::
 
 <Tabs
@@ -245,21 +160,21 @@ will not see the "Add to Rancher" options in the virtual cluster configuration.
                 In the vCluster Platform UI, select a project that has Rancher integration enabled. 
             </Step>
             <Step>
-                Click on Virtual Clusters and the <Button>Create Virtual Cluster</Button> button.
+                Click **Virtual Clusters**.
             </Step>
             <Step>
-                In the popup, optionally select the virtual cluster template, then click the
-                <Button>Configure</Button> button.
+                In the popup, optionally select the virtual cluster template, then click
+                <Button>Configure</Button>.
             </Step>
             <Step>
                 Click the <Label>Rancher</Label> configuration tab.
             </Step>
             <Step>
-                Slide the <Label>Add to Rancher</Label> slider to enabled.
+                Enable <Label>Add to Rancher</Label>.
             </Step>
             <Step>
-                Finish configuring anything else you'd like on your virtual cluster, then click the
-                <Button>Create</Button> button. The virtual cluster is created in vCluster Platform and imported into Rancher.
+                Finish configuring anything else you would like on your virtual cluster, then click
+                <Button>Create</Button>. The virtual cluster is created in vCluster Platform and imported into Rancher.
             </Step>
         </Flow>
     </TabItem>
@@ -315,14 +230,7 @@ Disabling integration at the project level removes all virtual clusters in that 
 
   ## Uninstall the vCluster Rancher Operator
   
-  To remove the vCluster Rancher Operator from your environment:
-  
-  ### DevSpace uninstall
-  
-  ```bash
-  devspace purge
-  rm -rf .devspace/*
-  ````
+  To remove the vCluster Rancher Operator from your environment uninstall Helm. 
   
   ### Helm uninstall
   

--- a/platform/integrations/rancher/rancher-integration.mdx
+++ b/platform/integrations/rancher/rancher-integration.mdx
@@ -92,14 +92,7 @@ After configuring Rancher within the vCluster Platform, you can import virtual c
   ```
   
   Replace `<release-name>` with the name of your Helm release.
-  
-  </details>
-  ```
 </details> 
-
-
-
-
 
 ### Prerequisites
 
@@ -189,7 +182,7 @@ If you are creating a project resource into vCluster Platform directly, you can 
 
 ## Manage virtual clusters in the Rancher UI
 
-### Creating a virtual cluster in the Rancher UI
+### Create a virtual cluster in the Rancher UI
 
 <Flow id="rancher-plugin-create-vcluster">
   <Step>
@@ -229,7 +222,7 @@ If you are creating a project resource into vCluster Platform directly, you can 
   </Step>
 </Flow>
 
-## Importing Virtual Clusters into Rancher through vCluster Platform UI
+## Import virtual clusters into Rancher through vCluster Platform UI
 
 Once a vCluster Platform project has the Rancher integration enabled, virtual clusters within that project are eligible to be
 synced into Rancher as an imported cluster in Rancher UI. In the vCluster Platform UI, you can enable virtual cluster import into Rancher during the virtual cluster creation step, or by enabling this feature on existing

--- a/platform/integrations/rancher/rancher-integration.mdx
+++ b/platform/integrations/rancher/rancher-integration.mdx
@@ -16,6 +16,8 @@ The vCluster Rancher Operator automatically imports vCluster installations as Ra
 
 After configuring Rancher within the vCluster Platform, you can import virtual clusters into Rancher and manage them as standard clusters.
 
+<!-- vale off -->
+
 ## Deploy the vCluster Rancher Operator
 
 To install the vCluster Rancher Operator using the Rancher UI:

--- a/platform/integrations/rancher/rancher-integration.mdx
+++ b/platform/integrations/rancher/rancher-integration.mdx
@@ -12,14 +12,11 @@ import Label from '@site/src/components/Label'
 
 import PartialRancher from "../../api/_partials/resources/projects/spec/rancher.mdx";
 
-The vCluster Rancher Operator automatically imports vCluster installations as Rancher clusters. Rancher users can deploy vClusters without possessing cluster create permissions, as the operator handles the necessary setup. Additionally, project owners of the project vCluster is installed in and the cluster owners of the host cluster are automatically assigned as cluster owners in the new Rancher cluster.
+The vCluster Rancher Operator automatically imports vCluster installations as Rancher clusters. Rancher users can deploy virtual clusters without having cluster create permissions, as the operator handles the necessary setup. Additionally, project owners of the project vCluster is installed in and the cluster owners of the host cluster are automatically assigned as cluster owners in the new Rancher cluster.
 
 After configuring Rancher within the vCluster Platform, you can import virtual clusters into Rancher and manage them as standard clusters.
 
-<details>
-  <summary><strong>vCluster Rancher Operator</strong></summary>
-
-## Develop and Deploy the vCluster Rancher Operator
+## Deploy the vCluster Rancher Operator
 
 To install the vCluster Rancher Operator using the Rancher UI:
 
@@ -53,7 +50,7 @@ To install the vCluster Rancher Operator using the Rancher UI:
 
 After it is installed, the vCluster Rancher Operator automatically integrates vCluster deployments with Rancher.
 
-### 🔍 Retrieve Rancher Cluster ID and Project ID
+### Retrieve the Rancher cluster ID and project ID
 
 <Flow id="rancher-id-lookup">
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
[Link to Preview](https://deploy-preview-708--vcluster-docs-site.netlify.app/docs/platform/next/integrations/rancher/rancher-integration)


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENG-6294

