### PR TITLE
fix: add EOS label for v0.23

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -143,7 +143,7 @@ const config = {
             badge: true,
           },
           "0.23.0": {
-            label: "v0.23",
+            label: "v0.23 (EOS)",
             banner: "none",
             badge: true,
           },


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Add EOS label 


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

[Link to Preview](https://deploy-preview-720--vcluster-docs-site.netlify.app/docs/vcluster)


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

