### PR TITLE
fix: Small edits for clarity

### DIFF
--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling.mdx
@@ -4,7 +4,7 @@ sidebar_label: hybridScheduling
 description: Configure hybrid scheduling to use both host and virtual cluster schedulers for workload placement.
 ---
 
-Hybrid scheduling enables virtual clusters to use multiple schedulers simultaneously - both from the host cluster and virtual cluster. Pods within the virtual cluster can use different schedulers based on their individual configuration
+Hybrid scheduling enables virtual clusters to use multiple schedulers simultaneously - both from the host cluster and virtual cluster. Pods within the virtual cluster can use different schedulers based on their individual configuration.
 
 You can enable hybrid scheduling using the following:
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling.mdx
@@ -46,7 +46,7 @@ sync:
 
 The default Kubernetes scheduler on the host cluster is always implicitly included in the `sync.toHost.pods.hybridScheduling.hostSchedulers` list.  
 
-Any pod that uses the default scheduler—either by omitting `.spec.schedulerName` or by explicitly setting it to `default-scheduler`—is scheduled by the Kubernetes scheduler running on the host cluster.
+A default scheduler can be used in two ways: by omitting `.spec.schedulerName` or by explicitly setting it to `default-scheduler`. In both cases, the default Kubernetes scheduler running on the host cluster schedules the pod.
 
 ### Use custom host schedulers
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling.mdx
@@ -1,13 +1,12 @@
 ---
 title: Hybrid Scheduling
 sidebar_label: hybridScheduling
-description: Configuration for ...
+description: Configure hybrid scheduling to use both host and virtual cluster schedulers for workload placement.
 ---
 
-Hybrid scheduling enables you to use custom schedulers from both host and virtual cluster at
-the same time for virtual cluster workloads.
+Hybrid scheduling enables virtual clusters to use multiple schedulers simultaneously - both from the host cluster and virtual cluster. Pods within the virtual cluster can use different schedulers based on their individual configuration
 
-You can enable hybrid scheduling like this:
+You can enable hybrid scheduling using the following:
 
 ```yaml
 sync:
@@ -21,13 +20,9 @@ sync:
     nodes:
       enabled: true
 ```
+You must also enable syncing of real nodes from the host to the virtual cluster. If you don’t, the virtual cluster displays an error.
 
-Notice that you must also enable syncing of real nodes from the host to the virtual cluster.
-If you don't enable syncing of real nodes, you wil get an error.
-
-By default, all the nodes are synced from the host. You can also choose to sync only nodes
-with specific labels by specifying labels selector for nodes like showed in the example
-below.
+By default, all nodes from the host cluster are synced to the virtual cluster. To sync only specific nodes, you can define a label selector as shown in the following example:
 
 ```yaml
 sync:
@@ -47,20 +42,19 @@ sync:
 
 ## Use host schedulers
 
-`sync.toHost.pods.hybridScheduling.hostSchedulers` is a list of schedulers that exist on the host
-cluster, which can be used by the pods in the virtual cluster.
+`sync.toHost.pods.hybridScheduling.hostSchedulers` specifies a list of schedulers available on the host cluster that virtual cluster pods can use.
 
-The default Kubernetes scheduler from the host cluster is always implicitly included in the
-`sync.toHost.pods.hybridScheduling.hostSchedulers` list. This means that all the pods that are
-using the default Kubernetes scheduler (either implicitly when pod's `.spec.schedulerName`
-field is not set, or explicitly, when `.spec.schedulerName` is set to `default-scheduler`) are
-scheduled by the Kubernetes scheduler that is running on the host cluster.
+The default Kubernetes scheduler on the host cluster is always implicitly included in the `sync.toHost.pods.hybridScheduling.hostSchedulers` list.  
+
+Any pod that uses the default scheduler—either by omitting `.spec.schedulerName` or by explicitly setting it to `default-scheduler`—is scheduled by the Kubernetes scheduler running on the host cluster.
 
 ### Use custom host schedulers
 
-The following hybrid scheduling configuration enables pods from the virtual cluster to use
-custom schedulers `my-custom-scheduler` and `my-gpu-scheduler` from the host cluster (the rest
-of the vCluster config is omitted for brevity):
+The following hybrid scheduling configuration allows virtual cluster pods to use the host cluster's custom schedulers my-custom-scheduler and my-gpu-scheduler. 
+
+:::note
+This example omits the full vCluster configuration to highlight the relevant hybrid scheduling settings.
+:::
 
 ```yaml
 sync:
@@ -73,8 +67,7 @@ sync:
         - my-gpu-scheduler
 ```
 
-Then, in your virtual cluster, you can deploy pods that use custom schedulers
-`my-custom-scheduler` and `my-gpu-scheduler` from the host cluster, for example:
+You can now deploy pods in the virtual cluster that use the host cluster’s custom schedulers `my-custom-scheduler` and `my-gpu-scheduler`. For example:
 
 ```yaml
 apiVersion: v1
@@ -100,16 +93,12 @@ spec:
 
 ## Use custom virtual schedulers
 
-Virtual cluster pods can use a custom scheduler that is running in the virtual cluster. For
-this to work correctly, don't add custom virtual schedulers to the
-`sync.toHost.pods.hybridScheduling.hostSchedulers` list in your vCluster config.
+Virtual cluster pods can use a custom scheduler that runs inside the virtual cluster.  
+To ensure these pods are scheduled correctly, **do not** include virtual schedulers in the `sync.toHost.pods.hybridScheduling.hostSchedulers` list in your vCluster configuration.
 
-The following examples show a pod that is scheduled by custom scheduler
-`my-virtual-ai-scheduler` that is running in the virtual cluster, and the hybrid scheduling
-configuration needed for that.
+The following example shows the hybrid scheduling configuration and a pod that uses the `my-virtual-ai-scheduler` running in the virtual cluster.
 
-Hybrid scheduling configuration:
-
+**Hybrid scheduling configuration**:
 ```yaml
 sync:
   toHost:
@@ -118,8 +107,7 @@ sync:
         enabled: true
 ```
 
-Pod:
-
+**Pod**:
 ```
 apiVersion: v1
 kind: Pod
@@ -132,26 +120,24 @@ spec:
     image: registry.k8s.io/pause:3.10
 ```
 
-## Other related configuration and cluster permissions
+## Other related configurations and cluster permissions
 
-With the Hybrid Scheduling enabled, and when the `PersistentVolumeClaims` are configured to be
-synced from the virtual to the host cluster, then, in order for scheduling to work correctly, the
-following resources are automatically synced from the host to the virtual cluster (unless you
-explicitly disable this in the vCluster config):
+When hybrid scheduling is enabled and PersistentVolumeClaims are synced from the virtual cluster to the host cluster, additional resources must also be present in the virtual cluster for scheduling to function correctly.
+
+By default, vCluster automatically syncs the following resources from the host to the virtual cluster, unless this behavior is explicitly disabled in the configuration:
+
 - `CSINodes`,
-- `CSIStorageCapacities`,
-- `CSIDrivers`.
+- `CSIStorageCapacities`
+- `CSIDrivers`
 
-Similarly to the above, when the `PersistentVolumeClaims` are configured to be synced to the host
-cluster, syncing of `StorageClasses` from the host to the virtual cluster is also automatically
-enabled, but only when syncing of `StorageClasses` from the virtual to the host cluster is disabled.
+
+When `PersistentVolumeClaims` are synced to the host cluster, vCluster also enables syncing of `StorageClasses` from the host to the virtual cluster.
+However, this only happens if syncing `StorageClasses` from the virtual cluster to the host is disabled in the configuration.
 
 :::warning
 Manually disabling `CSINodes`, `CSIStorageCapacities`, `CSIDrivers` and `StorageClasses` sync
 in the above cases can cause pod scheduling to fail in your virtual cluster.
 :::
 
-
-vCluster automatically adds the required `ClusterRole` rules, so that automatically enabled
-`CSINodes`, `CSIStorageCapacities`, `CSIDrivers` and `StorageClasses` syncing works correctly.
+vCluster automatically adds the required `ClusterRole` rules to ensure syncing works correctly for automatically enabled `CSINodes`, `CSIStorageCapacities`, `CSIDrivers`, and `StorageClasses`.
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Link to preview](https://deploy-preview-747--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-675

