### PR TITLE
fix: split permissions doc

### DIFF
--- a/platform/administer/users-permissions/permissions/vcluster.mdx
+++ b/platform/administer/users-permissions/permissions/vcluster.mdx
@@ -1,5 +1,6 @@
 ---
-title: Manage Access to the Virtual Cluster
+title: Manage access to the virtual cluster
+
 sidebar_label: vCluster 
 sidebar_position: 3
 ---
@@ -11,46 +12,131 @@ import NavStep from "@site/src/components/NavStep";
 import Label from "@site/src/components/Label";
 import Button from "@site/src/components/Button";
 
-Access to a virtual cluster is automatically granted to the following users:
+# Management access to the virtual cluster
 
-1. **Global Admins**: They have access to **all** virtual clusters in the platform.
-2. **Project Admins**: They have access to **all** virtual clusters within the project.
-2. **Virtual Cluster Owners**: They have access to the specific virtual cluster. 
-3. **Users with Physical Cluster Permissions**: Every user or team within the physical cluster that has the RBAC permission on the resource `virtualclusterinstances` in the API group `management.loft.sh` for the verb `use` can access any virtual cluster.
+Management access controls who can view, edit, or configure the virtual cluster object in the platform. It is separate from in-cluster access, which governs permissions inside the Kubernetes environment of the virtual cluster.
 
-In order to extend access to other users or teams, you can edit the permissions for the virtual cluster. 
+## Default management access
 
-## How does access within a virtual cluster work?
+By default, the following users and roles have management access to a virtual cluster:
 
-Each virtual cluster has a default cluster role when adding a user or team to give them access to the virtual cluster. The default cluster role is `cluster-admin`. The default cluster role can be changed in the virtual cluster template or on the virtual cluster object.
+* **Global administrators** – Access all virtual clusters on the platform.
+* **Project administrators** – Access all virtual clusters within their assigned projects.
+* **Virtual cluster owners** – Automatically receive access to the specific virtual cluster they create or own.
+* **Users with physical cluster permissions** – Any user or team with RBAC permissions on the underlying (physical) cluster and the `use` verb on the `virtualclusterinstances` resource in the `management.loft.sh` API group can access virtual clusters running on that cluster.
 
-Besides the default rule you can define extra rules on the virtual cluster or template that map a user or team to another cluster role. As soon as one rule matches a user or team, the default cluster role is not assigned. If multiple rules match a user, all the cluster roles defined in the rules are assigned.
+## Grant management access using the UI
 
-## Grant Access to a virtual cluster
+To extend access to additional users or teams, use the **Permissions** section for each virtual cluster in the platform UI:
 
-<Flow id="vcluster-share-ui">
+<Flow id="grant-management-access">
   <Step>
-    From the project drop-down menu (top left corner), select the project to find your virtual cluster.
+  Open the **Project** dropdown in the top-left corner and select the project that contains the virtual cluster.
   </Step>
   <Step>
-    Click on <NavStep>Virtual Clusters</NavStep>.
+  Click **Virtual Clusters** in the sidebar to view the list.
   </Step>
   <Step>
-    Click on <Label>Edit</Label> on the virtual cluster that you want to edit.
+  Click **Edit** on the target virtual cluster.
   </Step>
   <Step>
-    Click on the <NavStep>Permissions</NavStep>.
-    </Step>
-  <Step>
-    Click the <Label>Add Permission to"</Label> input and select the user or team to add. If you don't see the user or team you want to grant access in there,
-    confirm that they have project access.
+  Open the **Permissions** tab.
   </Step>
   <Step>
-    Specify the <Label>Cluster Role</Label> you want to assign the user or team.
+  Use the **Add permission to** field to select the user or team.
   </Step>
   <Step>
-    Once all virtual options have been specified, click the{" "}
-    <Button>Save Changes</Button>.
+  If the user or team does not appear, confirm that they have access to the project.
+  </Step>
+  <Step>
+  Choose a **ClusterRole** to assign (e.g., `cluster-admin`, `edit`, or `view`). This role determines the user's Kubernetes permissions inside the virtual cluster.
+  </Step>
+  <Step>
+  Click **Save changes**.
   </Step>
 </Flow>
 
+The platform grants the selected user or team management access to the virtual cluster object.
+
+## vCluster roles
+
+vCluster roles define what users and teams can do inside the virtual cluster. Kubernetes RBAC governs this access.
+
+### Default cluster role assignment
+
+By default, the platform assigns the `cluster-admin` Kubernetes ClusterRole to users with virtual cluster access. This role grants full access in all namespaces.
+
+### Change the default cluster role
+
+Administrators can override the default role in the virtual cluster template or in the virtual cluster configuration.
+
+<Flow id="change-default-role">
+  <Step>
+  Open the virtual cluster or template configuration.
+  </Step>
+  <Step>
+  Locate the **Default Cluster Role** field.
+  </Step>
+  <Step>
+  Enter a more limited role such as `edit` or `view`.
+  </Step>
+  <Step>
+  Save the updated configuration.
+  </Step>
+</Flow>
+
+### Define custom role mapping rules
+
+Use mapping rules to assign specific users or teams to specific cluster roles.
+
+- A user or team that matches at least one rule does **not** receive the default role.
+- If multiple rules match, the system assigns all specified roles.
+- If no rule matches, the system assigns the default role.
+
+<Flow id="configure-role-mapping">
+  <Step>
+  Open the virtual cluster or template YAML configuration.
+  </Step>
+  <Step>
+  Locate or create the `access.rules` section.
+  </Step>
+  <Step>
+  List `subjects` for each user or team.
+  </Step>
+  <Step>
+  Define the `clusterRole` for each rule.
+  </Step>
+  <Step>
+  Save and apply the configuration.
+  </Step>
+</Flow>
+
+#### Example
+
+```yaml
+apiVersion: management.loft.sh/v1
+kind: VirtualCluster
+metadata:
+  name: example-vcluster
+spec:
+  defaultClusterRole: cluster-admin
+  access:
+    rules:
+      - subjects:
+          - kind: User
+            name: Person 1
+        clusterRole: edit
+      - subjects:
+          - kind: Team
+            name: DevTeam
+        clusterRole: view
+```
+
+In this example:
+
+- Person 1 receives the `edit` role.
+- DevTeam receives the `view` role.
+- Person 1, if part of DevTeam, receives both roles.
+- All other users default to `cluster-admin`.
+
+Custom mapping rules allow more precise and secure access control inside the virtual cluster.

--- a/platform/administer/users-permissions/permissions/vcluster.mdx
+++ b/platform/administer/users-permissions/permissions/vcluster.mdx
@@ -93,6 +93,8 @@ Use mapping rules to assign specific users or teams to specific cluster roles.
 - If multiple rules match, the system assigns all specified roles.
 - If no rule matches, the system assigns the default role.
 
+<!-- vale off -->
+
 <Flow id="configure-role-mapping">
   <Step>
   Open the virtual cluster or template YAML configuration.
@@ -104,12 +106,14 @@ Use mapping rules to assign specific users or teams to specific cluster roles.
   List `subjects` for each user or team.
   </Step>
   <Step>
-  Define the `clusterRole` for each rule.
+  Define the `ClusterRole` for each rule.
   </Step>
   <Step>
   Save and apply the configuration.
   </Step>
 </Flow>
+
+<!-- vale on -->
 
 #### Example
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
-[Link to Preview](https://deploy-preview-715--vcluster-docs-site.netlify.app/docs/platform/next/administer/users-permissions/permissions/vcluster)


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-617

