### PR TITLE
fix: follow up to address vale issues

### DIFF
--- a/vcluster/configure/vcluster-yaml/policies/admission-control.mdx
+++ b/vcluster/configure/vcluster-yaml/policies/admission-control.mdx
@@ -1,5 +1,5 @@
 ---
-title: Central Admission Control
+title: Central admission control
 sidebar_label: centralAdmission
 sidebar_class_name: pro
 sidebar_position: 5
@@ -12,35 +12,35 @@ import ProAdmonition from '../../../_partials/admonitions/pro-admonition.mdx'
 <ProAdmonition/>
 
 :::important
-You must enable MutatingAdmissionWebhook and ValidatingAdmissionWebhook admission controllers to use the Central Admission Control feature. See the Kubernetes [Admission Controllers Reference](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use) for details.
+You must enable `MutatingAdmissionWebhook` and `ValidatingAdmissionWebhook` admission controllers to use the Central Admission Control feature. For more information, see the Kubernetes [admission controllers reference](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use).
 :::
 
-Centralized Admission Control is an advanced feature for cluster admins that have custom rules that they need to apply to the virtual cluster. Cluster admins can enforce [Kubernetes admission webhooks](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) that reference the host cluster or external policy services from within the virtual cluster. Examples of validating and  mutating webhook based policy engines include OPA, Kyverno, and jsPolicy.
+Centralized admission control is an advanced feature for cluster admins that have custom rules that they need to apply to the virtual cluster. Cluster admins can enforce [Kubernetes admission webhooks](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) that reference the host cluster or external policy services from within the virtual cluster. Examples of validating and mutating webhook based policy engines include OPA, Kyverno, and jsPolicy.
 
 :::warning
-- Central Admission Control is read-only after virtual cluster creation. Admins cannot bypass or alter hooks after vCluster deployment.
-- If you need the ability to modify or delete webhook configurations, do not use Central Admission Control. Instead, manually map the host policy service into the virtual cluster.
+- Central admission control is read-only after virtual cluster creation. Admins cannot bypass or alter hooks after vCluster deployment.
+- If you need to modify or delete webhook configurations, do not use central admission control. Instead, manually map the host policy service into the virtual cluster.
 :::
 
 Central admission webhooks are different from the other policies:
 
 - `LimitRange` and `ResourceQuota` resources are created and enforced on the host cluster. They do not appear as resources in the virtual cluster.
-- A user could define `LimitRange` and `ResourceQuota` resources inside the virtual cluster, but they have full control over them and can delete them at will.
+- A user could define `LimitRange` and `ResourceQuota` resources inside the virtual cluster, but they have full control over them and can delete them when needed.
 - Webhooks are different because they need to be configured inside the virtual cluster in order for them to be called by the vCluster's API server.
-- vCluster rewrites these definitions to point to a proxy for a host cluster service that handles webhook requests. The host may also have webhook configurations that use this service.
+- vCluster rewrites these definitions to point to a proxy for a host cluster service that handles webhook requests. The host might also have webhook configurations that use this service.
 - A user can still install a webhook service or webhook configuration into the virtual cluster outside of this config, but it would run inside the virtual cluster like any other workload.
 
-:::info Namespace Rewriting
+:::info Namespace rewriting
 vCluster rewrites the namespace of the object (if the object is namespace scoped) to the host namespace where vCluster is running in. This is not visible to the end-user, but the admission controller is able to use things like namespace selector like usual. Some admission controllers like gatekeeper wouldn't work otherwise as they rely on the namespace to always be there in the underlying cluster. To access the virtual namespace in a webhook, you can access the `request.options.vCluster.namespace.metadata.name` field in the [admission request object](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#request) that holds the full virtual namespace object.
 :::
 
-:::info Translated name of Pods
-In some circumstances it might be necessary to have the translated name of a Pod, which will be used when this Pod is created on the host cluster, available in a webhook running inside a virtual cluster.
-Therefore, vCluster puts the translated Pod name under the `request.options.vCluster.name` field in the [admission request object](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#request).
-As the final name is only available during validation phase this only works when using `validatingWebhooks` that have rules configured for Pods.
+:::info Translated name of pods
+In some circumstances it might be necessary to have the translated name of a pod, which is used when this pod is created on the host cluster, available in a webhook running inside a virtual cluster.
+Therefore, vCluster puts the translated pod name under the `request.options.vCluster.name` field in the [admission request object](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#request).
+As the final name is only available during validation phase this only works when using `validatingWebhooks` that have rules configured for pods.
 :::
 
-## Kyverno Example
+## Kyverno example
 
 This example ensures that all new ConfigMap resources are sent to a mutating webhook on the host cluster.
 
@@ -81,9 +81,9 @@ centralAdmission:
 
 Any time a ConfigMap is created, the vCluster API server forwards the admission request to a proxy, which in turn calls the actual admission hook running in the host cluster in the `kyverno` namespace.
 
-Note that the service providing the webhooks should not rely on the real names of the objects if they are synced on the host cluster (for example, pods). The requests that reach the host admission service holds the objects from the virtual cluster, so your policies need to be able to handle those objects (except for the namespace which is rewritten as outlined below).
+The service providing the webhooks should not rely on the real names of the objects if they are synced on the host cluster (for example, pods). The requests that reach the host admission service holds the objects from the virtual cluster, so your policies need to be able to handle those objects (except for the namespace which is rewritten as outlined below).
 
-The hook services do not require authentication as the proxy does not have access to the `AdmissionConfiguration` object or the files it references. Most policy engines (like jsPolicy, Kyverno, or Gatekeeper) do not set authentication by default, so it should work with most installations.
+The hook services do not require authentication as the proxy does not have access to the `AdmissionConfiguration` object or the files it references. Most policy engines (such as jsPolicy, Kyverno, or Gatekeeper) do not set authentication by default, so it should work with most installations.
 
 If a user inside the virtual cluster (admin or not) tries to delete one of your admission hooks, that uses is prompted with the following error message:
 
@@ -92,11 +92,14 @@ kubectl delete kyverno-webhook
 error: the resource kyverno-webhook is protected
 ```
 
-## Gatekeeper (OPA) Example
+<!-- vale off -->
+## Gatekeeper (OPA) example
+<!-- vale on -->
 
-First [install gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/install/) to your Kubernetes cluster.
+[Install gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/install/) to your Kubernetes cluster.
 
-Then create the following constraint template that denies pods without specified labels:
+Create the following constraint template that denies pods without specified labels:
+
 ```yaml
 apiVersion: config.gatekeeper.sh/v1alpha1
 kind: Config
@@ -148,7 +151,8 @@ spec:
         }
 ```
 
-Next create the constraint:
+Create the constraint:
+
 ```yaml
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sRequiredLabels
@@ -167,6 +171,7 @@ spec:
 ```
 
 Then start the vCluster with the following configuration:
+
 ```yaml
 policies:
   centralAdmission:
@@ -204,6 +209,7 @@ policies:
 ```
 
 Within the vCluster try to create the following pod which should get denied:
+
 ```bash
 $ echo "apiVersion: v1
 kind: Pod


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Just minor vale fixes


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-582

