### PR TITLE
Add Hybrid Scheduling docs

### DIFF
--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/README.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/README.mdx
@@ -5,9 +5,9 @@ sidebar_position: 1
 description: Configuration for ...
 ---
 
-import DisableResourceWarning from '../../../../../_fragments/hints/warning-do-not-disable-resource.mdx'
-import Patches from '../../../../../_fragments/patches.mdx'
-import SyncPods from '../../../../../_partials/config/sync/toHost/pods.mdx'
+import DisableResourceWarning from '../../../../../../_fragments/hints/warning-do-not-disable-resource.mdx'
+import Patches from '../../../../../../_fragments/patches.mdx'
+import SyncPods from '../../../../../../_partials/config/sync/toHost/pods.mdx'
 
 By default, this is enabled.
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling.mdx
@@ -1,0 +1,161 @@
+---
+title: Hybrid Scheduling
+sidebar_label: hybridScheduling
+description: Configuration for ...
+---
+
+Hybrid scheduling enables you to use custom schedulers from both host and virtual cluster at
+the same time for your virtual cluster workload.
+
+You can enable hybrid scheduling like this:
+
+```yaml
+sync:
+  toHost:
+    pods:
+      hybridScheduling:
+        enabled: true
+        hostSchedulers:
+        - my-custom-scheduler
+  fromHost:
+    nodes:
+      enabled: true
+```
+
+Notice that you must also enable syncing of real nodes from the host to the virtual cluster.
+If you don't enable syncing of real nodes, you wil get an error.
+
+By default, all the nodes are synced from the host. You can also choose to sync only nodes
+with specific labels by specifying labels selector for nodes like showed in the example
+below.
+
+```yaml
+sync:
+  toHost:
+    pods:
+      hybridScheduling:
+        enabled: true
+        hostSchedulers:
+        - my-custom-scheduler
+  fromHost:
+    nodes:
+      enabled: true
+      labels:
+        environment: production
+        team: backend
+```
+
+## Use host schedulers
+
+`sync.toHost.pods.hybridScheduling.hostSchedulers` is a list of schedulers that exist on the host
+cluster, which can be used by the pods in the virtual cluster.
+
+The default Kubernetes scheduler from the host cluster is always implicitly included in the
+`sync.toHost.pods.hybridScheduling.hostSchedulers` list. This means that all the pods that are
+using the default Kubernetes scheduler (either implicitly when pod's `.spec.schedulerName`
+field is not set, or explicitly, when `.spec.schedulerName` is set to `default-scheduler`) are
+scheduled by the Kubernetes scheduler that is running on the host cluster.
+
+### Use custom host schedulers
+
+The following hybrid scheduling configuration enables pods from the virtual cluster to use
+custom schedulers `my-custom-scheduler` and `my-gpu-scheduler` from the host cluster (the rest
+of the vCluster config is omitted for brevity):
+
+```yaml
+sync:
+  toHost:
+    pods:
+      hybridScheduling:
+        enabled: true
+        hostSchedulers:
+        - my-custom-scheduler
+        - my-gpu-scheduler
+```
+
+Then, in your virtual cluster, you can deploy pods that use custom schedulers
+`my-custom-scheduler` and `my-gpu-scheduler` from the host cluster, for example:
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-example
+spec:
+  schedulerName: my-custom-scheduler
+  containers:
+  - name: pause
+    image: registry.k8s.io/pause:3.10
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-gpu-example
+spec:
+  schedulerName: my-gpu-scheduler
+  containers:
+  - name: pause
+    image: registry.k8s.io/pause:3.10
+```
+
+## Use custom virtual schedulers
+
+Custom schedulers that are not in the `sync.toHost.pods.hybridScheduling.hostSchedulers` list
+are expected to be deployed in the virtual cluster.
+
+Therefore, in order for your virtual cluster pods to use a custom scheduler
+`my-virtual-ai-scheduler` that is running in the virtual cluster, don't add
+`my-virtual-ai-scheduler` in `sync.toHost.pods.hybridScheduling.hostSchedulers` list in your
+vCluster config.
+
+The following examples show a pod that is scheduled by custom scheduler
+`my-virtual-ai-scheduler` that is running in the virtual cluster, and the hybrid scheduling
+configuration needed for that.
+
+Hybrid scheduling configuration:
+
+```yaml
+sync:
+  toHost:
+    pods:
+      hybridScheduling:
+        enabled: true
+```
+
+Pod:
+
+```
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-ai-example
+spec:
+  schedulerName: my-virtual-ai-scheduler
+  containers:
+  - name: pause
+    image: registry.k8s.io/pause:3.10
+```
+
+## Other related configuration and cluster permissions
+
+When the `PersistentVolumeClaims` are configured to be synced from the virtual to the host
+cluster, then, the following resources are automatically synced from the host to the virtual
+cluster (unless you explicitly disable this in the vCluster config):
+- `CSINodes`,
+- `CSIStorageCapacities`,
+- `CSIDrivers`.
+
+Additionally, when the `PersistentVolumeClaims` are configured to be synced to the host
+cluster, syncing of `StorageClasses` from the host to the virtual cluster is also
+automatically enabled, but only when syncing of `StorageClasses` from the virtual to the host
+cluster is disabled.
+
+:::warning
+Manually disabling `CSINodes`, `CSIStorageCapacities`, `CSIDrivers` and `StorageClasses` sync
+in the above cases can cause pod scheduling to fail in your virtual cluster.
+:::
+
+
+vCluster automatically adds the required `ClusterRole` rules, so that automatically enabled
+`CSINodes`, `CSIStorageCapacities`, `CSIDrivers` and `StorageClasses` syncing works correctly.
+


### PR DESCRIPTION
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

Add docs which explains how hybrid scheduling works and how to configure it for different scheduling use cases.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-573

