### PR TITLE
Add troubleshooting section for self signed tls setup

### DIFF
--- a/platform/configure/troubleshooting.mdx
+++ b/platform/configure/troubleshooting.mdx
@@ -1,0 +1,116 @@
+---
+title: "Troubleshooting"
+sidebar_label: "Troubleshooting"
+sidebar_position: 8
+description: Learn how to troubleshoot common issues with the vCluster Platform installation and configuration.
+---
+
+hell yeah
+
+## Custom TLS
+
+### vCluster Platform certificate `unknown authority` issues for internal traffic
+
+If you encounter errors like this one:
+```json
+{
+    "component": "vcluster",
+    "error": "get self: Post \"https://loft.vcluster-platform/kubernetes/management/apis/management.loft.sh/v1/selves\": tls: failed to verify certificate: x509: certificate signed by unknown authority"
+}
+```
+
+in vClusters deployed through Platform that's using custom self-signed TLS cert, it might be caused by 2 scenarios - either platform is serving your custom cert, but vCluster doesn't recognise your CA or Platform is not properly serving your custom cert.
+
+In order to debug this, you can follow these steps:
+1. **Run debug pod in your host cluster**:
+   - Run `kubectl run -n {platform namespace} netshoot-debug --image=nicolaka/netshoot --restart=Never --rm -it --command -- /bin/bash`
+   - once in the pod, run:
+```
+openssl s_client -connect loft.platform namespace:443 -servername loft.platform namespace < /dev/null 2>/dev/null | \
+> sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > /tmp/service.crt
+```
+    - this will save certificate served by the Platform in `/tmp/service.crt` file.
+    - now run this command to inspect the certificate:
+    ```
+openssl x509 -in /tmp/service.crt -noout -text
+    ```
+    - This will show you something similar to this:
+    ```
+Certificate:
+    Data:
+        Version: 3 (0x2)
+        Serial Number: 317909375810987 (0x121230b6a7dab)
+        Signature Algorithm: sha256WithRSAEncryption
+        Issuer: O=loft
+        Validity
+            Not Before: May 29 12:31:33 2025 GMT
+            Not After : May 29 12:31:33 2035 GMT
+        Subject: O=loft
+        Subject Public Key Info:
+            Public Key Algorithm: rsaEncryption
+                Public-Key: (2048 bit)
+                Modulus:
+                    00:d1:15:7e:b2:7a:9f:c8:f6:b3:76:9c:a0:c1:d1:
+                    e6:9c:4a:0c:2c:7b:28:73:6b:16:ec:0d:04:ff:59:
+                    49:49:41:c3:ee:74:24:8d:fd:83:ad:86:a3:20:06:
+                    29:21:57:e9:d0:26:7d:ae:e8:8f:d7:54:ad:72:25:
+                    3b:c4:48:c6:a6:90:96:c5:31:df:42:51:c0:10:54:
+                    c0:4d:f5:4e:9c:ef:8a:70:c9:de:01:20:33:4c:93:
+                    37:18:fb:9a:19:12:b1:aa:f5:67:ff:5d:bf:b0:05:
+                    a3:3b:48:5c:3b:c6:76:b3:2f:bf:aa:f2:18:58:b5:
+                    80:6d:54:9b:60:8b:fc:aa:03:26:84:8b:e5:e4:6b:
+                    bf:cb:47:2d:79:20:27:4b:48:20:b3:0d:f6:63:f4:
+                    de:d8:17:79:e8:2e:38:56:cb:6e:ce:a2:da:c1:7f:
+                    c0:f4:c7:6a:ff:7e:ca:26:db:fb:f2:a2:71:57:c2:
+                    82:20:82:5a:88:3c:6c:cd:aa:22:68:53:1e:f0:6a:
+                    e3:7b:34:9f:4c:2d:3e:46:cd:03:24:44:2b:17:a2:
+                    19:0d:ad:d0:58:21:42:6e:66:ac:ad:10:fc:35:98:
+                    bc:c5:86:5a:28:a3:7e:f0:bb:9f:e1:1a:6b:0d:6f:
+                    ef:dc:fc:0f:56:ca:c0:cf:72:90:5a:ce:7e:4d:cd:
+                    2c:0f
+                Exponent: 65537 (0x10001)
+        X509v3 extensions:
+            X509v3 Key Usage: critical
+                Digital Signature
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication, TLS Web Server Authentication
+            X509v3 Basic Constraints: critical
+                CA:FALSE
+            X509v3 Subject Alternative Name:
+                DNS:localhost, DNS:loft.vcluster-platform, DNS:loft.vcluster-platform.svc, DNS:loft.vcluster-platform.svc.cluster.local
+    Signature Algorithm: sha256WithRSAEncryption
+    Signature Value:
+        85:bd:9f:7d:b9:96:44:0c:53:49:4f:b3:d8:7c:a6:42:4e:49:
+        4e:09:53:4b:ca:ca:66:7d:4a:b6:0b:c5:0c:6d:24:cd:04:28:
+        b4:fc:e4:b6:62:75:3d:32:1b:57:6c:e1:ec:01:d2:9f:63:43:
+        c3:b2:37:f5:cf:9d:a4:3b:23:34:50:2a:f1:5a:7e:c5:d6:70:
+        f9:0d:4b:2a:04:68:35:7a:b5:bb:c9:cd:44:2b:e7:58:79:e6:
+        e4:d6:84:59:82:34:93:fd:a4:fc:12:6c:aa:b8:ad:0c:dc:96:
+        bc:b1:9c:38:22:af:33:6e:fc:09:7d:16:b1:0f:1f:94:32:79:
+        b7:35:b6:8d:50:95:20:1b:01:18:a7:5f:5e:04:f4:78:18:d1:
+        63:6d:33:e2:a0:31:43:ba:9e:51:6e:67:89:da:c4:a6:4c:15:
+        06:d5:50:8f:58:c0:9b:b9:e2:54:ef:86:fa:e4:44:9a:13:aa:
+        88:b3:de:6b:98:a2:6e:16:43:c2:7f:c8:92:db:4d:bc:c5:a6:
+        d8:21:c0:00:2a:9d:b6:75:99:92:9d:ba:8c:9d:14:70:94:7d:
+        0a:f6:07:2e:f2:e4:6a:27:e1:93:c0:e4:93:61:1a:cd:11:eb:
+        24:16:c2:be:05:ff:3f:20:be:f7:9e:98:bc:59:42:bd:dd:c3:
+        58:40:13:4d
+    ```
+
+    Take a look at `Issuer` section - it should match the CA that you used to sign your custom TLS certificate.
+
+If you're not sure, you can inspect your own CA cert to check by running this command against it:
+
+```
+openssl x509 -in your-ca-crt-file.crt -noout -subject
+```
+this will show you issuer subject:
+```
+subject=C=US, ST=Some-state, L=Some-city, O=my-org, OU=my-org, CN=my-org , emailAddress=my@org.com
+```
+
+
+    If they don't match, most likely you didn't configure `tls` section in your `vcluster-platform.yaml` values file correctly. please refer to [this guide](./domain.mdx) to learn how to configure custom TLS for vCluster Platform.
+
+    If they do - you most likely forgot to include `additionalCA` in your `vcluster-platform.yaml` values file, which is required for vCluster to trust the Platform's custom TLS certificate. [Use a custom certificate authority section](./config.mdx)
+


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Adds troubleshooting page for issues with self-signed cert setup

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-664

