### PR TITLE
fix: node IP visibility

### DIFF
--- a/vcluster/learn-how-to/control-node-ip-visibility.mdx
+++ b/vcluster/learn-how-to/control-node-ip-visibility.mdx
@@ -32,42 +32,6 @@ vCluster automatically replaces the actual node IP addresses with obfuscated val
 
 <ProAdmonition/>
 
-You can customize node syncing behavior using patches to control which information is visible in the virtual cluster.
-
-### Preserve original node IPs
-
-To sync real node IPs without obfuscation, use a patch that preserves the original values:
-
-```yaml title="Preserve original node IPs"
-sync:
-  fromHost:
-    nodes:
-      enabled: true
-      patches:
-      - path: status.addresses
-        expression: |
-          value
-```
-
-### Custom IP obfuscation
-
-You can create custom obfuscation logic using JavaScript expressions:
-
-```yaml title="Custom IP obfuscation"
-sync:
-  fromHost:
-    nodes:
-      enabled: true
-      patches:
-      - path: status.addresses[*].address
-        expression: |
-          if (type === "InternalIP") {
-            "10.0.0." + Math.floor(Math.random() * 254 + 1)
-          } else {
-            value
-          }
-```
-
 ### Remove IP information completely
 
 To remove IP addresses entirely from synced nodes:


### PR DESCRIPTION
# Content Description
Removed some example commands that don't have any effect or may lead to issues.
Node IPs for the virtual cluster are always obfuscated and changing this behavior is not possible or tricky.


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
[Document Preview](https://netlify.preview/docs/vcluster/next/learn-how-to/control-node-ip-visibility). -->


