### PR TITLE
fix: Fix typo in redirect link for quick start guide

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -171,11 +171,11 @@ to = "/docs/platform/:version/administer/users-permissions/overview"
 
 # Quick Start Guide / vCluster CLI
 [[redirects]]
-  from = "/docs/platform-ui-link/platform/quick-start-quide"
+  from = "/docs/platform-ui-link/platform/quick-start-guide"
   to = "/docs/platform/install/quick-start-guide"
 
 [[redirects]]
-  from = "/docs/platform-ui-link/platform/quick-start-quide/:version"
+  from = "/docs/platform-ui-link/platform/quick-start-guide/:version"
   to = "/docs/platform/:version/install/quick-start-guide"
 
 # karpenter integration


### PR DESCRIPTION

# Content Description

Fixed a typo in one of the redirects `quick-start-quide` -> `quick-start-guide`

