### PR TITLE
feat: same glossary term can be referenced in platform and vcluster

### DIFF
--- a/platform/reference/glossary.mdx
+++ b/platform/reference/glossary.mdx
@@ -15,7 +15,10 @@ This page contains definitions for common terms used throughout the platform doc
 
 <!-- vale off -->
 {Object.entries(glossaryData)
-  .filter(([key, entry]) => entry.type === 'platform')
+  .filter(([key, entry]) => {
+    const typeValue = entry.type;
+    return Array.isArray(typeValue) ? typeValue.includes('platform') : typeValue === 'platform';
+  })
   .sort((a, b) => a[1].term.localeCompare(b[1].term))
   .map(([key, entry]) => (
     <div key={key} id={key} style={{ marginBottom: '2.5rem', borderBottom: '1px solid #eee', paddingBottom: '1.5rem' }}>

--- a/scripts/generate-glossary-usage.js
+++ b/scripts/generate-glossary-usage.js
@@ -31,8 +31,12 @@ const usageData = {};
 
 // Initialize each term with an empty array of usages and include type information
 Object.keys(glossaryData).forEach(term => {
+  // Handle both single string type and array of types
+  const typeValue = glossaryData[term].type || 'general';
+  const typeArray = Array.isArray(typeValue) ? typeValue : [typeValue];
+  
   usageData[term] = {
-    type: glossaryData[term].type || 'general',
+    type: typeArray,
     term: glossaryData[term].term,
     usages: []
   };
@@ -87,16 +91,26 @@ fs.writeFileSync(outputPath, JSON.stringify(usageData, null, 2));
 // Generate summary statistics
 const termsByType = {
   vcluster: {
-    total: Object.keys(glossaryData).filter(k => glossaryData[k].type === 'vcluster').length,
-    used: Object.keys(usageData).filter(k => 
-      glossaryData[k].type === 'vcluster' && usageData[k].usages.length > 0
-    ).length
+    total: Object.keys(glossaryData).filter(k => {
+      const typeValue = glossaryData[k].type;
+      return Array.isArray(typeValue) ? typeValue.includes('vcluster') : typeValue === 'vcluster';
+    }).length,
+    used: Object.keys(usageData).filter(k => {
+      const typeValue = glossaryData[k].type;
+      const hasType = Array.isArray(typeValue) ? typeValue.includes('vcluster') : typeValue === 'vcluster';
+      return hasType && usageData[k].usages.length > 0;
+    }).length
   },
   platform: {
-    total: Object.keys(glossaryData).filter(k => glossaryData[k].type === 'platform').length,
-    used: Object.keys(usageData).filter(k => 
-      glossaryData[k].type === 'platform' && usageData[k].usages.length > 0
-    ).length
+    total: Object.keys(glossaryData).filter(k => {
+      const typeValue = glossaryData[k].type;
+      return Array.isArray(typeValue) ? typeValue.includes('platform') : typeValue === 'platform';
+    }).length,
+    used: Object.keys(usageData).filter(k => {
+      const typeValue = glossaryData[k].type;
+      const hasType = Array.isArray(typeValue) ? typeValue.includes('platform') : typeValue === 'platform';
+      return hasType && usageData[k].usages.length > 0;
+    }).length
   }
 };
 

--- a/src/data/glossary-usage.json
+++ b/src/data/glossary-usage.json
@@ -1,6 +1,8 @@
 {
   "vcluster": {
-    "type": "vcluster",
+    "type": [
+      "vcluster"
+    ],
     "term": "vCluster",
     "usages": [
       {
@@ -12,8 +14,10 @@
     ]
   },
   "virtual-cluster": {
-    "type": "vcluster",
-    "term": "virtual cluster",
+    "type": [
+      "vcluster"
+    ],
+    "term": "Virtual Cluster",
     "usages": [
       {
         "path": "vcluster/_partials/what-are-virtual-clusters.mdx",
@@ -24,8 +28,10 @@
     ]
   },
   "host-cluster": {
-    "type": "vcluster",
-    "term": "host cluster",
+    "type": [
+      "vcluster"
+    ],
+    "term": "Host Cluster",
     "usages": [
       {
         "path": "vcluster/_partials/what-are-virtual-clusters.mdx",
@@ -36,8 +42,10 @@
     ]
   },
   "syncer": {
-    "type": "vcluster",
-    "term": "syncer",
+    "type": [
+      "vcluster"
+    ],
+    "term": "Syncer",
     "usages": [
       {
         "path": "vcluster/_partials/what-are-virtual-clusters.mdx",
@@ -48,8 +56,10 @@
     ]
   },
   "multi-tenancy": {
-    "type": "vcluster",
-    "term": "multi-tenancy",
+    "type": [
+      "vcluster"
+    ],
+    "term": "Multi-tenancy",
     "usages": [
       {
         "path": "vcluster/_partials/what-are-virtual-clusters.mdx",
@@ -60,7 +70,10 @@
     ]
   },
   "k3s": {
-    "type": "vcluster",
+    "type": [
+      "vcluster",
+      "platform"
+    ],
     "term": "K3s",
     "usages": [
       {
@@ -72,12 +85,18 @@
     ]
   },
   "k8s": {
-    "type": "vcluster",
+    "type": [
+      "vcluster",
+      "platform"
+    ],
     "term": "K8s",
     "usages": []
   },
   "k0s": {
-    "type": "vcluster",
+    "type": [
+      "vcluster",
+      "platform"
+    ],
     "term": "K0s",
     "usages": [
       {
@@ -89,48 +108,66 @@
     ]
   },
   "platform": {
-    "type": "platform",
-    "term": "the platform",
+    "type": [
+      "platform"
+    ],
+    "term": "The Platform",
     "usages": []
   },
   "project": {
-    "type": "platform",
-    "term": "project",
+    "type": [
+      "platform"
+    ],
+    "term": "Project",
     "usages": []
   },
   "team": {
-    "type": "platform",
-    "term": "team",
+    "type": [
+      "platform"
+    ],
+    "term": "Team",
     "usages": []
   },
   "user": {
-    "type": "platform",
-    "term": "user",
+    "type": [
+      "platform"
+    ],
+    "term": "User",
     "usages": []
   },
   "template": {
-    "type": "platform",
-    "term": "template",
+    "type": [
+      "platform"
+    ],
+    "term": "Template",
     "usages": []
   },
   "virtual-cluster-template": {
-    "type": "platform",
-    "term": "virtual cluster template",
+    "type": [
+      "platform"
+    ],
+    "term": "Virtual Cluster Template",
     "usages": []
   },
   "namespace": {
-    "type": "platform",
-    "term": "namespace",
+    "type": [
+      "platform"
+    ],
+    "term": "Namespace",
     "usages": []
   },
   "access-key": {
-    "type": "platform",
-    "term": "access key",
+    "type": [
+      "platform"
+    ],
+    "term": "Access Key",
     "usages": []
   },
   "sleep-mode": {
-    "type": "platform",
-    "term": "sleep mode",
+    "type": [
+      "platform"
+    ],
+    "term": "Sleep Mode",
     "usages": []
   }
 }

--- a/src/data/glossary.yaml
+++ b/src/data/glossary.yaml
@@ -33,21 +33,21 @@ k3s:
   term: "K3s"
   definition: "A lightweight, certified Kubernetes distribution often used as the default distribution for virtual clusters due to its minimal resource requirements and fast startup time."
   related: ["k8s", "k0s"]
-  type: "vcluster"
+  type: ["vcluster", "platform"]
   url: "https://k3s.io/"
 
 k8s:
   term: "K8s"
   definition: "The standard Kubernetes distribution that can be used in virtual clusters, offering full compatibility with upstream Kubernetes features."
   related: ["k3s", "k0s"]
-  type: "vcluster"
+  type: ["vcluster", "platform"]
   url: "https://kubernetes.io/"
 
 k0s:
   term: "K0s"
   definition: "A lightweight, certified Kubernetes distribution that can be used in virtual clusters as an alternative to K3s or standard Kubernetes."
   related: ["k3s", "k8s"]
-  type: "vcluster"
+  type: ["vcluster", "platform"]
   url: "https://k0sproject.io/"
 
 platform:

--- a/vcluster/reference/glossary.mdx
+++ b/vcluster/reference/glossary.mdx
@@ -15,7 +15,10 @@ This page contains definitions for common terms used throughout the vCluster doc
 
 <!-- vale off -->
 {Object.entries(glossaryData)
-  .filter(([key, entry]) => entry.type === 'vcluster')
+  .filter(([key, entry]) => {
+    const typeValue = entry.type;
+    return Array.isArray(typeValue) ? typeValue.includes('vcluster') : typeValue === 'vcluster';
+  })
   .sort((a, b) => a[1].term.localeCompare(b[1].term))
   .map(([key, entry]) => (
     <div key={key} id={key} style={{ marginBottom: '2.5rem', borderBottom: '1px solid #eee', paddingBottom: '1.5rem' }}>


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Glossary term can be referenced in platform only, vcluster only or both. The following syntaxt is supported.

```yaml
type: "platform"
type: ["platform", "vcluster"]
```

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-655

