### PR TITLE
fix(infra): javascript calls overload in dev mode

### DIFF
--- a/src/js/details-clicks.js
+++ b/src/js/details-clicks.js
@@ -1,6 +1,7 @@
 import ExecutionEnvironment from "@docusaurus/ExecutionEnvironment";
 
-const copyToClipboard = async (text) => {
+// Only define browser-specific functions when in browser environment
+const copyToClipboard = ExecutionEnvironment.canUseDOM ? async (text) => {
   if (navigator.clipboard && window.isSecureContext) {
     try {
       await navigator.clipboard.writeText(text);
@@ -41,9 +42,9 @@ const copyToClipboard = async (text) => {
     console.warn('Fallback clipboard method failed:', err);
     return false;
   }
-};
+} : async () => false;
 
-const addCopyButtons = function() {
+const addCopyButtons = ExecutionEnvironment.canUseDOM ? function() {
   document.querySelectorAll('details.config-field').forEach(function(el) {
     if (el.getAttribute('data-copy-button') !== 'true') {
       el.setAttribute('data-copy-button', 'true');
@@ -122,7 +123,7 @@ copyButton.style.cssText = `
       });
     }
   });
-};
+} : () => {};
 
 const parseMapValue = function(mapStr) {
   console.log('Parsing map:', mapStr);
@@ -511,7 +512,7 @@ const generateYaml = function (element, processedElements = new Set()) {
   return yaml;
 };
 
-const preserveExpansionStates = function(skipEventListener) {
+const preserveExpansionStates = ExecutionEnvironment.canUseDOM ? function(skipEventListener) {
   const state = new URLSearchParams(window.location.search.substring(1));
 
   if (document.querySelectorAll('.markdown').length == 0) {
@@ -607,10 +608,9 @@ const preserveExpansionStates = function(skipEventListener) {
     }
   });
 
-  setTimeout(function() {
-    preserveExpansionStates();
-  }, 300);
-};
+  // Remove the infinite recursion - this was causing browser errors
+  // The function is already called initially and on relevant events
+} : () => {};
 
 if (ExecutionEnvironment.canUseDOM) {
   preserveExpansionStates();
@@ -631,4 +631,4 @@ if (ExecutionEnvironment.canUseDOM) {
   }
 }
 
-export default preserveExpansionStates;
+export default ExecutionEnvironment.canUseDOM ? preserveExpansionStates : () => {};

--- a/vcluster/_partials/admonitions/pro-admonition.mdx
+++ b/vcluster/_partials/admonitions/pro-admonition.mdx
@@ -1,6 +1,6 @@
 import Admonition from '@theme/Admonition';
 
-<div class="enterprise-feature">
+<div className="enterprise-feature">
 :::info Enterprise-Only Feature
 
 This feature is an Enterprise feature. See our [pricing plans](https://www.vcluster.com/pricing) or [contact our sales team](https://www.vcluster.com/enterprise-demo) for more information.

--- a/vcluster_versioned_docs/version-0.20.0/_partials/admonitions/pro-admonition.mdx
+++ b/vcluster_versioned_docs/version-0.20.0/_partials/admonitions/pro-admonition.mdx
@@ -1,6 +1,6 @@
 import Admonition from '@theme/Admonition';
 
-<div class="enterprise-feature">
+<div className="enterprise-feature">
 :::info Enterprise-Only Feature
 
 This feature is an Enterprise feature. See our [pricing plans](https://www.vcluster.com/pricing) or [contact our sales team](https://www.vcluster.com/enterprise-demo) for more information.

--- a/vcluster_versioned_docs/version-0.21.0/_partials/admonitions/pro-admonition.mdx
+++ b/vcluster_versioned_docs/version-0.21.0/_partials/admonitions/pro-admonition.mdx
@@ -1,6 +1,6 @@
 import Admonition from '@theme/Admonition';
 
-<div class="enterprise-feature">
+<div className="enterprise-feature">
 :::info Enterprise-Only Feature
 
 This feature is an Enterprise feature. See our [pricing plans](https://www.vcluster.com/pricing) or [contact our sales team](https://www.vcluster.com/enterprise-demo) for more information.

--- a/vcluster_versioned_docs/version-0.22.0/_partials/admonitions/pro-admonition.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/_partials/admonitions/pro-admonition.mdx
@@ -1,6 +1,6 @@
 import Admonition from '@theme/Admonition';
 
-<div class="enterprise-feature">
+<div className="enterprise-feature">
 :::info Enterprise-Only Feature
 
 This feature is an Enterprise feature. See our [pricing plans](https://www.vcluster.com/pricing) or [contact our sales team](https://www.vcluster.com/enterprise-demo) for more information.

--- a/vcluster_versioned_docs/version-0.23.0/_partials/admonitions/pro-admonition.mdx
+++ b/vcluster_versioned_docs/version-0.23.0/_partials/admonitions/pro-admonition.mdx
@@ -1,6 +1,6 @@
 import Admonition from '@theme/Admonition';
 
-<div class="enterprise-feature">
+<div className="enterprise-feature">
 :::info Enterprise-Only Feature
 
 This feature is an Enterprise feature. See our [pricing plans](https://www.vcluster.com/pricing) or [contact our sales team](https://www.vcluster.com/enterprise-demo) for more information.

--- a/vcluster_versioned_docs/version-0.24.0/_partials/admonitions/pro-admonition.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/_partials/admonitions/pro-admonition.mdx
@@ -1,6 +1,6 @@
 import Admonition from '@theme/Admonition';
 
-<div class="enterprise-feature">
+<div className="enterprise-feature">
 :::info Enterprise-Only Feature
 
 This feature is an Enterprise feature. See our [pricing plans](https://www.vcluster.com/pricing) or [contact our sales team](https://www.vcluster.com/enterprise-demo) for more information.

--- a/vcluster_versioned_docs/version-0.25.0/_partials/admonitions/pro-admonition.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/_partials/admonitions/pro-admonition.mdx
@@ -1,6 +1,6 @@
 import Admonition from '@theme/Admonition';
 
-<div class="enterprise-feature">
+<div className="enterprise-feature">
 :::info Enterprise-Only Feature
 
 This feature is an Enterprise feature. See our [pricing plans](https://www.vcluster.com/pricing) or [contact our sales team](https://www.vcluster.com/enterprise-demo) for more information.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

- Fixed React warnings by changing `class` to `className` in pro-admonition.mdx partials across all versions to prevent errors like these:

![Screenshot from 2025-05-30 13-59-21](https://github.com/user-attachments/assets/a6812616-bea2-4a81-a8c0-6ebd3b4969c5)

- Removed infinite recursion in details-clicks.js that was causing "Too many calls to Location or History APIs" errors
- Added proper ExecutionEnvironment checks for browser-specific functions to prevent SSR issues
- Tested on production build and confirmed no regression errors

Browser errors like these should no longer appear when running `npm run start` on configuration pages with pro/enterprise labels.

![image](https://github.com/user-attachments/assets/547eca5b-3d07-4096-b2e6-1403120544f5)


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-740--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-665

