### PR TITLE
Add when AllowedExtraClaims are applied to User

### DIFF
--- a/platform/_partials/auth/sso/oidc.mdx
+++ b/platform/_partials/auth/sso/oidc.mdx
@@ -74,7 +74,9 @@ auth:
     # (Optional) PreferredUsername is the JWT field to use as the user's display name
     preferredUsername: "preferred_username"
     # (Optional) AllowedExtraClaims are claims of interest that are provided by the OIDC provider but may not already be
-    # covered by a User field. They will be copied to User.Spec.ExtraClaims.
+    # covered by a User field. These additional claims of interest will be copied to User.Spec.ExtraClaims.
+    # Like other claims, User.Spec.ExtraClaims is only updated when the User logs in using the OIDC provider. A user must
+    # login after changes to AllowedExtraClaims for them to be reflected in a User's User.Spec.ExtraClaims.
     allowedExtraClaims: ["department"]
 ```
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-728--vcluster-docs-site.netlify.app/docs/platform/next/configure/single-sign-on/providers/openid-connect


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

