### PR TITLE
feature: Add `sync.fromHost.*Classes` limits

### DIFF
--- a/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
@@ -44,13 +44,13 @@ If you try to create an IngressClass directly in the virtual cluster, using for 
 
 When IngressClass sync is enabled, vCluster uses selector criteria to control which resources are synced between clusters. This affects two different resource types that flow in opposite directions.
 
-- **IngressClass resources**: Flow from host cluster to virtual cluster only. You cannot create IngressClass resources in the virtual cluster. vCluster copies IngressClass resources from the host cluster based on your selector criteria to make them available for you to reference in their Ingress configurations. If no `selector` is specified, all IngressClass resources from the host cluster are synced.
+- **IngressClass resources (host → virtual)**: Flow from host cluster to virtual cluster only. You cannot create IngressClass resources in the virtual cluster. vCluster copies IngressClass resources from the host cluster based on your selector criteria to make them available for you to reference in their Ingress configurations. If no `selector` is specified, all IngressClass resources from the host cluster are synced.
 
-- **Ingress resources**: Flow from virtual cluster to host cluster where ingress controllers process them. An Ingress syncs only if it references an IngressClass that matches your selector criteria. Ingress resources also sync if they have an empty `ingressClassName` field or if no `selector` is specified in the configuration - this works as a bypass mechanism.
+- **Ingress resources (virtual → host)**: Flow from virtual cluster to host cluster where ingress controllers process them. An Ingress syncs only if it references an IngressClass that matches your selector criteria. Ingress resources also sync if they have an empty `ingressClassName` field or if no `selector` is specified in the configuration.
 
 - **How selectors control both flows**: The selector determines which IngressClass resources get copied from host to virtual cluster. The same selector also determines which Ingress resources can sync from virtual to host cluster. If an Ingress references an IngressClass that wasn't synced to the virtual cluster, that Ingress cannot sync to the host cluster.
 
-## Using selectors to filter IngressClasses
+## Use selectors to filter IngressClasses
 
 Selectors provide precise control over which IngressClass resources get synced from the host cluster. vCluster supports two types of selector criteria that follow standard Kubernetes label selector syntax.
 
@@ -65,9 +65,9 @@ The `matchExpressions` selector allows more flexible, set-based filtering with s
 
 All specified label conditions must match for an IngressClass to be included in the sync. This means that if you define both `matchLabels` and `matchExpressions`, an IngressClass must satisfy all criteria to be synced to the virtual cluster.
 
-## Sync behavior and considerations
+## Sync behavior considerations
 
-### Resource lifecycle and validation
+### Resource lifecycle
 
 Synced IngressClass resources function like any other Kubernetes resource in the virtual cluster. You can view them with `kubectl get ingressclass` and reference them in your Ingress specifications. When you modify an IngressClass in the host cluster, vCluster re-evaluates whether it still matches the selector criteria. If the IngressClass continues to match, vCluster updates the corresponding resource in the virtual cluster to reflect the changes. If the IngressClass no longer matches the selector criteria, vCluster removes it from the virtual cluster.
 
@@ -85,7 +85,7 @@ When you creates an Ingress resource that references an IngressClass not matchin
 
 The error output appears as a Kubernetes event that you can view using `kubectl describe`. The event message clearly states that the ingress was not synced because the referenced IngressClass does not match the configured selector criteria.
 
-### Orphaned resources and cleanup
+### Remove orphaned resources
 
 When vCluster removes a synced IngressClass from the virtual cluster due to selector changes or deletion from the host cluster, any Ingress resources that reference it remain in the virtual cluster. These orphaned Ingress resources stop receiving updates but vCluster does not automatically delete them to prevent unintended data loss. To remove these orphaned resources, you must delete them manually in the host cluster. This manual approach ensures that you maintain full control over resource cleanup and can verify that deletions are intentional.
 
@@ -95,7 +95,7 @@ When vCluster removes a synced IngressClass from the virtual cluster due to sele
 
 To sync only IngressClass resources labeled `environment: development`:
 
-```yaml title="Filter example ingressClass"
+```yaml title="Filter example IngressClass"
 sync:
   toHost:
     ingresses:
@@ -112,7 +112,7 @@ sync:
 
 To sync IngressClass resources where the label `kubernetes.io/ingress.class` is either `nginx` or `traefik`:
 
-```yaml title="Flexible filter example ingressClass"
+```yaml title="Flexible filter example IngressClass"
 sync:
   toHost:
     ingresses:
@@ -133,7 +133,7 @@ sync:
 
 The following configuration syncs IngressClass resources that match both label and expression criteria:
 
-```yaml title="Combined filter example ingressClass"
+```yaml title="Combined filter example IngressClass"
 sync:
   toHost:
     ingresses:
@@ -156,7 +156,7 @@ sync:
 
 When an Ingress resource references an IngressClass that doesn't match the selector criteria, the error output looks like this:
 
-```bash title"Error handling example ingressClass"
+```bash title"Error handling example IngressClass"
 vcluster-virtual-cluster-1:~$ kubectl describe ingress my-ingress
 Name:             my-ingress
 Namespace:        default

--- a/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
@@ -13,9 +13,15 @@ import EnableSwitch from '../../../../_partials/config/sync/fromHost/ingressClas
 - original issue: https://github.com/loft-sh/vcluster/issues/663
 */}
 
-By default, this is disabled.
+By default, IngressClass synchronization is disabled.
 
-Sync `IngressClass` resources from the host cluster to the virtual cluster.
+You can enable this feature to sync `IngressClass` resources from the host cluster to the virtual cluster.
+
+This is useful in scenarios where selective access to ingress configurations is required. Common use cases include:
+
+- **Development environments**: Sync only the IngressClasses required for development clusters to reduce noise and avoid unnecessary exposure.
+- **Multi-tenancy**: Enable teams to use their own IngressClasses while sharing a single host cluster.
+- **Security**: Restrict the IngressClasses available in the virtual cluster to enforce access control and prevent unintended configurations.
 
 ## Enable syncing IngressClasses from the host to virtual cluster
 
@@ -26,6 +32,7 @@ sync:
       enabled: true
 ```
 
+<!-- vale off -->
 ### Example
 
 The following configuration syncs all `IngressClasses` that match the specified labels and expressions from the host cluster to the virtual cluster:
@@ -57,6 +64,7 @@ The `selector` field follows the same syntax as Kubernetes label selectors. Use 
 All specified label conditions must match for an `IngressClass` to be included in the sync.
 :::
 
+
 ## Use selectors to filter IngressClasses
 
 Use `matchLabels` and `matchExpressions` to filter which `IngressClass` resources are synced based on their labels.
@@ -86,7 +94,7 @@ Use `matchLabels` and `matchExpressions` to filter which `IngressClass` resource
 
 For more details on how to use label selectors effectively, refer to the [Kubernetes documentation on label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements).
 
-### Considerations
+## Sync behavior and considerations
 
 When `IngressClass` synchronization is enabled, the vCluster syncer uses selector criteria to control which `IngressClasses` are synchronized between the host and virtual clusters.
 
@@ -96,17 +104,21 @@ The selector configuration creates a bidirectional filter:
 
 - **From virtual cluster to host**: `Ingress` resources created in the virtual cluster are synchronized to the host only if they reference `IngressClasses` that match the selector criteria.
 
+### Resource availability and updates
 
+- Synced `IngressClass` resources appear in the virtual cluster and can be referenced by `Ingress` resources.
+- When an `IngressClass` in the host cluster is modified, the selector is re-evaluated:
+  - If it still matches, the resource is updated in the virtual cluster.
+  - If it no longer matches, it is removed from the virtual cluster.
+- If an `IngressClass` fails to meet the selector criteria, a warning is logged in the vCluster syncer pod’s output.
 
-- `IngressClass` resources synced from the host are available in the virtual cluster. You can create `Ingress` resources in the virtual cluster that reference these synced classes.
+### Orphaned Ingress resources
 
-- When an `IngressClass` in the host cluster is modified (e.g., patched or updated), the selector is re-evaluated. If it still matches the criteria, the synced `IngressClass` is updated in the virtual cluster. If it no longer matches, it is removed from the virtual cluster.
+- If a synced `IngressClass` is removed from the virtual cluster (due to selector mismatch or deletion), any `Ingress` resources referencing it remain in the virtual cluster.
+- These `Ingress` resources stop receiving updates but are not automatically deleted.
+- To remove them, you must delete them manually in the host cluster.
 
-- If an `IngressClass` cannot be synced because it doesn't meet the selector criteria, a warning is logged in the vCluster syncer pod's stdout.
-
-- Existing `Ingress` resources in the virtual cluster are not automatically deleted if their associated `IngressClass` is removed or no longer matches the selector. However, they will no longer receive updates. To remove them, you must delete them manually in the host cluster.
-
-### Constraint enforcement
+## Constraint enforcement
 
 The selector acts as both a filter and a validation mechanism:
 
@@ -116,14 +128,15 @@ The selector acts as both a filter and a validation mechanism:
 
 - **Sync restriction**: Ingress resources referencing non-matching `IngressClasses` are blocked from synchronizing to the host cluster.
 
-### Error handling
+## Error handling
 
 When an `Ingress` resource references an `IngressClass` that doesn't match the selector criteria:
+
 - The `Ingress` synchronization to the host cluster fails.
 - An event is recorded on the `Ingress` resource in the virtual cluster.
 - The event indicates that the specified `IngressClass` is not available in the host.
 
-This should look like this:
+The event output looks similar to the following:
 
 ```shell
 vcluster-virtual-cluster-1:~$ kubectl describe ingress my-ingress
@@ -135,11 +148,6 @@ Events:
   ----     ------            ----  ----                -------
   Warning  SyncWarning       10s   ingress-syncer      did not sync ingress "my-ingress" to host because it does not match the selector under 'sync.fromHost.ingressClasses.selector'
 ```
-
-### Use cases
-- **Development Environments**: Sync specific IngressClasses that are used in development environments.
-- **Multi-Tenancy**: Allow different teams to use their own IngressClasses while still sharing the same host cluster resources.
-- **Security**: Limit the IngressClasses available in the virtual cluster to only those that are necessary.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
@@ -33,6 +33,11 @@ sync:
 ```
 
 <!-- vale off -->
+
+:::note
+When `sync.fromHost.ingressClasses.enabled` is enabled, any `IngressClass` created in the virtual cluster will be immediately deleted.
+:::
+
 ### Example
 
 The following configuration syncs all `IngressClasses` that match the specified labels and expressions from the host cluster to the virtual cluster:

--- a/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
@@ -69,10 +69,10 @@ All specified label conditions must match for an `IngressClass` to be included i
 
 Use `matchLabels` and `matchExpressions` to filter which `IngressClass` resources are synced based on their labels.
 
-- `matchLabels`: Defines exact label key-value pairs.  
-  
+- `matchLabels`: Defines exact label key-value pairs.
+
   For example, to sync only `IngressClasses` labeled `environment: development`:
-  
+
   ```yaml
   matchLabels:
     environment: development
@@ -81,7 +81,7 @@ Use `matchLabels` and `matchExpressions` to filter which `IngressClass` resource
 - `matchExpressions`: Allows more flexible, set-based filtering.
 
   For example, to sync `IngressClasses` where the label `kubernetes.io/ingress.class` is either `nginx` or `traefik`:
-  
+
   ```yaml
   matchExpressions:
     - key: kubernetes.io/ingress.class
@@ -124,9 +124,9 @@ The selector acts as both a filter and a validation mechanism:
 
 - **Resource filtering**: Only `IngressClasses` that match the selector criteria are made available in the virtual cluster's API server.
 
-- **Creation validation**: Ingress resources in the virtual cluster can only reference `IngressClasses` that exist in the filtered set.
+- **Creation validation**: `Ingress` resources in the virtual cluster can only reference `IngressClasses` that exist in the filtered set.
 
-- **Sync restriction**: Ingress resources referencing non-matching `IngressClasses` are blocked from synchronizing to the host cluster.
+- **Sync restriction**: `Ingress` resources referencing non-matching `IngressClasses` are blocked from synchronizing to the host cluster.
 
 ## Error handling
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
@@ -12,7 +12,7 @@ By default, this is disabled.
 
 IngressClass syncing allows virtual clusters to use ingress controllers from the host cluster. Typically, each virtual cluster needs its own ingress controller to handle incoming traffic. With IngressClass syncing enabled, virtual clusters can reference IngressClass resources from the host cluster instead.
 
-You can enable this feature to sync IngressClass resources from the host cluster to the virtual cluster. Add labels to IngressClass resources in your host cluster and configure vCluster to sync only those that match specific label selectors. When a user creates an Ingress resource in the virtual cluster that references a synced IngressClass, the host cluster's ingress controller handles the traffic routing.
+You can enable this feature to sync IngressClass resources from the host cluster to the virtual cluster. Add labels to IngressClass resources in your host cluster and configure vCluster to sync only those that match specific label selectors. When you create an Ingress resource in the virtual cluster that references a synced IngressClass, the host cluster's ingress controller handles the traffic routing.
 
 This saves resources since you don't need separate ingress controllers in every virtual cluster. It also gives you centralized control over which ingress capabilities teams can access. 
 
@@ -44,13 +44,11 @@ If you try to create an IngressClass directly in the virtual cluster, using for 
 
 When IngressClass sync is enabled, vCluster uses selector criteria to control which resources are synced between clusters. This affects two different resource types that flow in opposite directions.
 
-- **IngressClass resources**: Flow from host cluster to virtual cluster only. You cannot create IngressClass resources in the virtual cluster. vCluster copies IngressClass resources from the host cluster based on your selector criteria to make them available for users to reference in their Ingress configurations. If no `selector` is specified, all IngressClass resources from the host cluster are synced.
+- **IngressClass resources**: Flow from host cluster to virtual cluster only. You cannot create IngressClass resources in the virtual cluster. vCluster copies IngressClass resources from the host cluster based on your selector criteria to make them available for you to reference in their Ingress configurations. If no `selector` is specified, all IngressClass resources from the host cluster are synced.
 
 - **Ingress resources**: Flow from virtual cluster to host cluster where ingress controllers process them. An Ingress syncs only if it references an IngressClass that matches your selector criteria. Ingress resources also sync if they have an empty `ingressClassName` field or if no `selector` is specified in the configuration - this works as a bypass mechanism.
 
 - **How selectors control both flows**: The selector determines which IngressClass resources get copied from host to virtual cluster. The same selector also determines which Ingress resources can sync from virtual to host cluster. If an Ingress references an IngressClass that wasn't synced to the virtual cluster, that Ingress cannot sync to the host cluster.
-
-This approach ensures users can only create Ingress resources that reference approved IngressClass resources.
 
 ## Using selectors to filter IngressClasses
 
@@ -71,25 +69,25 @@ All specified label conditions must match for an IngressClass to be included in 
 
 ### Resource lifecycle and validation
 
-Synced IngressClass resources function like any other Kubernetes resource in the virtual cluster. Users can view them with `kubectl get ingressclass` and reference them in their Ingress specifications. When you modify an IngressClass in the host cluster, vCluster re-evaluates whether it still matches the selector criteria. If the IngressClass continues to match, vCluster updates the corresponding resource in the virtual cluster to reflect the changes. If the IngressClass no longer matches the selector criteria, vCluster removes it from the virtual cluster.
+Synced IngressClass resources function like any other Kubernetes resource in the virtual cluster. You can view them with `kubectl get ingressclass` and reference them in your Ingress specifications. When you modify an IngressClass in the host cluster, vCluster re-evaluates whether it still matches the selector criteria. If the IngressClass continues to match, vCluster updates the corresponding resource in the virtual cluster to reflect the changes. If the IngressClass no longer matches the selector criteria, vCluster removes it from the virtual cluster.
 
-The selector system acts as both a resource filter and a validation mechanism. As a resource filter, it ensures that vCluster makes only IngressClass resources matching the selector criteria available in the virtual cluster's API server. The selector also functions as a creation validation mechanism - when users create Ingress resources in the virtual cluster, those resources can only reference IngressClass resources that exist in the filtered set.
+The selector system acts as both a resource filter and a validation mechanism. As a resource filter, it ensures that vCluster makes only IngressClass resources matching the selector criteria available in the virtual cluster's API server. The selector also functions as a creation validation mechanism - when you create Ingress resources in the virtual cluster, the resources can only reference IngressClass resources that exist in the filtered set.
 
 ### Error handling and troubleshooting
 
 When an IngressClass fails to meet the selector criteria during evaluation, vCluster logs a warning in the syncer pod's output to help with troubleshooting and monitoring. This logging provides visibility into which resources are being filtered out and why.
 
-When a user creates an Ingress resource that references an IngressClass not matching the selector criteria, several things occur to provide clear feedback:
+When you creates an Ingress resource that references an IngressClass not matching the selector criteria, several things occur to provide clear feedback:
 
 - The Ingress synchronization to the host cluster fails
 - vCluster records an event on the Ingress resource in the virtual cluster  
 - The event indicates that the specified IngressClass is not available according to the current selector configuration
 
-The error output appears as a Kubernetes event that you can view using `kubectl describe`. The event message clearly states that the ingress was not synced because the referenced IngressClass does not match the configured selector criteria. This immediate feedback helps users understand why their Ingress resources are not working and guides them toward using approved IngressClass resources.
+The error output appears as a Kubernetes event that you can view using `kubectl describe`. The event message clearly states that the ingress was not synced because the referenced IngressClass does not match the configured selector criteria.
 
 ### Orphaned resources and cleanup
 
-When vCluster removes a synced IngressClass from the virtual cluster due to selector changes or deletion from the host cluster, any Ingress resources that reference it remain in the virtual cluster. These orphaned Ingress resources stop receiving updates but vCluster does not automatically delete them to prevent unintended data loss. To remove these orphaned resources, you must delete them manually in the host cluster. This manual approach ensures that users maintain full control over resource cleanup and can verify that deletions are intentional.
+When vCluster removes a synced IngressClass from the virtual cluster due to selector changes or deletion from the host cluster, any Ingress resources that reference it remain in the virtual cluster. These orphaned Ingress resources stop receiving updates but vCluster does not automatically delete them to prevent unintended data loss. To remove these orphaned resources, you must delete them manually in the host cluster. This manual approach ensures that you maintain full control over resource cleanup and can verify that deletions are intentional.
 
 ## Examples
 
@@ -154,7 +152,7 @@ sync:
               - traefik
 ```
 
-### Error handling example
+### Error handling
 
 When an Ingress resource references an IngressClass that doesn't match the selector criteria, the error output looks like this:
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
@@ -1,8 +1,8 @@
 ---
-title: Ingress Classes
+title: Ingress classes
 sidebar_label: ingressClasses
 sidebar_position: 3
-description: Configuration for Ingress Classes in vCluster
+description: Configuration for IngressClasses in vCluster
 ---
 
 import EnableSwitch from '../../../../_partials/config/sync/fromHost/ingressClasses.mdx'
@@ -15,9 +15,9 @@ import EnableSwitch from '../../../../_partials/config/sync/fromHost/ingressClas
 
 By default, this is disabled.
 
-Sync IngressClass resources from the host cluster to the virtual cluster.
+Sync `IngressClass` resources from the host cluster to the virtual cluster.
 
-### Enable syncing IngressClasses from the host to virtual cluster
+## Enable syncing IngressClasses from the host to virtual cluster
 
 ```YAML
 sync:
@@ -27,7 +27,8 @@ sync:
 ```
 
 ### Example
-The following configuration syncs all IngressClasses that match the specified labels and expressions from the host cluster to the virtual cluster.
+
+The following configuration syncs all `IngressClasses` that match the specified labels and expressions from the host cluster to the virtual cluster:
 
 ```YAML
 sync:
@@ -50,23 +51,78 @@ sync:
               - traefik
 ```
 
-The selector section uses the same syntax as the Kubernetes label selector, allowing you to filter which IngressClasses should be synced from the host based on their labels.
-Note that all the criteria must match for an IngressClass to be included in the sync.
+The `selector` field follows the same syntax as Kubernetes label selectors. Use it to filter which `IngressClass` resources are synced from the host cluster based on their labels.
 
-### How selector works
+:::note
+All specified label conditions must match for an `IngressClass` to be included in the sync.
+:::
 
-`matchLabels` and `matchExpressions` are used to filter IngressClasses based on their labels.
-- matchLabels: This section allows you to specify exact label matches. For example, if you want to sync only IngressClasses with the label `environment: development`, you would specify it here.
-- matchExpressions: This section allows for more complex queries. For example, if you want to sync IngressClasses with the label `kubernetes.io/ingress.class` that are either `nginx` or `traefik`, you would specify it here using the `In` operator. Allowed operators include `In`, `NotIn`, `Exists`, and `DoesNotExist`.
+## Use selectors to filter IngressClasses
 
-Refer to the [Kubernetes documentation on label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements) for more details on how to use label selectors effectively.
+Use `matchLabels` and `matchExpressions` to filter which `IngressClass` resources are synced based on their labels.
 
-When you enable the syncing of IngressClasses from the host cluster, the vCluster syncer looks for IngressClasses that match the specified selector criteria.
+- `matchLabels`: Defines exact label key-value pairs.  
+  
+  For example, to sync only `IngressClasses` labeled `environment: development`:
+  
+  ```yaml
+  matchLabels:
+    environment: development
+  ```
 
-The selector limits not only the IngressClasses that are synced from the host but also the sync of the Ingress resources created in the virtual cluster to the host.
-This ensures that only the relevant classes are available for use. So when trying to create an Ingress resource in the virtual cluster, it only allows the IngressClasses that match the specified selector criteria.
+- `matchExpressions`: Allows more flexible, set-based filtering.
 
-The Ingress resource sync to host fails when using an IngressClass that does not match the selector. An event is recorded for the Ingress in the virtual cluster, indicating that the IngressClass is not available in the host.
+  For example, to sync `IngressClasses` where the label `kubernetes.io/ingress.class` is either `nginx` or `traefik`:
+  
+  ```yaml
+  matchExpressions:
+    - key: kubernetes.io/ingress.class
+      operator: In
+      values:
+        - nginx
+        - traefik
+  ```
+  Supported operators are `In`, `NotIn`, `Exists`, and `DoesNotExist`.
+
+For more details on how to use label selectors effectively, refer to the [Kubernetes documentation on label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements).
+
+### Considerations
+
+When `IngressClass` synchronization is enabled, the vCluster syncer uses selector criteria to control which `IngressClasses` are synchronized between the host and virtual clusters.
+
+The selector configuration creates a bidirectional filter:
+
+- **From host to virtual cluster**: Only `IngressClasses` matching the selector criteria are synchronized from the host cluster to the virtual cluster.
+
+- **From virtual cluster to host**: `Ingress` resources created in the virtual cluster are synchronized to the host only if they reference `IngressClasses` that match the selector criteria.
+
+
+
+- `IngressClass` resources synced from the host are available in the virtual cluster. You can create `Ingress` resources in the virtual cluster that reference these synced classes.
+
+- When an `IngressClass` in the host cluster is modified (e.g., patched or updated), the selector is re-evaluated. If it still matches the criteria, the synced `IngressClass` is updated in the virtual cluster. If it no longer matches, it is removed from the virtual cluster.
+
+- If an `IngressClass` cannot be synced because it doesn't meet the selector criteria, a warning is logged in the vCluster syncer pod's stdout.
+
+- Existing `Ingress` resources in the virtual cluster are not automatically deleted if their associated `IngressClass` is removed or no longer matches the selector. However, they will no longer receive updates. To remove them, you must delete them manually in the host cluster.
+
+### Constraint enforcement
+
+The selector acts as both a filter and a validation mechanism:
+
+- **Resource filtering**: Only `IngressClasses` that match the selector criteria are made available in the virtual cluster's API server.
+
+- **Creation validation**: Ingress resources in the virtual cluster can only reference `IngressClasses` that exist in the filtered set.
+
+- **Sync restriction**: Ingress resources referencing non-matching `IngressClasses` are blocked from synchronizing to the host cluster.
+
+### Error handling
+
+When an `Ingress` resource references an `IngressClass` that doesn't match the selector criteria:
+- The `Ingress` synchronization to the host cluster fails.
+- An event is recorded on the `Ingress` resource in the virtual cluster.
+- The event indicates that the specified `IngressClass` is not available in the host.
+
 This should look like this:
 
 ```shell
@@ -84,12 +140,6 @@ Events:
 - **Development Environments**: Sync specific IngressClasses that are used in development environments.
 - **Multi-Tenancy**: Allow different teams to use their own IngressClasses while still sharing the same host cluster resources.
 - **Security**: Limit the IngressClasses available in the virtual cluster to only those that are necessary.
-
-### Important notes
-- The synced IngressClasses is synced to the virtual cluster, allowing you to create Ingress resources that reference them.
-- As soon as the IngressClass changes in the host cluster (ex. through a patch or update), the selector is re-evaluated, and the IngressClass is updated in the virtual cluster or deleted if it doesn't match the selector criteria.
-- A Warning is logged in the stdout of the vCluster syncer pod if an IngressClass cannot be synced due to the selector criteria not matching.
-- The already synced Ingresses are not deleted if the IngressClass is removed or does not match the criteria in the host cluster, but they are not updated anymore. If you want to remove them, you need to delete them manually in the host cluster.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
@@ -95,7 +95,7 @@ When vCluster removes a synced IngressClass from the virtual cluster due to sele
 
 To sync only IngressClass resources labeled `environment: development`:
 
-```yaml
+```yaml title="Filter example ingressClass"
 sync:
   toHost:
     ingresses:
@@ -112,7 +112,7 @@ sync:
 
 To sync IngressClass resources where the label `kubernetes.io/ingress.class` is either `nginx` or `traefik`:
 
-```yaml
+```yaml title="Flexible filter example ingressClass"
 sync:
   toHost:
     ingresses:
@@ -133,7 +133,7 @@ sync:
 
 The following configuration syncs IngressClass resources that match both label and expression criteria:
 
-```yaml
+```yaml title="Combined filter example ingressClass"
 sync:
   toHost:
     ingresses:
@@ -156,7 +156,7 @@ sync:
 
 When an Ingress resource references an IngressClass that doesn't match the selector criteria, the error output looks like this:
 
-```bash
+```bash title"Error handling example ingressClass"
 vcluster-virtual-cluster-1:~$ kubectl describe ingress my-ingress
 Name:             my-ingress
 Namespace:        default

--- a/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
@@ -2,7 +2,7 @@
 title: Ingress Classes
 sidebar_label: ingressClasses
 sidebar_position: 3
-description: Configuration for ...
+description: Configuration for Ingress Classes in vCluster
 ---
 
 import EnableSwitch from '../../../../_partials/config/sync/fromHost/ingressClasses.mdx'
@@ -13,12 +13,11 @@ import EnableSwitch from '../../../../_partials/config/sync/fromHost/ingressClas
 - original issue: https://github.com/loft-sh/vcluster/issues/663
 */}
 
-By default, this is disabled. 
+By default, this is disabled.
 
-Sync IngressClass resources from the host cluster to the virtual cluster. 
+Sync IngressClass resources from the host cluster to the virtual cluster.
 
-### Enable Syncing IngressClasses from the Host to Virtual Cluster
-
+### Enable syncing IngressClasses from the host to virtual cluster
 
 ```YAML
 sync:
@@ -26,6 +25,71 @@ sync:
     ingressClasses:
       enabled: true
 ```
+
+### Example
+The following configuration syncs all IngressClasses that match the specified labels and expressions from the host cluster to the virtual cluster.
+
+```YAML
+sync:
+  toHost:
+    ingresses:
+      enabled: true
+  fromHost:
+    ingressClasses:
+      enabled: true
+      selector:
+        matchLabels:
+          # Match all IngressClasses with the label `environment` with value `development`
+          environment: "development"
+        matchExpressions:
+          # Match IngressClasses with the label `kubernetes.io/ingress.class` that are either `nginx` or `traefik`
+          - key: "kubernetes.io/ingress.class"
+            operator: In
+            values:
+              - nginx
+              - traefik
+```
+
+The selector section uses the same syntax as the Kubernetes label selector, allowing you to filter which IngressClasses should be synced from the host based on their labels.
+Note that all the criteria must match for an IngressClass to be included in the sync.
+
+### How selector works
+
+`matchLabels` and `matchExpressions` are used to filter IngressClasses based on their labels.
+- matchLabels: This section allows you to specify exact label matches. For example, if you want to sync only IngressClasses with the label `environment: development`, you would specify it here.
+- matchExpressions: This section allows for more complex queries. For example, if you want to sync IngressClasses with the label `kubernetes.io/ingress.class` that are either `nginx` or `traefik`, you would specify it here using the `In` operator. Allowed operators include `In`, `NotIn`, `Exists`, and `DoesNotExist`.
+
+Refer to the [Kubernetes documentation on label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements) for more details on how to use label selectors effectively.
+
+When you enable the syncing of IngressClasses from the host cluster, the vCluster syncer looks for IngressClasses that match the specified selector criteria.
+
+The selector limits not only the IngressClasses that are synced from the host but also the sync of the Ingress resources created in the virtual cluster to the host.
+This ensures that only the relevant classes are available for use. So when trying to create an Ingress resource in the virtual cluster, it only allows the IngressClasses that match the specified selector criteria.
+
+The Ingress resource sync to host fails when using an IngressClass that does not match the selector. An event is recorded for the Ingress in the virtual cluster, indicating that the IngressClass is not available in the host.
+This should look like this:
+
+```shell
+vcluster-virtual-cluster-1:~$ kubectl describe ingress my-ingress
+Name:             my-ingress
+Namespace:        default
+Ingress Class:    nginx
+Events:
+  Type     Reason            Age   From                Message
+  ----     ------            ----  ----                -------
+  Warning  SyncWarning       10s   ingress-syncer      did not sync ingress "my-ingress" to host because it does not match the selector under 'sync.fromHost.ingressClasses.selector'
+```
+
+### Use cases
+- **Development Environments**: Sync specific IngressClasses that are used in development environments.
+- **Multi-Tenancy**: Allow different teams to use their own IngressClasses while still sharing the same host cluster resources.
+- **Security**: Limit the IngressClasses available in the virtual cluster to only those that are necessary.
+
+### Important notes
+- The synced IngressClasses is synced to the virtual cluster, allowing you to create Ingress resources that reference them.
+- As soon as the IngressClass changes in the host cluster (ex. through a patch or update), the selector is re-evaluated, and the IngressClass is updated in the virtual cluster or deleted if it doesn't match the selector criteria.
+- A Warning is logged in the stdout of the vCluster syncer pod if an IngressClass cannot be synced due to the selector criteria not matching.
+- The already synced Ingresses are not deleted if the IngressClass is removed or does not match the criteria in the host cluster, but they are not updated anymore. If you want to remove them, you need to delete them manually in the host cluster.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
@@ -11,15 +11,20 @@ import EnableSwitch from '../../../../_partials/config/sync/fromHost/ingressClas
 By default, this is disabled.
 
 IngressClass syncing allows virtual clusters to use ingress controllers from the host cluster. Typically, each virtual cluster needs its own ingress controller to handle incoming traffic. With IngressClass syncing enabled, virtual clusters can reference IngressClass resources from the host cluster instead.
+
 You can enable this feature to sync IngressClass resources from the host cluster to the virtual cluster. Add labels to IngressClass resources in your host cluster and configure vCluster to sync only those that match specific label selectors. When a user creates an Ingress resource in the virtual cluster that references a synced IngressClass, the host cluster's ingress controller handles the traffic routing.
+
 This saves resources since you don't need separate ingress controllers in every virtual cluster. It also gives you centralized control over which ingress capabilities teams can access. 
+
 This approach is useful in scenarios where selective access to ingress configurations is required. Common use cases include:
 
 - **Development environments**: Sync only the IngressClass resources required for development clusters to reduce noise and avoid unnecessary exposure.
 - **Multi-tenancy**: Enable teams to use their own IngressClass resources while sharing a single host cluster.
 - **Security**: Restrict the IngressClass resources available in the virtual cluster to enforce access control and prevent unintended configurations.
 
-## Enable syncing IngressClasses from the host to virtual cluster
+## Enable IngressClasses syncing
+
+To enable IngressClass syncing from the host cluster without filtering:
 
 ```YAML
 sync:
@@ -37,17 +42,15 @@ If you try to create an IngressClass directly in the virtual cluster, using for 
 
 ## How IngressClass syncing works
 
-When IngressClass sync is enabled, vCluster uses selector criteria to control which IngressClass resources are synced from the host cluster to the virtual cluster. The selector configuration affects two related but separate syncing processes:
+When IngressClass sync is enabled, vCluster uses selector criteria to control which resources are synced between clusters. This affects two different resource types that flow in opposite directions.
 
-- **IngressClass resources**: Sync only from host cluster to virtual cluster based on selector criteria
-- **Ingress resources**: Sync from virtual cluster to host cluster, but only if they reference IngressClasses that match the selector criteria
+- **IngressClass resources**: Flow from host cluster to virtual cluster only. You cannot create IngressClass resources in the virtual cluster. vCluster copies IngressClass resources from the host cluster based on your selector criteria to make them available for users to reference in their Ingress configurations. If no `selector` is specified, all IngressClass resources from the host cluster are synced.
 
-IngressClass resources never sync from the virtual cluster back to the host cluster. The syncing is unidirectional for IngressClasses themselves, but the selector criteria influence which Ingress resources can be successfully synced to the host cluster for processing.
+- **Ingress resources**: Flow from virtual cluster to host cluster where ingress controllers process them. An Ingress syncs only if it references an IngressClass that matches your selector criteria. Ingress resources also sync if they have an empty `ingressClassName` field or if no `selector` is specified in the configuration - this works as a bypass mechanism.
 
-:::note
-When `sync.fromHost.ingressClasses.enabled` is set to `true`, vCluster takes control of all IngressClass resources in the virtual cluster. It only allows IngressClass resources that are synced from the host cluster to exist.
-If you try to create an IngressClass directly in the virtual cluster, using for example `kubectl create` or `kubectl apply`, vCluster detects it and deletes it immediately. This prevents conflicts between locally-created IngressClasses and those synced from the host cluster, ensuring that only approved IngressClass resources (those made available through the host cluster) exist in the virtual cluster.
-:::
+- **How selectors control both flows**: The selector determines which IngressClass resources get copied from host to virtual cluster. The same selector also determines which Ingress resources can sync from virtual to host cluster. If an Ingress references an IngressClass that wasn't synced to the virtual cluster, that Ingress cannot sync to the host cluster.
+
+This approach ensures users can only create Ingress resources that reference approved IngressClass resources.
 
 ## Using selectors to filter IngressClasses
 
@@ -86,7 +89,7 @@ The error output appears as a Kubernetes event that you can view using `kubectl 
 
 ### Orphaned resources and cleanup
 
-When vCluster removes a synced IngressClass from the virtual cluster due to selector changes or deletion from the host cluster, any Ingress resources that reference it remain in the virtual cluster. These orphaned Ingress resources stop receiving updates but vCluster does not automatically delete them to prevent unintended data loss. To remove these orphaned resources, you must delete them manually in the host cluster. This manual approach ensures that administrators maintain full control over resource cleanup and can verify that deletions are intentional.
+When vCluster removes a synced IngressClass from the virtual cluster due to selector changes or deletion from the host cluster, any Ingress resources that reference it remain in the virtual cluster. These orphaned Ingress resources stop receiving updates but vCluster does not automatically delete them to prevent unintended data loss. To remove these orphaned resources, you must delete them manually in the host cluster. This manual approach ensures that users maintain full control over resource cleanup and can verify that deletions are intentional.
 
 ## Examples
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
@@ -7,21 +7,17 @@ description: Configuration for IngressClasses in vCluster
 
 import EnableSwitch from '../../../../_partials/config/sync/fromHost/ingressClasses.mdx'
 
-{/*
-`ingressClasses.enabled`:
-- covered by the generic section here: https://www.vcluster.com/docs/syncer/config#enable-or-disable-synced-resources
-- original issue: https://github.com/loft-sh/vcluster/issues/663
-*/}
 
 By default, this is disabled.
 
-You can enable this feature to sync `IngressClass` resources from the host cluster to the virtual cluster.
+IngressClass syncing allows virtual clusters to use ingress controllers from the host cluster. Typically, each virtual cluster needs its own ingress controller to handle incoming traffic. With IngressClass syncing enabled, virtual clusters can reference IngressClass resources from the host cluster instead.
+You can enable this feature to sync IngressClass resources from the host cluster to the virtual cluster. Add labels to IngressClass resources in your host cluster and configure vCluster to sync only those that match specific label selectors. When a user creates an Ingress resource in the virtual cluster that references a synced IngressClass, the host cluster's ingress controller handles the traffic routing.
+This saves resources since you don't need separate ingress controllers in every virtual cluster. It also gives you centralized control over which ingress capabilities teams can access. 
+This approach is useful in scenarios where selective access to ingress configurations is required. Common use cases include:
 
-This is useful in scenarios where selective access to ingress configurations is required. Common use cases include:
-
-- **Development environments**: Sync only the `IngressClasses` required for development clusters to reduce noise and avoid unnecessary exposure.
-- **Multi-tenancy**: Enable teams to use their own `IngressClasses` while sharing a single host cluster.
-- **Security**: Restrict the `IngressClasses` available in the virtual cluster to enforce access control and prevent unintended configurations.
+- **Development environments**: Sync only the IngressClass resources required for development clusters to reduce noise and avoid unnecessary exposure.
+- **Multi-tenancy**: Enable teams to use their own IngressClass resources while sharing a single host cluster.
+- **Security**: Restrict the IngressClass resources available in the virtual cluster to enforce access control and prevent unintended configurations.
 
 ## Enable syncing IngressClasses from the host to virtual cluster
 
@@ -35,12 +31,68 @@ sync:
 <!-- vale off -->
 
 :::note
-When `sync.fromHost.ingressClasses.enabled` is enabled, any `IngressClass` created in the virtual cluster is immediately deleted.
+When `sync.fromHost.ingressClasses.enabled` is set to `true`, vCluster takes control of all IngressClass resources in the virtual cluster. It only allows IngressClass resources that are synced from the host cluster to exist.
+If you try to create an IngressClass directly in the virtual cluster, using for example `kubectl create` or `kubectl apply`, vCluster detects it and deletes it immediately. This prevents conflicts between locally-created IngressClasses and those synced from the host cluster, ensuring that only approved IngressClass resources (those made available through the host cluster) exist in the virtual cluster.
 :::
 
-### Example
+## How IngressClass syncing works
 
-The following configuration syncs all `IngressClasses` that match the specified labels and expressions from the host cluster to the virtual cluster:
+When IngressClass sync is enabled, vCluster uses selector criteria to control which IngressClass resources are synced from the host cluster to the virtual cluster. The selector configuration affects two related but separate syncing processes:
+
+- **IngressClass resources**: Sync only from host cluster to virtual cluster based on selector criteria
+- **Ingress resources**: Sync from virtual cluster to host cluster, but only if they reference IngressClasses that match the selector criteria
+
+IngressClass resources never sync from the virtual cluster back to the host cluster. The syncing is unidirectional for IngressClasses themselves, but the selector criteria influence which Ingress resources can be successfully synced to the host cluster for processing.
+
+:::note
+When `sync.fromHost.ingressClasses.enabled` is set to `true`, vCluster takes control of all IngressClass resources in the virtual cluster. It only allows IngressClass resources that are synced from the host cluster to exist.
+If you try to create an IngressClass directly in the virtual cluster, using for example `kubectl create` or `kubectl apply`, vCluster detects it and deletes it immediately. This prevents conflicts between locally-created IngressClasses and those synced from the host cluster, ensuring that only approved IngressClass resources (those made available through the host cluster) exist in the virtual cluster.
+:::
+
+## Using selectors to filter IngressClasses
+
+Selectors provide precise control over which IngressClass resources get synced from the host cluster. vCluster supports two types of selector criteria that follow standard Kubernetes label selector syntax.
+
+The `matchLabels` selector defines exact label key-value pairs that must be present on an IngressClass for it to be synced. This provides straightforward filtering based on specific label values. For example, setting `matchLabels` to `environment: development` syncs only IngressClass resources that have exactly that label and value.
+
+The `matchExpressions` selector allows more flexible, set-based filtering with support for multiple operators:
+
+- `In`: Matches IngressClass resources where the label value exists within a specified list
+- `NotIn`: Excludes resources with certain label values  
+- `Exists`: Requires the presence of a label key regardless of its value
+- `DoesNotExist`: Excludes resources that have a particular label key
+
+All specified label conditions must match for an IngressClass to be included in the sync. This means that if you define both `matchLabels` and `matchExpressions`, an IngressClass must satisfy all criteria to be synced to the virtual cluster.
+
+## Sync behavior and considerations
+
+### Resource lifecycle and validation
+
+Synced IngressClass resources function like any other Kubernetes resource in the virtual cluster. Users can view them with `kubectl get ingressclass` and reference them in their Ingress specifications. When you modify an IngressClass in the host cluster, vCluster re-evaluates whether it still matches the selector criteria. If the IngressClass continues to match, vCluster updates the corresponding resource in the virtual cluster to reflect the changes. If the IngressClass no longer matches the selector criteria, vCluster removes it from the virtual cluster.
+
+The selector system acts as both a resource filter and a validation mechanism. As a resource filter, it ensures that vCluster makes only IngressClass resources matching the selector criteria available in the virtual cluster's API server. The selector also functions as a creation validation mechanism - when users create Ingress resources in the virtual cluster, those resources can only reference IngressClass resources that exist in the filtered set.
+
+### Error handling and troubleshooting
+
+When an IngressClass fails to meet the selector criteria during evaluation, vCluster logs a warning in the syncer pod's output to help with troubleshooting and monitoring. This logging provides visibility into which resources are being filtered out and why.
+
+When a user creates an Ingress resource that references an IngressClass not matching the selector criteria, several things occur to provide clear feedback:
+
+- The Ingress synchronization to the host cluster fails
+- vCluster records an event on the Ingress resource in the virtual cluster  
+- The event indicates that the specified IngressClass is not available according to the current selector configuration
+
+The error output appears as a Kubernetes event that you can view using `kubectl describe`. The event message clearly states that the ingress was not synced because the referenced IngressClass does not match the configured selector criteria. This immediate feedback helps users understand why their Ingress resources are not working and guides them toward using approved IngressClass resources.
+
+### Orphaned resources and cleanup
+
+When vCluster removes a synced IngressClass from the virtual cluster due to selector changes or deletion from the host cluster, any Ingress resources that reference it remain in the virtual cluster. These orphaned Ingress resources stop receiving updates but vCluster does not automatically delete them to prevent unintended data loss. To remove these orphaned resources, you must delete them manually in the host cluster. This manual approach ensures that administrators maintain full control over resource cleanup and can verify that deletions are intentional.
+
+## Examples
+
+### Filter with matchLabels
+
+To sync only IngressClass resources labeled `environment: development`:
 
 ```yaml
 sync:
@@ -52,10 +104,46 @@ sync:
       enabled: true
       selector:
         matchLabels:
-          # Match all IngressClasses with the label environment with value development
+          environment: development
+```
+
+### Flexible filter with matchExpressions
+
+To sync IngressClass resources where the label `kubernetes.io/ingress.class` is either `nginx` or `traefik`:
+
+```yaml
+sync:
+  toHost:
+    ingresses:
+      enabled: true
+  fromHost:
+    ingressClasses:
+      enabled: true
+      selector:
+        matchExpressions:
+          - key: kubernetes.io/ingress.class
+            operator: In
+            values:
+              - nginx
+              - traefik
+```
+
+### Combined filter criteria
+
+The following configuration syncs IngressClass resources that match both label and expression criteria:
+
+```yaml
+sync:
+  toHost:
+    ingresses:
+      enabled: true
+  fromHost:
+    ingressClasses:
+      enabled: true
+      selector:
+        matchLabels:
           environment: "development"
         matchExpressions:
-          # Match IngressClasses with the label kubernetes.io/ingress.class that are either nginx or traefik
           - key: "kubernetes.io/ingress.class"
             operator: In
             values:
@@ -63,85 +151,9 @@ sync:
               - traefik
 ```
 
-The `selector` field follows the same syntax as Kubernetes label selectors. Use it to filter which `IngressClass` resources are synced from the host cluster based on their labels.
+### Error handling example
 
-:::note
-All specified label conditions must match for an `IngressClass` to be included in the sync.
-:::
-
-
-## Use selectors to filter IngressClasses
-
-Use `matchLabels` and `matchExpressions` to filter which `IngressClass` resources are synced based on their labels.
-
-- `matchLabels`: Defines exact label key-value pairs.
-
-  For example, to sync only `IngressClasses` labeled `environment: development`:
-
-  ```yaml
-  matchLabels:
-    environment: development
-  ```
-
-- `matchExpressions`: Allows more flexible, set-based filtering.
-
-  For example, to sync `IngressClasses` where the label `kubernetes.io/ingress.class` is either `nginx` or `traefik`:
-
-  ```yaml
-  matchExpressions:
-    - key: kubernetes.io/ingress.class
-      operator: In
-      values:
-        - nginx
-        - traefik
-  ```
-  Supported operators are `In`, `NotIn`, `Exists`, and `DoesNotExist`.
-
-For more details on how to use label selectors effectively, refer to the [Kubernetes documentation on label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements).
-
-## Sync behavior and considerations
-
-When `IngressClass` sync is enabled, the vCluster syncer uses selector criteria to control which `IngressClasses` are synchronized between the host and virtual clusters.
-
-The selector configuration creates a bidirectional filter:
-
-- **From host to virtual cluster**: Only `IngressClasses` matching the selector criteria are synchronized from the host cluster to the virtual cluster.
-
-- **From virtual cluster to host**: `Ingress` resources created in the virtual cluster are synchronized to the host only if they reference `IngressClasses` that match the selector criteria.
-
-### Resource availability and updates
-
-- Synced `IngressClass` resources appear in the virtual cluster and can be referenced by `Ingress` resources.
-- When an `IngressClass` in the host cluster is modified, the selector is re-evaluated:
-  - If it still matches, the resource is updated in the virtual cluster.
-  - If it no longer matches, it is removed from the virtual cluster.
-- If an `IngressClass` fails to meet the selector criteria, a warning is logged in the vCluster syncer pod’s output.
-
-### Orphaned Ingress resources
-
-- If a synced `IngressClass` is removed from the virtual cluster (due to selector mismatch or deletion), any `Ingress` resources referencing it remain in the virtual cluster.
-- These `Ingress` resources stop receiving updates but are not automatically deleted.
-- To remove them, you must delete them manually in the host cluster.
-
-## Constraint enforcement
-
-The selector acts as both a filter and a validation mechanism:
-
-- **Resource filtering**: Only `IngressClasses` that match the selector criteria are made available in the virtual cluster's API server.
-
-- **Creation validation**: `Ingress` resources in the virtual cluster can only reference `IngressClasses` that exist in the filtered set.
-
-- **Sync restriction**: `Ingress` resources referencing non-matching `IngressClasses` are blocked from synchronizing to the host cluster.
-
-## Error handling
-
-When an `Ingress` resource references an `IngressClass` that doesn't match the selector criteria:
-
-- The `Ingress` synchronization to the host cluster fails.
-- An event is recorded on the `Ingress` resource in the virtual cluster.
-- The event indicates that the specified `IngressClass` is not available in the host.
-
-The event output looks similar to the following:
+When an Ingress resource references an IngressClass that doesn't match the selector criteria, the error output looks like this:
 
 ```bash
 vcluster-virtual-cluster-1:~$ kubectl describe ingress my-ingress
@@ -153,6 +165,9 @@ Events:
   ----     ------            ----  ----                -------
   Warning  SyncWarning       10s   ingress-syncer      did not sync ingress "my-ingress" to host because it does not match the selector under 'sync.fromHost.ingressClasses.selector'
 ```
+
+For more details on how to use label selectors effectively, refer to the [Kubernetes documentation on label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements).
+
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/ingress-classes.mdx
@@ -13,15 +13,15 @@ import EnableSwitch from '../../../../_partials/config/sync/fromHost/ingressClas
 - original issue: https://github.com/loft-sh/vcluster/issues/663
 */}
 
-By default, IngressClass synchronization is disabled.
+By default, this is disabled.
 
 You can enable this feature to sync `IngressClass` resources from the host cluster to the virtual cluster.
 
 This is useful in scenarios where selective access to ingress configurations is required. Common use cases include:
 
-- **Development environments**: Sync only the IngressClasses required for development clusters to reduce noise and avoid unnecessary exposure.
-- **Multi-tenancy**: Enable teams to use their own IngressClasses while sharing a single host cluster.
-- **Security**: Restrict the IngressClasses available in the virtual cluster to enforce access control and prevent unintended configurations.
+- **Development environments**: Sync only the `IngressClasses` required for development clusters to reduce noise and avoid unnecessary exposure.
+- **Multi-tenancy**: Enable teams to use their own `IngressClasses` while sharing a single host cluster.
+- **Security**: Restrict the `IngressClasses` available in the virtual cluster to enforce access control and prevent unintended configurations.
 
 ## Enable syncing IngressClasses from the host to virtual cluster
 
@@ -35,14 +35,14 @@ sync:
 <!-- vale off -->
 
 :::note
-When `sync.fromHost.ingressClasses.enabled` is enabled, any `IngressClass` created in the virtual cluster will be immediately deleted.
+When `sync.fromHost.ingressClasses.enabled` is enabled, any `IngressClass` created in the virtual cluster is immediately deleted.
 :::
 
 ### Example
 
 The following configuration syncs all `IngressClasses` that match the specified labels and expressions from the host cluster to the virtual cluster:
 
-```YAML
+```yaml
 sync:
   toHost:
     ingresses:
@@ -52,10 +52,10 @@ sync:
       enabled: true
       selector:
         matchLabels:
-          # Match all IngressClasses with the label `environment` with value `development`
+          # Match all IngressClasses with the label environment with value development
           environment: "development"
         matchExpressions:
-          # Match IngressClasses with the label `kubernetes.io/ingress.class` that are either `nginx` or `traefik`
+          # Match IngressClasses with the label kubernetes.io/ingress.class that are either nginx or traefik
           - key: "kubernetes.io/ingress.class"
             operator: In
             values:
@@ -101,7 +101,7 @@ For more details on how to use label selectors effectively, refer to the [Kubern
 
 ## Sync behavior and considerations
 
-When `IngressClass` synchronization is enabled, the vCluster syncer uses selector criteria to control which `IngressClasses` are synchronized between the host and virtual clusters.
+When `IngressClass` sync is enabled, the vCluster syncer uses selector criteria to control which `IngressClasses` are synchronized between the host and virtual clusters.
 
 The selector configuration creates a bidirectional filter:
 
@@ -143,7 +143,7 @@ When an `Ingress` resource references an `IngressClass` that doesn't match the s
 
 The event output looks similar to the following:
 
-```shell
+```bash
 vcluster-virtual-cluster-1:~$ kubectl describe ingress my-ingress
 Name:             my-ingress
 Namespace:        default

--- a/vcluster/configure/vcluster-yaml/sync/from-host/priority-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/priority-classes.mdx
@@ -102,7 +102,7 @@ When vCluster removes a synced PriorityClass from the virtual cluster due to sel
 
 To sync only PriorityClass resources labeled `environment: development`:
 
-```yaml
+```yaml title="Filter example priorityClass"
 sync:
   fromHost:
     priorityClasses:
@@ -116,7 +116,7 @@ sync:
 
 To sync PriorityClass resources where the label `kubernetes.io/priority.class` is either `low` or `medium`:
 
-```yaml
+```yaml title="Flexible filter example priorityClass"
 sync:
   fromHost:
     priorityClasses:
@@ -134,7 +134,7 @@ sync:
 
 The following configuration syncs PriorityClass resources that match both label and expression criteria:
 
-```yaml
+```yaml title="Combined filter example priorityClass"
 sync:
   fromHost:
     priorityClasses:
@@ -154,7 +154,7 @@ sync:
 
 When a Pod resource references a PriorityClass that doesn't match the selector criteria, the error output looks like this:
 
-```bash
+```bash title="Error handling example priorityClass"
 vcluster-virtual-cluster-1:~$ kubectl describe pod my-pod
 Name:             my-pod
 Namespace:        default

--- a/vcluster/configure/vcluster-yaml/sync/from-host/priority-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/priority-classes.mdx
@@ -33,6 +33,11 @@ sync:
 ```
 
 <!-- vale off -->
+
+:::note
+When `sync.fromHost.priorityClasses.enabled` is enabled, any `PriorityClass` created in the virtual cluster will be immediately deleted.
+:::
+
 ### Example
 
 The following configuration syncs all `PriorityClasses` that match the specified labels and expressions from the host cluster to the virtual cluster:

--- a/vcluster/configure/vcluster-yaml/sync/from-host/priority-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/priority-classes.mdx
@@ -7,7 +7,9 @@ description: Configure priority classes in vCluster
 
 import EnableSwitch from '../../../../_partials/config/sync/fromHost/priorityClasses.mdx'
 
-# PriorityClass Syncing
+<!-- vale off -->
+
+# PriorityClass syncing
 
 By default, this is disabled.
 
@@ -17,7 +19,7 @@ By default, each virtual cluster needs its own copy of every PriorityClass. This
 
 PriorityClass syncing eliminates this duplication by making host cluster PriorityClass resources available to virtual clusters. You define priority classes once in the host cluster, and vCluster automatically makes them accessible to virtual clusters based on your configuration.
 
-You can Configure syncing using label selectors on your host cluster PriorityClass resources. Add labels to the PriorityClass resources you want to share, then configure vCluster to sync only those whose labels match your selector criteria. Virtual clusters can then reference these synced priority classes in their pod specifications without creating local copies.
+You can configure syncing using label selectors on your host cluster PriorityClass resources. Add labels to the PriorityClass resources you want to share, then configure vCluster to sync only those whose labels match your selector criteria. Virtual clusters can then reference these synced priority classes in their pod specifications without creating local copies.
 
 When a virtual cluster pod references a `priorityClassName`, vCluster validates that the corresponding PriorityClass exists in the virtual cluster through the syncing process. If the referenced PriorityClass is not synced (either because it does not exist in the host cluster or does not match your label selector), the pod is not scheduled on the host cluster.
 
@@ -35,7 +37,7 @@ sync:
 :::note
 When `sync.fromHost.priorityClasses.enabled` is set to `true`, vCluster takes control of all PriorityClass resources in the virtual cluster. It only allows PriorityClass resources that are synced from the host cluster to exist.
 
-If you try to create a PriorityClass directly in the virtual cluster, using for example `kubectl create` or `kubectl apply`, vCluster detects it and deletes it immediately. This prevents conflicts between locally-created PriorityClasses and those synced from the host cluster, ensuring that only approved PriorityClass resources (those made available through the host cluster) exist in the virtual cluster.
+If you try to create a PriorityClass directly in the virtual cluster, using for example `kubectl create` or `kubectl apply`, vCluster detects it and deletes it immediately. This prevents conflicts between locally created PriorityClasses and those synced from the host cluster, ensuring that only approved PriorityClass resources (those made available through the host cluster) exist in the virtual cluster.
 :::
 
 ## How PriorityClass syncing works
@@ -74,7 +76,9 @@ All specified label conditions must match for a PriorityClass to be included in 
 
 Synced PriorityClass resources function like any other Kubernetes resource in the virtual cluster. You can view them with `kubectl get priorityclass` and reference them in their Pod specifications. When you modify a PriorityClass in the host cluster, vCluster re-evaluates whether it still matches the selector criteria. If the PriorityClass continues to match, vCluster updates the corresponding resource in the virtual cluster to reflect the changes. If the PriorityClass no longer matches the selector criteria, vCluster removes it from the virtual cluster.
 
-The selector system acts as both a resource filter and a validation mechanism. As a resource filter, it ensures that vCluster makes only PriorityClass resources matching the selector criteria available in the virtual cluster's API server. The selector also functions as a creation validation mechanism - when you create Pod resources in the virtual cluster, those resources can only reference PriorityClass resources that exist in the filtered set.
+The selector acts as both a resource filter and a validation mechanism. As a resource filter, it ensures that vCluster makes only PriorityClass resources matching the selector criteria available in the virtual cluster's API server. The selector also functions as a creation validation mechanism - when you create Pod resources in the virtual cluster, the resources can only reference PriorityClass resources that exist in the filtered set.
+
+For more details on how to use label selectors effectively, refer to the [Kubernetes documentation on label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements).
 
 ### Error handling and troubleshooting
 
@@ -160,8 +164,6 @@ Events:
   ----     ------            ----  ----                -------
   Warning  SyncWarning       10s   pod-syncer          did not sync pod "my-pod" to host because it does not match the selector under 'sync.fromHost.priorityClasses.selector'
 ```
-
-For more details on how to use label selectors effectively, refer to the [Kubernetes documentation on label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements).
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/priority-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/priority-classes.mdx
@@ -1,0 +1,151 @@
+---
+title: Priority Classes
+sidebar_label: priorityClasses
+sidebar_position: 3
+description: Configuration for Priority Classes in vCluster
+---
+
+import EnableSwitch from '../../../../_partials/config/sync/fromHost/priorityClasses.mdx'
+
+{/*
+`priorityClasses.enabled`:
+- covered by the generic section here: https://www.vcluster.com/docs/syncer/config#enable-or-disable-synced-resources
+*/}
+
+By default, PriorityClass synchronization is disabled.
+
+You can enable this feature to sync `PriorityClass` resources from the host cluster to the virtual cluster.
+
+This is useful in scenarios where selective access to Pod configurations is required. Common use cases include:
+
+- **Development environments**: Sync only the PriorityClasses required for development clusters to reduce noise and avoid unnecessary exposure.
+- **Multi-tenancy**: Enable teams to use their own PriorityClasses while sharing a single host cluster.
+- **Security**: Restrict the PriorityClasses available in the virtual cluster to enforce access control and prevent unintended configurations.
+
+### Enable Syncing priority classes from the host to virtual cluster
+
+
+```YAML
+sync:
+  fromHost:
+    priorityClasses:
+      enabled: true
+```
+
+<!-- vale off -->
+### Example
+
+The following configuration syncs all `PriorityClasses` that match the specified labels and expressions from the host cluster to the virtual cluster:
+
+```YAML
+sync:
+  fromHost:
+    priorityClasses:
+      enabled: true
+      selector:
+        matchLabels:
+          # Match all PriorityClasses with the label `environment` with value `development`
+          environment: "development"
+        matchExpressions:
+          # Match PriorityClasses with the label `kubernetes.io/priority.class` that are either `low` or `medium`
+          - key: "kubernetes.io/priority.class"
+            operator: In
+            values:
+              - low
+              - medium
+```
+
+The `selector` field follows the same syntax as Kubernetes label selectors. Use it to filter which `PriorityClass` resources are synced from the host cluster based on their labels.
+
+:::note
+All specified label conditions must match for an `PriorityClass` to be included in the sync.
+:::
+
+
+## Use selectors to filter PriorityClasses
+
+Use `matchLabels` and `matchExpressions` to filter which `PriorityClass` resources are synced based on their labels.
+
+- `matchLabels`: Defines exact label key-value pairs.
+
+For example, to sync only `PriorityClasses` labeled `environment: development`:
+
+```yaml
+matchLabels:
+  environment: development
+  ```
+
+- `matchExpressions`: Allows more flexible, set-based filtering.
+
+For example, to sync `PriorityClasses` where the label `kubernetes.io/priority.class` is either `low` or `medium`:
+
+```yaml
+matchExpressions:
+  - key: kubernetes.io/priority.class
+    operator: In
+    values:
+      - low
+      - medium
+  ```
+Supported operators are `In`, `NotIn`, `Exists`, and `DoesNotExist`.
+
+For more details on how to use label selectors effectively, refer to the [Kubernetes documentation on label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements).
+
+## Sync behavior and considerations
+
+When `PriorityClass` synchronization is enabled, the vCluster syncer uses selector criteria to control which `PriorityClasses` are synchronized between the host and virtual clusters.
+
+The selector configuration creates a bidirectional filter:
+
+- **From host to virtual cluster**: Only `PriorityClasses` matching the selector criteria are synchronized from the host cluster to the virtual cluster.
+
+- **From virtual cluster to host**: `Pod` resources created in the virtual cluster are synchronized to the host only if they reference `PriorityClasses` that match the selector criteria.
+
+### Resource availability and updates
+
+- Synced `PriorityClass` resources appear in the virtual cluster and can be referenced by `Pod` resources.
+- When an `PriorityClass` in the host cluster is modified, the selector is re-evaluated:
+- If it still matches, the resource is updated in the virtual cluster.
+- If it no longer matches, it is removed from the virtual cluster.
+- If an `PriorityClass` fails to meet the selector criteria, a warning is logged in the vCluster syncer pod’s output.
+
+### Orphaned Pod resources
+
+- If a synced `PriorityClass` is removed from the virtual cluster (due to selector mismatch or deletion), any `Pod` resources referencing it remain in the virtual cluster.
+- These `Pod` resources stop receiving updates but are not automatically deleted.
+- To remove them, you must delete them manually in the host cluster.
+
+## Constraint enforcement
+
+The selector acts as both a filter and a validation mechanism:
+
+- **Resource filtering**: Only `PriorityClasses` that match the selector criteria are made available in the virtual cluster's API server.
+
+- **Creation validation**: `Pod` resources in the virtual cluster can only reference `PriorityClasses` that exist in the filtered set.
+
+- **Sync restriction**: `Pod` resources referencing non-matching `PriorityClasses` are blocked from synchronizing to the host cluster.
+
+## Error handling
+
+When a `Pod` resource references a `PriorityClass` that doesn't match the selector criteria:
+
+- The `Pod` synchronization to the host cluster fails.
+- An event is recorded on the `Pod` resource in the virtual cluster.
+- The event indicates that the specified `PriorityClass` is not available in the host.
+
+The event output looks similar to the following:
+
+```shell
+vcluster-virtual-cluster-1:~$ kubectl describe pod my-pod
+Name:             my-pod
+Namespace:        default
+Priority Class:   high
+Events:
+  Type     Reason            Age   From                Message
+  ----     ------            ----  ----                -------
+  Warning  SyncWarning       10s   pod-syncer          did not sync pod "my-pod" to host because it does not match the selector under 'sync.fromHost.priorityClasses.selector'
+```
+
+## Config reference
+
+<EnableSwitch/>

--- a/vcluster/configure/vcluster-yaml/sync/from-host/priority-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/priority-classes.mdx
@@ -1,58 +1,144 @@
 ---
-title: Priority Classes
+title: Priority classes
 sidebar_label: priorityClasses
 sidebar_position: 3
-description: Configuration for Priority Classes in vCluster
+description: Configure priority classes in vCluster
 ---
 
 import EnableSwitch from '../../../../_partials/config/sync/fromHost/priorityClasses.mdx'
 
-{/*
-`priorityClasses.enabled`:
-- covered by the generic section here: https://www.vcluster.com/docs/syncer/config#enable-or-disable-synced-resources
-*/}
+# PriorityClass Syncing
 
-By default, PriorityClass synchronization is disabled.
+By default, this is disabled.
 
-You can enable this feature to sync `PriorityClass` resources from the host cluster to the virtual cluster.
+PriorityClass resources set which pods get scheduled first when resources are limited. High-priority pods can kick out low-priority pods to get resources.
 
-This is useful in scenarios where selective access to Pod configurations is required. Common use cases include:
+By default, each virtual cluster needs its own copy of every PriorityClass. This means creating the same PriorityClass multiple times-once per virtual cluster. You must update each copy separately when changes are needed.
 
-- **Development environments**: Sync only the PriorityClasses required for development clusters to reduce noise and avoid unnecessary exposure.
-- **Multi-tenancy**: Enable teams to use their own PriorityClasses while sharing a single host cluster.
-- **Security**: Restrict the PriorityClasses available in the virtual cluster to enforce access control and prevent unintended configurations.
+PriorityClass syncing eliminates this duplication by making host cluster PriorityClass resources available to virtual clusters. You define priority classes once in the host cluster, and vCluster automatically makes them accessible to virtual clusters based on your configuration.
 
-### Enable Syncing priority classes from the host to virtual cluster
+You can Configure syncing using label selectors on your host cluster PriorityClass resources. Add labels to the PriorityClass resources you want to share, then configure vCluster to sync only those whose labels match your selector criteria. Virtual clusters can then reference these synced priority classes in their pod specifications without creating local copies.
 
+When a virtual cluster pod references a `priorityClassName`, vCluster validates that the corresponding PriorityClass exists in the virtual cluster through the syncing process. If the referenced PriorityClass is not synced (either because it does not exist in the host cluster or does not match your label selector), the pod is not scheduled on the host cluster.
 
-```YAML
+## Enable PriorityClass syncing
+
+To enable PriorityClass syncing from the host cluster without filtering:
+
+```yaml
 sync:
   fromHost:
     priorityClasses:
       enabled: true
 ```
 
-<!-- vale off -->
-
 :::note
-When `sync.fromHost.priorityClasses.enabled` is enabled, any `PriorityClass` created in the virtual cluster will be immediately deleted.
+When `sync.fromHost.priorityClasses.enabled` is set to `true`, vCluster takes control of all PriorityClass resources in the virtual cluster. It only allows PriorityClass resources that are synced from the host cluster to exist.
+
+If you try to create a PriorityClass directly in the virtual cluster, using for example `kubectl create` or `kubectl apply`, vCluster detects it and deletes it immediately. This prevents conflicts between locally-created PriorityClasses and those synced from the host cluster, ensuring that only approved PriorityClass resources (those made available through the host cluster) exist in the virtual cluster.
 :::
 
-### Example
+## How PriorityClass syncing works
 
-The following configuration syncs all `PriorityClasses` that match the specified labels and expressions from the host cluster to the virtual cluster:
+When PriorityClass syncing is enabled, vCluster uses a label selector to control which PriorityClass and Pod resources are synchronized between the host and virtual clusters. This affects two resource types with separate unidirectional sync flows:
 
-```YAML
+- **PriorityClass resources** (host → virtual): vCluster copies PriorityClass resources from the host cluster to the virtual cluster if they match the selector. You cannot create PriorityClass resources directly in the virtual cluster. If no selector is defined, all PriorityClass resources from the host cluster are synced and made available for reference in Pods.
+
+- **Pod resources** (virtual → host): vCluster syncs Pod resources from the virtual cluster to the host cluster only if one of the following is true:
+   - The Pod's `priorityClassName` matches a PriorityClass allowed by the selector.
+   - The Pod has an empty `priorityClassName` field.
+   - No selector is defined, which disables PriorityClass filtering entirely and allows all Pods to sync regardless of their priorityClassName.
+
+The same selector controls both sync flows. The selector determines which PriorityClass resources are imported from the host cluster and which Pod resources can sync to the host cluster based on their priorityClassName field.
+
+If a Pod references a PriorityClass that is not synced into the virtual cluster, the Pod cannot sync to the host cluster. This ensures Pods only use explicitly allowed priority classes. 
+
+## Use selectors to filter PriorityClasses
+
+Selectors provide precise control over which PriorityClass resources get synced from the host cluster. vCluster supports two types of selector criteria that follow standard Kubernetes label selector syntax.
+
+The `matchLabels` selector defines exact label key-value pairs that must be present on a PriorityClass for it to be synced. This provides straightforward filtering based on specific label values. For example, setting `matchLabels` to `environment: development` syncs only PriorityClass resources that have exactly that label and value.
+
+The `matchExpressions` selector allows more flexible, set-based filtering with support for multiple operators:
+
+- `In`: Matches PriorityClass resources where the label value exists within a specified list
+- `NotIn`: Excludes resources with certain label values  
+- `Exists`: Requires the presence of a label key regardless of its value
+- `DoesNotExist`: Excludes resources that have a particular label key
+
+All specified label conditions must match for a PriorityClass to be included in the sync. This means that if you define both `matchLabels` and `matchExpressions`, a PriorityClass must satisfy all criteria to be synced to the virtual cluster.
+
+## Sync behavior and considerations
+
+### Resource lifecycle and validation
+
+Synced PriorityClass resources function like any other Kubernetes resource in the virtual cluster. You can view them with `kubectl get priorityclass` and reference them in their Pod specifications. When you modify a PriorityClass in the host cluster, vCluster re-evaluates whether it still matches the selector criteria. If the PriorityClass continues to match, vCluster updates the corresponding resource in the virtual cluster to reflect the changes. If the PriorityClass no longer matches the selector criteria, vCluster removes it from the virtual cluster.
+
+The selector system acts as both a resource filter and a validation mechanism. As a resource filter, it ensures that vCluster makes only PriorityClass resources matching the selector criteria available in the virtual cluster's API server. The selector also functions as a creation validation mechanism - when you create Pod resources in the virtual cluster, those resources can only reference PriorityClass resources that exist in the filtered set.
+
+### Error handling and troubleshooting
+
+When a PriorityClass fails to meet the selector criteria during evaluation, vCluster logs a warning in the syncer pod's output to help with troubleshooting and monitoring. This logging provides visibility into which resources are being filtered out and why.
+
+If you create a Pod resource that references a PriorityClass not matching the selector criteria, several things occur to provide feedback:
+
+- The Pod sync to the host cluster fails.
+- vCluster records an event on the Pod resource in the virtual cluster.
+- The event indicates that the specified PriorityClass is not available according to the current selector configuration.
+
+The error output appears as a Kubernetes event that you can view using `kubectl describe`. The event message states that the pod was not synced because the referenced PriorityClass does not match the configured selector criteria. This immediate feedback can help you understand why Pod resources are not working.
+
+### Orphaned resources and cleanup
+
+When vCluster removes a synced PriorityClass from the virtual cluster due to selector changes or deletion from the host cluster, any Pod resources that reference it remain in the virtual cluster. These orphaned Pod resources stop receiving updates but vCluster does not automatically delete them to prevent unintended data loss. To remove these orphaned resources, you must delete them manually in the host cluster. This manual approach ensures that you maintain full control over resource cleanup and can verify that deletions are intentional.
+
+## Examples
+
+### Filter with matchLabels
+
+To sync only PriorityClass resources labeled `environment: development`:
+
+```yaml
 sync:
   fromHost:
     priorityClasses:
       enabled: true
       selector:
         matchLabels:
-          # Match all PriorityClasses with the label `environment` with value `development`
+          environment: development
+```
+
+### Flexible filter with matchExpressions
+
+To sync PriorityClass resources where the label `kubernetes.io/priority.class` is either `low` or `medium`:
+
+```yaml
+sync:
+  fromHost:
+    priorityClasses:
+      enabled: true
+      selector:
+        matchExpressions:
+          - key: kubernetes.io/priority.class
+            operator: In
+            values:
+              - low
+              - medium
+```
+
+### Combined filter criteria
+
+The following configuration syncs PriorityClass resources that match both label and expression criteria:
+
+```yaml
+sync:
+  fromHost:
+    priorityClasses:
+      enabled: true
+      selector:
+        matchLabels:
           environment: "development"
         matchExpressions:
-          # Match PriorityClasses with the label `kubernetes.io/priority.class` that are either `low` or `medium`
           - key: "kubernetes.io/priority.class"
             operator: In
             values:
@@ -60,87 +146,11 @@ sync:
               - medium
 ```
 
-The `selector` field follows the same syntax as Kubernetes label selectors. Use it to filter which `PriorityClass` resources are synced from the host cluster based on their labels.
+### Error handling
 
-:::note
-All specified label conditions must match for an `PriorityClass` to be included in the sync.
-:::
+When a Pod resource references a PriorityClass that doesn't match the selector criteria, the error output looks like this:
 
-
-## Use selectors to filter PriorityClasses
-
-Use `matchLabels` and `matchExpressions` to filter which `PriorityClass` resources are synced based on their labels.
-
-- `matchLabels`: Defines exact label key-value pairs.
-
-For example, to sync only `PriorityClasses` labeled `environment: development`:
-
-```yaml
-matchLabels:
-  environment: development
-  ```
-
-- `matchExpressions`: Allows more flexible, set-based filtering.
-
-For example, to sync `PriorityClasses` where the label `kubernetes.io/priority.class` is either `low` or `medium`:
-
-```yaml
-matchExpressions:
-  - key: kubernetes.io/priority.class
-    operator: In
-    values:
-      - low
-      - medium
-  ```
-Supported operators are `In`, `NotIn`, `Exists`, and `DoesNotExist`.
-
-For more details on how to use label selectors effectively, refer to the [Kubernetes documentation on label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements).
-
-## Sync behavior and considerations
-
-When `PriorityClass` synchronization is enabled, the vCluster syncer uses selector criteria to control which `PriorityClasses` are synchronized between the host and virtual clusters.
-
-The selector configuration creates a bidirectional filter:
-
-- **From host to virtual cluster**: Only `PriorityClasses` matching the selector criteria are synchronized from the host cluster to the virtual cluster.
-
-- **From virtual cluster to host**: `Pod` resources created in the virtual cluster are synchronized to the host only if they reference `PriorityClasses` that match the selector criteria.
-
-### Resource availability and updates
-
-- Synced `PriorityClass` resources appear in the virtual cluster and can be referenced by `Pod` resources.
-- When an `PriorityClass` in the host cluster is modified, the selector is re-evaluated:
-- If it still matches, the resource is updated in the virtual cluster.
-- If it no longer matches, it is removed from the virtual cluster.
-- If an `PriorityClass` fails to meet the selector criteria, a warning is logged in the vCluster syncer pod’s output.
-
-### Orphaned Pod resources
-
-- If a synced `PriorityClass` is removed from the virtual cluster (due to selector mismatch or deletion), any `Pod` resources referencing it remain in the virtual cluster.
-- These `Pod` resources stop receiving updates but are not automatically deleted.
-- To remove them, you must delete them manually in the host cluster.
-
-## Constraint enforcement
-
-The selector acts as both a filter and a validation mechanism:
-
-- **Resource filtering**: Only `PriorityClasses` that match the selector criteria are made available in the virtual cluster's API server.
-
-- **Creation validation**: `Pod` resources in the virtual cluster can only reference `PriorityClasses` that exist in the filtered set.
-
-- **Sync restriction**: `Pod` resources referencing non-matching `PriorityClasses` are blocked from synchronizing to the host cluster.
-
-## Error handling
-
-When a `Pod` resource references a `PriorityClass` that doesn't match the selector criteria:
-
-- The `Pod` synchronization to the host cluster fails.
-- An event is recorded on the `Pod` resource in the virtual cluster.
-- The event indicates that the specified `PriorityClass` is not available in the host.
-
-The event output looks similar to the following:
-
-```shell
+```bash
 vcluster-virtual-cluster-1:~$ kubectl describe pod my-pod
 Name:             my-pod
 Namespace:        default
@@ -150,6 +160,8 @@ Events:
   ----     ------            ----  ----                -------
   Warning  SyncWarning       10s   pod-syncer          did not sync pod "my-pod" to host because it does not match the selector under 'sync.fromHost.priorityClasses.selector'
 ```
+
+For more details on how to use label selectors effectively, refer to the [Kubernetes documentation on label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements).
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/priority-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/priority-classes.mdx
@@ -44,9 +44,9 @@ If you try to create a PriorityClass directly in the virtual cluster, using for 
 
 When PriorityClass syncing is enabled, vCluster uses a label selector to control which PriorityClass and Pod resources are synchronized between the host and virtual clusters. This affects two resource types with separate unidirectional sync flows:
 
-- **PriorityClass resources** (host → virtual): vCluster copies PriorityClass resources from the host cluster to the virtual cluster if they match the selector. You cannot create PriorityClass resources directly in the virtual cluster. If no selector is defined, all PriorityClass resources from the host cluster are synced and made available for reference in Pods.
+- **PriorityClass resources (host → virtual)**: vCluster copies PriorityClass resources from the host cluster to the virtual cluster if they match the selector. You cannot create PriorityClass resources directly in the virtual cluster. If no selector is defined, all PriorityClass resources from the host cluster are synced and made available for reference in Pods.
 
-- **Pod resources** (virtual → host): vCluster syncs Pod resources from the virtual cluster to the host cluster only if one of the following is true:
+- **Pod resources (virtual → host)**: vCluster syncs Pod resources from the virtual cluster to the host cluster only if one of the following is true:
    - The Pod's `priorityClassName` matches a PriorityClass allowed by the selector.
    - The Pod has an empty `priorityClassName` field.
    - No selector is defined, which disables PriorityClass filtering entirely and allows all Pods to sync regardless of their priorityClassName.
@@ -70,9 +70,9 @@ The `matchExpressions` selector allows more flexible, set-based filtering with s
 
 All specified label conditions must match for a PriorityClass to be included in the sync. This means that if you define both `matchLabels` and `matchExpressions`, a PriorityClass must satisfy all criteria to be synced to the virtual cluster.
 
-## Sync behavior and considerations
+## Sync behavior considerations
 
-### Resource lifecycle and validation
+### Resource lifecycle
 
 Synced PriorityClass resources function like any other Kubernetes resource in the virtual cluster. You can view them with `kubectl get priorityclass` and reference them in their Pod specifications. When you modify a PriorityClass in the host cluster, vCluster re-evaluates whether it still matches the selector criteria. If the PriorityClass continues to match, vCluster updates the corresponding resource in the virtual cluster to reflect the changes. If the PriorityClass no longer matches the selector criteria, vCluster removes it from the virtual cluster.
 
@@ -92,7 +92,7 @@ If you create a Pod resource that references a PriorityClass not matching the se
 
 The error output appears as a Kubernetes event that you can view using `kubectl describe`. The event message states that the pod was not synced because the referenced PriorityClass does not match the configured selector criteria. This immediate feedback can help you understand why Pod resources are not working.
 
-### Orphaned resources and cleanup
+### Remove orphaned resources
 
 When vCluster removes a synced PriorityClass from the virtual cluster due to selector changes or deletion from the host cluster, any Pod resources that reference it remain in the virtual cluster. These orphaned Pod resources stop receiving updates but vCluster does not automatically delete them to prevent unintended data loss. To remove these orphaned resources, you must delete them manually in the host cluster. This manual approach ensures that you maintain full control over resource cleanup and can verify that deletions are intentional.
 
@@ -102,7 +102,7 @@ When vCluster removes a synced PriorityClass from the virtual cluster due to sel
 
 To sync only PriorityClass resources labeled `environment: development`:
 
-```yaml title="Filter example priorityClass"
+```yaml title="Filter example PriorityClass"
 sync:
   fromHost:
     priorityClasses:
@@ -116,7 +116,7 @@ sync:
 
 To sync PriorityClass resources where the label `kubernetes.io/priority.class` is either `low` or `medium`:
 
-```yaml title="Flexible filter example priorityClass"
+```yaml title="Flexible filter example PriorityClass"
 sync:
   fromHost:
     priorityClasses:
@@ -134,7 +134,7 @@ sync:
 
 The following configuration syncs PriorityClass resources that match both label and expression criteria:
 
-```yaml title="Combined filter example priorityClass"
+```yaml title="Combined filter example PriorityClass"
 sync:
   fromHost:
     priorityClasses:
@@ -154,7 +154,7 @@ sync:
 
 When a Pod resource references a PriorityClass that doesn't match the selector criteria, the error output looks like this:
 
-```bash title="Error handling example priorityClass"
+```bash title="Error handling example PriorityClass"
 vcluster-virtual-cluster-1:~$ kubectl describe pod my-pod
 Name:             my-pod
 Namespace:        default

--- a/vcluster/configure/vcluster-yaml/sync/from-host/runtime-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/runtime-classes.mdx
@@ -99,7 +99,7 @@ When vCluster removes a synced RuntimeClass from the virtual cluster due to sele
 
 To sync only RuntimeClass resources labeled `environment: development`:
 
-```yaml
+```yaml title="Filter example runtimeClass"
 sync:
   toHost:
     pods:
@@ -116,7 +116,7 @@ sync:
 
 To sync RuntimeClass resources where the label `kubernetes.io/runtime.class` is either `gvisor` or `youki`:
 
-```yaml
+```yaml title="Flexible filter example runtimeClass"
 sync:
   toHost:
     pods:
@@ -137,7 +137,7 @@ sync:
 
 The following configuration syncs RuntimeClass resources that match both label and expression criteria:
 
-```yaml
+```yaml title="Combined filter example runtimeClass"
 sync:
   toHost:
     pods:
@@ -160,7 +160,7 @@ sync:
 
 When a Pod resource references a RuntimeClass that doesn't match the selector criteria, the error output looks like this:
 
-```bash
+```bash title="Error handling example runtimeClass"
 vcluster-virtual-cluster-1:~$ kubectl describe pod my-pod
 Name:             my-pod
 Namespace:        default

--- a/vcluster/configure/vcluster-yaml/sync/from-host/runtime-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/runtime-classes.mdx
@@ -22,7 +22,7 @@ This is useful in scenarios where selective access to Pod configurations is requ
 - **Multi-tenancy**: Enable teams to use their own RuntimeClasses while sharing a single host cluster.
 - **Security**: Restrict the RuntimeClasses available in the virtual cluster to enforce access control and prevent unintended configurations.
 
-### Enable Syncing RuntimeClasses from the Host to Virtual Cluster
+### Enable Syncing runtime classes from the host to virtual cluster
 
 
 ```YAML

--- a/vcluster/configure/vcluster-yaml/sync/from-host/runtime-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/runtime-classes.mdx
@@ -2,14 +2,25 @@
 title: Runtime Classes
 sidebar_label: runtimeClasses
 sidebar_position: 3
-description: Configuration for ...
+description: Configuration for Runtime Classes in vCluster
 ---
 
 import EnableSwitch from '../../../../_partials/config/sync/fromHost/runtimeClasses.mdx'
 
-By default, this is disabled.
+{/*
+`runtimeClasses.enabled`:
+- covered by the generic section here: https://www.vcluster.com/docs/syncer/config#enable-or-disable-synced-resources
+*/}
 
-Sync RuntimeClass resources from the host cluster to the virtual cluster.
+By default, RuntimeClass synchronization is disabled.
+
+You can enable this feature to sync `RuntimeClass` resources from the host cluster to the virtual cluster.
+
+This is useful in scenarios where selective access to Pod configurations is required. Common use cases include:
+
+- **Development environments**: Sync only the RuntimeClasses required for development clusters to reduce noise and avoid unnecessary exposure.
+- **Multi-tenancy**: Enable teams to use their own RuntimeClasses while sharing a single host cluster.
+- **Security**: Restrict the RuntimeClasses available in the virtual cluster to enforce access control and prevent unintended configurations.
 
 ### Enable Syncing RuntimeClasses from the Host to Virtual Cluster
 
@@ -19,6 +30,120 @@ sync:
   fromHost:
     runtimeClasses:
       enabled: true
+```
+
+<!-- vale off -->
+### Example
+
+The following configuration syncs all `RuntimeClasses` that match the specified labels and expressions from the host cluster to the virtual cluster:
+
+```YAML
+sync:
+  fromHost:
+    runtimeClasses:
+      enabled: true
+      selector:
+        matchLabels:
+          # Match all RuntimeClasses with the label `environment` with value `development`
+          environment: "development"
+        matchExpressions:
+          # Match RuntimeClasses with the label `kubernetes.io/runtime.class` that are either `gvisor` or `youki`
+          - key: "kubernetes.io/runtime.class"
+            operator: In
+            values:
+              - gvisor
+              - youki
+```
+
+The `selector` field follows the same syntax as Kubernetes label selectors. Use it to filter which `RuntimeClass` resources are synced from the host cluster based on their labels.
+
+:::note
+All specified label conditions must match for an `RuntimeClass` to be included in the sync.
+:::
+
+
+## Use selectors to filter RuntimeClasses
+
+Use `matchLabels` and `matchExpressions` to filter which `RuntimeClass` resources are synced based on their labels.
+
+- `matchLabels`: Defines exact label key-value pairs.
+
+For example, to sync only `RuntimeClasses` labeled `environment: development`:
+
+```yaml
+matchLabels:
+  environment: development
+  ```
+
+- `matchExpressions`: Allows more flexible, set-based filtering.
+
+For example, to sync `RuntimeClasses` where the label `kubernetes.io/runtime.class` is either `gvisor` or `youki`:
+
+```yaml
+matchExpressions:
+  - key: kubernetes.io/runtime.class
+    operator: In
+    values:
+      - gvisor
+      - youki
+  ```
+Supported operators are `In`, `NotIn`, `Exists`, and `DoesNotExist`.
+
+For more details on how to use label selectors effectively, refer to the [Kubernetes documentation on label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements).
+
+## Sync behavior and considerations
+
+When `RuntimeClass` synchronization is enabled, the vCluster syncer uses selector criteria to control which `RuntimeClasses` are synchronized between the host and virtual clusters.
+
+The selector configuration creates a bidirectional filter:
+
+- **From host to virtual cluster**: Only `RuntimeClasses` matching the selector criteria are synchronized from the host cluster to the virtual cluster.
+
+- **From virtual cluster to host**: `Pod` resources created in the virtual cluster are synchronized to the host only if they reference `RuntimeClasses` that match the selector criteria.
+
+### Resource availability and updates
+
+- Synced `RuntimeClass` resources appear in the virtual cluster and can be referenced by `Pod` resources.
+- When an `RuntimeClass` in the host cluster is modified, the selector is re-evaluated:
+- If it still matches, the resource is updated in the virtual cluster.
+- If it no longer matches, it is removed from the virtual cluster.
+- If an `RuntimeClass` fails to meet the selector criteria, a warning is logged in the vCluster syncer pod’s output.
+
+### Orphaned Pod resources
+
+- If a synced `RuntimeClass` is removed from the virtual cluster (due to selector mismatch or deletion), any `Pod` resources referencing it remain in the virtual cluster.
+- These `Pod` resources stop receiving updates but are not automatically deleted.
+- To remove them, you must delete them manually in the host cluster.
+
+## Constraint enforcement
+
+The selector acts as both a filter and a validation mechanism:
+
+- **Resource filtering**: Only `RuntimeClasses` that match the selector criteria are made available in the virtual cluster's API server.
+
+- **Creation validation**: `Pod` resources in the virtual cluster can only reference `RuntimeClasses` that exist in the filtered set.
+
+- **Sync restriction**: `Pod` resources referencing non-matching `RuntimeClasses` are blocked from synchronizing to the host cluster.
+
+## Error handling
+
+When a `Pod` resource references a `RuntimeClass` that doesn't match the selector criteria:
+
+- The `Pod` synchronization to the host cluster fails.
+- An event is recorded on the `Pod` resource in the virtual cluster.
+- The event indicates that the specified `RuntimeClass` is not available in the host.
+
+The event output looks similar to the following:
+
+```shell
+vcluster-virtual-cluster-1:~$ kubectl describe pod my-pod
+Name:             my-pod
+Namespace:        default
+Runtime Class:    gvisor
+Events:
+  Type     Reason            Age   From                Message
+  ----     ------            ----  ----                -------
+  Warning  SyncWarning       10s   pod-syncer          did not sync pod "my-pod" to host because it does not match the selector under 'sync.fromHost.runtimeClasses.selector'
 ```
 
 ## Config reference

--- a/vcluster/configure/vcluster-yaml/sync/from-host/runtime-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/runtime-classes.mdx
@@ -52,7 +52,7 @@ When RuntimeClass synchronization is enabled, vCluster uses selector criteria to
 
 **Unified selector control**: The same selector determines which RuntimeClass resources are imported into the virtual cluster and which Pod resources can sync to the host cluster. If a Pod references a RuntimeClass that was not synced to the virtual cluster, that Pod cannot sync to the host cluster.
 
-## Using selectors to filter RuntimeClasses
+## Use selectors to filter RuntimeClasses
 
 Selectors provide precise control over which RuntimeClass resources get synced from the host cluster. vCluster supports two types of selector criteria that follow standard Kubernetes label selector syntax.
 
@@ -69,9 +69,9 @@ All specified label conditions must match for a RuntimeClass to be included in t
 
 For more details on label selectors, refer to the [Kubernetes documentation on label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements).
 
-## Sync behavior and considerations
+## Sync behavior considerations
 
-### Resource lifecycle and validation
+### Resource lifecycle
 
 Synced RuntimeClass resources function like any other Kubernetes resource in the virtual cluster. You can view them with `kubectl get runtimeclass` and reference them in Pod specifications using the runtimeClassName field.
 
@@ -89,7 +89,7 @@ When a RuntimeClass fails to meet the selector criteria during evaluation, vClus
 
 The error output appears as a Kubernetes event that you can view using `kubectl describe`.
 
-### Orphaned resources and cleanup
+### Remove orphaned resources
 
 When vCluster removes a synced RuntimeClass from the virtual cluster due to selector changes or deletion from the host cluster, any Pod resources that reference it remain in the virtual cluster. These orphaned Pod resources stop receiving updates but vCluster does not automatically delete them to prevent unintended data loss. To remove these orphaned resources, you must delete them manually in the host cluster.
 
@@ -99,7 +99,7 @@ When vCluster removes a synced RuntimeClass from the virtual cluster due to sele
 
 To sync only RuntimeClass resources labeled `environment: development`:
 
-```yaml title="Filter example runtimeClass"
+```yaml title="Filter example RuntimeClass"
 sync:
   toHost:
     pods:
@@ -116,7 +116,7 @@ sync:
 
 To sync RuntimeClass resources where the label `kubernetes.io/runtime.class` is either `gvisor` or `youki`:
 
-```yaml title="Flexible filter example runtimeClass"
+```yaml title="Flexible filter example RuntimeClass"
 sync:
   toHost:
     pods:
@@ -137,7 +137,7 @@ sync:
 
 The following configuration syncs RuntimeClass resources that match both label and expression criteria:
 
-```yaml title="Combined filter example runtimeClass"
+```yaml title="Combined filter example RuntimeClass"
 sync:
   toHost:
     pods:
@@ -160,7 +160,7 @@ sync:
 
 When a Pod resource references a RuntimeClass that doesn't match the selector criteria, the error output looks like this:
 
-```bash title="Error handling example runtimeClass"
+```bash title="Error handling example RuntimeClass"
 vcluster-virtual-cluster-1:~$ kubectl describe pod my-pod
 Name:             my-pod
 Namespace:        default

--- a/vcluster/configure/vcluster-yaml/sync/from-host/runtime-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/runtime-classes.mdx
@@ -33,6 +33,11 @@ sync:
 ```
 
 <!-- vale off -->
+
+:::note
+When `sync.fromHost.runtimeClasses.enabled` is enabled, any `RuntimeClass` created in the virtual cluster will be immediately deleted.
+:::
+
 ### Example
 
 The following configuration syncs all `RuntimeClasses` that match the specified labels and expressions from the host cluster to the virtual cluster:

--- a/vcluster/configure/vcluster-yaml/sync/from-host/runtime-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/runtime-classes.mdx
@@ -1,29 +1,35 @@
 ---
-title: Runtime Classes
+title: Runtime classes
 sidebar_label: runtimeClasses
 sidebar_position: 3
-description: Configuration for Runtime Classes in vCluster
+description: Configure runtime classes in vCluster
 ---
 
 import EnableSwitch from '../../../../_partials/config/sync/fromHost/runtimeClasses.mdx'
 
-{/*
-`runtimeClasses.enabled`:
-- covered by the generic section here: https://www.vcluster.com/docs/syncer/config#enable-or-disable-synced-resources
-*/}
+<!-- vale off -->
 
 By default, RuntimeClass synchronization is disabled.
 
-You can enable this feature to sync `RuntimeClass` resources from the host cluster to the virtual cluster.
+RuntimeClass syncing allows virtual clusters to use runtime classes from the host cluster. RuntimeClass resources define container runtime configurations including security sandboxes, alternative runtimes like gVisor or Kata Containers, and runtime-specific settings.
 
-This is useful in scenarios where selective access to Pod configurations is required. Common use cases include:
+Virtual clusters are isolated from each other; a RuntimeClass created in one virtual cluster does not exist in another. For more details on enabling and disabling synced resources, see the [sync configuration documentation](https://www.vcluster.com/docs/syncer/config#enable-or-disable-synced-resources).
 
-- **Development environments**: Sync only the RuntimeClasses required for development clusters to reduce noise and avoid unnecessary exposure.
-- **Multi-tenancy**: Enable teams to use their own RuntimeClasses while sharing a single host cluster.
-- **Security**: Restrict the RuntimeClasses available in the virtual cluster to enforce access control and prevent unintended configurations.
+You can enable this feature to sync RuntimeClass resources from the host cluster to the virtual cluster. Add labels to RuntimeClass resources in your host cluster and configure vCluster to sync only those matching specific selectors. When you create a Pod that references a synced RuntimeClass, the host cluster uses that runtime configuration.
 
-### Enable Syncing runtime classes from the host to virtual cluster
+This approach provides centralized control over runtime configurations and ensures consistent container runtime behavior across virtual clusters. Common use cases include:
 
+- **Security isolation**: Control which security runtimes different teams can access while sharing a single host cluster. Only authorized workloads can use enhanced security runtimes such as gVisor or Kata Containers. This prevents unauthorized access to privileged runtime configurations.
+
+- **Development environments**: Sync only required RuntimeClasses to reduce noise and avoid unnecessary exposure to production runtime configurations.
+
+- **Multi-tenancy**: Enable teams to use specific runtime configurations while preventing access to incompatible or resource-intensive runtimes that could affect other tenants. Each team gets only the runtime classes appropriate for their workloads and security requirements.
+
+- **Compliance**: Maintain strict control over container runtime configurations by defining runtime classes once in the host cluster and making only approved runtime configurations available to virtual clusters. All workloads use compliant runtime settings.
+
+- **Resource optimization**: Prevent teams from using resource-intensive runtime configurations that could impact cluster performance without proper oversight. Access to high-overhead runtimes is restricted and used only when necessary.
+
+### Enable RuntimeClass syncing
 
 ```YAML
 sync:
@@ -32,27 +38,117 @@ sync:
       enabled: true
 ```
 
-<!-- vale off -->
-
 :::note
-When `sync.fromHost.runtimeClasses.enabled` is enabled, any `RuntimeClass` created in the virtual cluster will be immediately deleted.
+When `sync.fromHost.runtimeClasses.enabled` is enabled, any RuntimeClass created in the virtual cluster is immediately deleted. This prevents conflicts between locally created RuntimeClasses and those synced from the host cluster.
 :::
 
-### Example
+## How RuntimeClass syncing works
 
-The following configuration syncs all `RuntimeClasses` that match the specified labels and expressions from the host cluster to the virtual cluster:
+When RuntimeClass synchronization is enabled, vCluster uses selector criteria to control which RuntimeClasses are synchronized between clusters. This affects two different resource flows:
 
-```YAML
+**RuntimeClass resources (host → virtual)**: Only RuntimeClasses matching the selector criteria are synchronized from the host cluster to the virtual cluster. You cannot create RuntimeClass resources directly in the virtual cluster. If no selector is specified, all RuntimeClass resources from the host cluster are synced.
+
+**Pod resources (virtual → host)**: Pod resources created in the virtual cluster are synchronized to the host only if they reference RuntimeClasses that match the selector criteria. Pod resources also sync if they have an empty runtimeClassName field or if no selector is specified.
+
+**Unified selector control**: The same selector determines which RuntimeClass resources are imported into the virtual cluster and which Pod resources can sync to the host cluster. If a Pod references a RuntimeClass that was not synced to the virtual cluster, that Pod cannot sync to the host cluster.
+
+## Using selectors to filter RuntimeClasses
+
+Selectors provide precise control over which RuntimeClass resources get synced from the host cluster. vCluster supports two types of selector criteria that follow standard Kubernetes label selector syntax.
+
+The `matchLabels` selector defines exact label key-value pairs that must be present on a RuntimeClass for it to be synced. This provides straightforward filtering based on specific label values and is ideal for simple categorization schemes.
+
+The `matchExpressions` selector allows more flexible, set-based filtering with support for multiple operators:
+
+- `In`: Matches RuntimeClass resources where the label value exists within a specified list
+- `NotIn`: Excludes resources with certain label values
+- `Exists`: Requires the presence of a label key regardless of its value
+- `DoesNotExist`: Excludes resources that have a particular label key
+
+All specified label conditions must match for a RuntimeClass to be included in the sync. This means that if you define both `matchLabels` and `matchExpressions`, a RuntimeClass must satisfy all criteria to be synced to the virtual cluster.
+
+For more details on label selectors, refer to the [Kubernetes documentation on label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements).
+
+## Sync behavior and considerations
+
+### Resource lifecycle and validation
+
+Synced RuntimeClass resources function like any other Kubernetes resource in the virtual cluster. You can view them with `kubectl get runtimeclass` and reference them in Pod specifications using the runtimeClassName field.
+
+When a RuntimeClass in the host cluster is modified, vCluster re-evaluates whether it still matches the selector criteria. If the RuntimeClass continues to match, vCluster updates the corresponding resource in the virtual cluster. If the RuntimeClass no longer matches the selector criteria, vCluster removes it from the virtual cluster.
+
+The selector system acts as both a resource filter and a validation mechanism. As a resource filter, it ensures that vCluster makes only RuntimeClass resources matching the selector criteria available in the virtual cluster. The selector also functions as a creation validation mechanism - Pod resources in the virtual cluster can only reference RuntimeClass resources that exist in the filtered set.
+
+### Error handling and troubleshooting
+
+When a RuntimeClass fails to meet the selector criteria during evaluation, vCluster logs a warning in the syncer pod's output. When you create a Pod resource that references a RuntimeClass not matching the selector criteria, several things occur:
+
+- The Pod synchronization to the host cluster fails
+- vCluster records an event on the Pod resource in the virtual cluster
+- The event indicates that the specified RuntimeClass is not available according to the current selector configuration
+
+The error output appears as a Kubernetes event that you can view using `kubectl describe`.
+
+### Orphaned resources and cleanup
+
+When vCluster removes a synced RuntimeClass from the virtual cluster due to selector changes or deletion from the host cluster, any Pod resources that reference it remain in the virtual cluster. These orphaned Pod resources stop receiving updates but vCluster does not automatically delete them to prevent unintended data loss. To remove these orphaned resources, you must delete them manually in the host cluster.
+
+## Examples
+
+### Filter with matchLabels
+
+To sync only RuntimeClass resources labeled `environment: development`:
+
+```yaml
 sync:
+  toHost:
+    pods:
+      enabled: true
   fromHost:
     runtimeClasses:
       enabled: true
       selector:
         matchLabels:
-          # Match all RuntimeClasses with the label `environment` with value `development`
+          environment: development
+```
+
+### Flexible filter with matchExpressions
+
+To sync RuntimeClass resources where the label `kubernetes.io/runtime.class` is either `gvisor` or `youki`:
+
+```yaml
+sync:
+  toHost:
+    pods:
+      enabled: true
+  fromHost:
+    runtimeClasses:
+      enabled: true
+      selector:
+        matchExpressions:
+          - key: kubernetes.io/runtime.class
+            operator: In
+            values:
+              - gvisor
+              - youki
+```
+
+### Combined filter criteria
+
+The following configuration syncs RuntimeClass resources that match both label and expression criteria:
+
+```yaml
+sync:
+  toHost:
+    pods:
+      enabled: true
+  fromHost:
+    runtimeClasses:
+      enabled: true
+      selector:
+        matchLabels:
           environment: "development"
         matchExpressions:
-          # Match RuntimeClasses with the label `kubernetes.io/runtime.class` that are either `gvisor` or `youki`
           - key: "kubernetes.io/runtime.class"
             operator: In
             values:
@@ -60,87 +156,11 @@ sync:
               - youki
 ```
 
-The `selector` field follows the same syntax as Kubernetes label selectors. Use it to filter which `RuntimeClass` resources are synced from the host cluster based on their labels.
+### Error handling
 
-:::note
-All specified label conditions must match for an `RuntimeClass` to be included in the sync.
-:::
+When a Pod resource references a RuntimeClass that doesn't match the selector criteria, the error output looks like this:
 
-
-## Use selectors to filter RuntimeClasses
-
-Use `matchLabels` and `matchExpressions` to filter which `RuntimeClass` resources are synced based on their labels.
-
-- `matchLabels`: Defines exact label key-value pairs.
-
-For example, to sync only `RuntimeClasses` labeled `environment: development`:
-
-```yaml
-matchLabels:
-  environment: development
-  ```
-
-- `matchExpressions`: Allows more flexible, set-based filtering.
-
-For example, to sync `RuntimeClasses` where the label `kubernetes.io/runtime.class` is either `gvisor` or `youki`:
-
-```yaml
-matchExpressions:
-  - key: kubernetes.io/runtime.class
-    operator: In
-    values:
-      - gvisor
-      - youki
-  ```
-Supported operators are `In`, `NotIn`, `Exists`, and `DoesNotExist`.
-
-For more details on how to use label selectors effectively, refer to the [Kubernetes documentation on label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements).
-
-## Sync behavior and considerations
-
-When `RuntimeClass` synchronization is enabled, the vCluster syncer uses selector criteria to control which `RuntimeClasses` are synchronized between the host and virtual clusters.
-
-The selector configuration creates a bidirectional filter:
-
-- **From host to virtual cluster**: Only `RuntimeClasses` matching the selector criteria are synchronized from the host cluster to the virtual cluster.
-
-- **From virtual cluster to host**: `Pod` resources created in the virtual cluster are synchronized to the host only if they reference `RuntimeClasses` that match the selector criteria.
-
-### Resource availability and updates
-
-- Synced `RuntimeClass` resources appear in the virtual cluster and can be referenced by `Pod` resources.
-- When an `RuntimeClass` in the host cluster is modified, the selector is re-evaluated:
-- If it still matches, the resource is updated in the virtual cluster.
-- If it no longer matches, it is removed from the virtual cluster.
-- If an `RuntimeClass` fails to meet the selector criteria, a warning is logged in the vCluster syncer pod’s output.
-
-### Orphaned Pod resources
-
-- If a synced `RuntimeClass` is removed from the virtual cluster (due to selector mismatch or deletion), any `Pod` resources referencing it remain in the virtual cluster.
-- These `Pod` resources stop receiving updates but are not automatically deleted.
-- To remove them, you must delete them manually in the host cluster.
-
-## Constraint enforcement
-
-The selector acts as both a filter and a validation mechanism:
-
-- **Resource filtering**: Only `RuntimeClasses` that match the selector criteria are made available in the virtual cluster's API server.
-
-- **Creation validation**: `Pod` resources in the virtual cluster can only reference `RuntimeClasses` that exist in the filtered set.
-
-- **Sync restriction**: `Pod` resources referencing non-matching `RuntimeClasses` are blocked from synchronizing to the host cluster.
-
-## Error handling
-
-When a `Pod` resource references a `RuntimeClass` that doesn't match the selector criteria:
-
-- The `Pod` synchronization to the host cluster fails.
-- An event is recorded on the `Pod` resource in the virtual cluster.
-- The event indicates that the specified `RuntimeClass` is not available in the host.
-
-The event output looks similar to the following:
-
-```shell
+```bash
 vcluster-virtual-cluster-1:~$ kubectl describe pod my-pod
 Name:             my-pod
 Namespace:        default

--- a/vcluster/configure/vcluster-yaml/sync/from-host/storage-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/storage-classes.mdx
@@ -46,7 +46,7 @@ When StorageClass sync is enabled, vCluster uses selector criteria to control wh
 
 **Unified selector control**: The same selector determines which StorageClass resources are imported into the virtual cluster and which PersistentVolume and PersistentVolumeClaim resources can sync to the host cluster. If a PersistentVolumeClaim references a StorageClass that was not synced to the virtual cluster, that PersistentVolumeClaim cannot sync to the host cluster.
 
-## Using selectors to filter StorageClasses
+## Use selectors to filter StorageClasses
 
 Selectors provide precise control over which StorageClass resources get synced from the host cluster. vCluster supports two types of selector criteria that follow standard Kubernetes label selector syntax.
 
@@ -63,9 +63,9 @@ All specified label conditions must match for a StorageClass to be included in t
 
 For more details on label selectors, refer to the [Kubernetes documentation on label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements).
 
-## Sync behavior and considerations
+## Sync behavior considerations
 
-### Resource lifecycle and validation
+### Resource lifecycle
 
 Synced StorageClass resources function like any other Kubernetes resource in the virtual cluster. You can view them with `kubectl get storageclass` and reference them in PersistentVolumeClaim specifications using the storageClassName field.
 
@@ -83,7 +83,7 @@ When a StorageClass fails to meet the selector criteria during evaluation, vClus
 
 The error output appears as a Kubernetes event that you can view using `kubectl describe`.
 
-### Orphaned resources and cleanup
+### Remove orphaned resources
 
 When vCluster removes a synced StorageClass from the virtual cluster due to selector changes or deletion from the host cluster, any PersistentVolume and PersistentVolumeClaim resources that reference it remain in the virtual cluster. These orphaned resources stop receiving updates but vCluster does not automatically delete them to prevent unintended data loss. To remove these orphaned resources, you must delete them manually in the host cluster.
 
@@ -93,7 +93,7 @@ When vCluster removes a synced StorageClass from the virtual cluster due to sele
 
 To sync only StorageClass resources labeled `environment: development`:
 
-```yaml title="Filter example for storageClass"
+```yaml title="Filter example for StorageClass"
 sync:
   toHost:
     persistentVolumes:
@@ -112,7 +112,7 @@ sync:
 
 To sync StorageClass resources where the label `kubernetes.io/storage.class` is either `network-nas` or `fast-ssd`:
 
-```yaml title="Flexible filter example for storageClass"
+```yaml title="Flexible filter example for StorageClass"
 sync:
   toHost:
     persistentVolumes:
@@ -135,7 +135,7 @@ sync:
 
 The following configuration syncs StorageClass resources that match both label and expression criteria:
 
-```yaml title="Combined filter example for storageClass"
+```yaml title="Combined filter example for StorageClass"
 sync:
   toHost:
     persistentVolumes:
@@ -160,7 +160,7 @@ sync:
 
 When a PersistentVolumeClaim resource references a StorageClass that doesn't match the selector criteria, the error output looks like this:
 
-```bash title="Error handling example for storageClass"
+```bash title="Error handling example for StorageClass"
 vcluster-virtual-cluster-1:~$ kubectl describe pvc my-pvc
 Name:             my-pvc
 Namespace:        default

--- a/vcluster/configure/vcluster-yaml/sync/from-host/storage-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/storage-classes.mdx
@@ -37,6 +37,11 @@ sync:
 ```
 
 <!-- vale off -->
+
+:::note
+When `sync.fromHost.storageClasses.enabled` is enabled, any `StorageClass` created in the virtual cluster will be immediately deleted.
+:::
+
 ### Example
 
 The following configuration syncs all `StorageClasses` that match the specified labels and expressions from the host cluster to the virtual cluster:

--- a/vcluster/configure/vcluster-yaml/sync/from-host/storage-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/storage-classes.mdx
@@ -2,22 +2,27 @@
 title: Storage Classes
 sidebar_label: storageClasses
 sidebar_position: 4
-description: Configuration for ...
+description: Configuration for Storage Classes in vCluster
 ---
 
 import EnableSwitch from '../../../../_partials/config/sync/fromHost/storageClasses.mdx'
 
-By default, this is disabled. 
+By default, StorageClass synchronization is disabled.
 
 vCluster does not sync storage classes from the host cluster to the virtual cluster. While it's not strictly required when you're syncing PersistentVolume and PersistentVolumeClaim resources, syncing StorageClass resources may be required for informational purposes or ensuring that storage is handled consistently between the host and virtual clusters.
 
+This is useful in scenarios where selective access to PersistentVolume and PersistentVolumeClaim configurations is required. Common use cases include:
+
+- **Development environments**: Sync only the StorageClasses required for development clusters to reduce noise and avoid unnecessary exposure.
+- **Multi-tenancy**: Enable teams to use their own StorageClasses while sharing a single host cluster.
+- **Security**: Restrict the StorageClasses available in the virtual cluster to enforce access control and prevent unintended configurations.
 
 {/*
 `storageClasses.enabled`:
 - covered by the generic section here: https://www.vcluster.com/docs/syncer/config#enable-or-disable-synced-resources
 - more context behind this config: https://github.com/loft-sh/vcluster/pull/378
 - looks like this is a rare resource that is scheduled both from and to the host cluster
-  - my understanding is that you can simply use the host cluster's storage classes by default, and the from host syncing is for referenctial integrity
+  - my understanding is that you can simply use the host cluster's storage classes by default, and the from host syncing is for referential integrity
   - if one needs to customize the storage used by vCluster persistent volumes, this would be a reason to define a storage class in the vCluster that then gets synced to the host
   - may want to verify this assessment with Rohan / Fabian
 */}
@@ -29,6 +34,120 @@ sync:
   fromHost:
     storageClasses:
       enabled: true
+```
+
+<!-- vale off -->
+### Example
+
+The following configuration syncs all `StorageClasses` that match the specified labels and expressions from the host cluster to the virtual cluster:
+
+```YAML
+sync:
+  fromHost:
+    storageClasses:
+      enabled: true
+      selector:
+        matchLabels:
+          # Match all StorageClasses with the label `environment` with value `development`
+          environment: "development"
+        matchExpressions:
+          # Match StorageClasses with the label `kubernetes.io/storage.class` that are either `network-nas` or `fast-sdd`
+          - key: "kubernetes.io/storage.class"
+            operator: In
+            values:
+              - network-nas
+              - fast-ssd
+```
+
+The `selector` field follows the same syntax as Kubernetes label selectors. Use it to filter which `StorageClass` resources are synced from the host cluster based on their labels.
+
+:::note
+All specified label conditions must match for an `StorageClass` to be included in the sync.
+:::
+
+
+## Use selectors to filter StorageClasses
+
+Use `matchLabels` and `matchExpressions` to filter which `StorageClass` resources are synced based on their labels.
+
+- `matchLabels`: Defines exact label key-value pairs.
+
+For example, to sync only `StorageClasses` labeled `environment: development`:
+
+```yaml
+matchLabels:
+  environment: development
+  ```
+
+- `matchExpressions`: Allows more flexible, set-based filtering.
+
+For example, to sync `StorageClasses` where the label `kubernetes.io/storage.class` is either `network-nas` or `fast-ssd`:
+
+```yaml
+matchExpressions:
+  - key: kubernetes.io/storage.class
+    operator: In
+    values:
+      - network-nas
+      - fast-ssd
+  ```
+Supported operators are `In`, `NotIn`, `Exists`, and `DoesNotExist`.
+
+For more details on how to use label selectors effectively, refer to the [Kubernetes documentation on label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements).
+
+## Sync behavior and considerations
+
+When `StorageClass` synchronization is enabled, the vCluster syncer uses selector criteria to control which `StorageClasses` are synchronized between the host and virtual clusters.
+
+The selector configuration creates a bidirectional filter:
+
+- **From host to virtual cluster**: Only `StorageClasses` matching the selector criteria are synchronized from the host cluster to the virtual cluster.
+
+- **From virtual cluster to host**: `PersistentVolume` and `PersistentVolumeClaim` resources created in the virtual cluster are synchronized to the host only if they reference `StorageClasses` that match the selector criteria.
+
+### Resource availability and updates
+
+- Synced `StorageClass` resources appear in the virtual cluster and can be referenced by `PersistentVolume` or `PersistentVolumeClaim` resources.
+- When an `StorageClass` in the host cluster is modified, the selector is re-evaluated:
+- If it still matches, the resource is updated in the virtual cluster.
+- If it no longer matches, it is removed from the virtual cluster.
+- If an `StorageClass` fails to meet the selector criteria, a warning is logged in the vCluster syncer pod’s output.
+
+### Orphaned PersistentVolume and PersistentVolumeClaim resources
+
+- If a synced `StorageClass` is removed from the virtual cluster (due to selector mismatch or deletion), any `PersistentVolume` or `PersistentVolumeClaim` resources referencing it remain in the virtual cluster.
+- These `PersistentVolume` and `PersistentVolumeClaim` resources stop receiving updates but are not automatically deleted.
+- To remove them, you must delete them manually in the host cluster.
+
+## Constraint enforcement
+
+The selector acts as both a filter and a validation mechanism:
+
+- **Resource filtering**: Only `StorageClasses` that match the selector criteria are made available in the virtual cluster's API server.
+
+- **Creation validation**: `PersistentVolume` and `PersistentVolumeClaim` resources in the virtual cluster can only reference `StorageClasses` that exist in the filtered set.
+
+- **Sync restriction**: `PersistentVolume` and `PersistentVolumeClaim` resources referencing non-matching `StorageClasses` are blocked from synchronizing to the host cluster.
+
+## Error handling
+
+When a `PersistentVolume` or `PersistentVolumeClaim` resource references a `StorageClass` that doesn't match the selector criteria:
+
+- The `PersistentVolume` and `PersistentVolumeClaim` synchronization to the host cluster fails.
+- An event is recorded on the `PersistentVolume` and `PersistentVolumeClaim` resource in the virtual cluster.
+- The event indicates that the specified `StorageClass` is not available in the host.
+
+The event output looks similar to the following:
+
+```shell
+vcluster-virtual-cluster-1:~$ kubectl describe pvc my-pvc
+Name:             my-pvc
+Namespace:        default
+Storage Class:    fast-ssd
+Events:
+  Type     Reason            Age   From                Message
+  ----     ------            ----  ----                -------
+  Warning  SyncWarning       10s   pvc-syncer          did not sync pvc "my-pvc" to host because it does not match the selector under 'sync.fromHost.StorageClasses.selector'
 ```
 
 ## Config reference

--- a/vcluster/configure/vcluster-yaml/sync/from-host/storage-classes.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/storage-classes.mdx
@@ -7,27 +7,23 @@ description: Configuration for Storage Classes in vCluster
 
 import EnableSwitch from '../../../../_partials/config/sync/fromHost/storageClasses.mdx'
 
-By default, StorageClass synchronization is disabled.
+<!-- vale off -->
 
-vCluster does not sync storage classes from the host cluster to the virtual cluster. While it's not strictly required when you're syncing PersistentVolume and PersistentVolumeClaim resources, syncing StorageClass resources may be required for informational purposes or ensuring that storage is handled consistently between the host and virtual clusters.
+By default, this is disabled.
 
-This is useful in scenarios where selective access to PersistentVolume and PersistentVolumeClaim configurations is required. Common use cases include:
+StorageClass resources define how virtual clusters provision storage. They specify storage backends such as AWS EBS, Azure Disk, or GCP Persistent Disk, along with parameters such as performance tiers and replication settings.
 
-- **Development environments**: Sync only the StorageClasses required for development clusters to reduce noise and avoid unnecessary exposure.
-- **Multi-tenancy**: Enable teams to use their own StorageClasses while sharing a single host cluster.
-- **Security**: Restrict the StorageClasses available in the virtual cluster to enforce access control and prevent unintended configurations.
+By default, each virtual cluster needs its own StorageClass resources. StorageClass syncing allows virtual clusters to use StorageClass resources from the host cluster instead.
 
-{/*
-`storageClasses.enabled`:
-- covered by the generic section here: https://www.vcluster.com/docs/syncer/config#enable-or-disable-synced-resources
-- more context behind this config: https://github.com/loft-sh/vcluster/pull/378
-- looks like this is a rare resource that is scheduled both from and to the host cluster
-  - my understanding is that you can simply use the host cluster's storage classes by default, and the from host syncing is for referential integrity
-  - if one needs to customize the storage used by vCluster persistent volumes, this would be a reason to define a storage class in the vCluster that then gets synced to the host
-  - may want to verify this assessment with Rohan / Fabian
-*/}
+You can enable this feature to sync StorageClass resources from the host cluster to the virtual cluster. Add labels to StorageClass resources in your host cluster and configure vCluster to sync only those matching specific selectors. When you create a PersistentVolumeClaim that references a synced StorageClass, the host cluster uses that storage configuration. Common use cases include:
 
-### Sync StorageClasses from the host to virtual cluster
+- **Cost control**: Restrict access to specific storage classes based on cost or performance characteristics.
+- **Compliance**: Control which storage backends and configurations are available to virtual clusters.
+- **Multi-tenancy**: Provide different storage options to different teams while preventing access to restricted storage types.
+- **Simplified management**: Update storage class configurations in the host cluster rather than in each virtual cluster.
+- **Security**: Control access to storage backends and encryption options.
+
+### Enable StorageClass syncing
 
 ```YAML
 sync:
@@ -36,27 +32,123 @@ sync:
       enabled: true
 ```
 
-<!-- vale off -->
-
 :::note
-When `sync.fromHost.storageClasses.enabled` is enabled, any `StorageClass` created in the virtual cluster will be immediately deleted.
+When `sync.fromHost.storageClasses.enabled` is enabled, any StorageClass created in the virtual cluster is immediately deleted. This prevents conflicts between locally-created StorageClasses and those synced from the host cluster.
 :::
 
-### Example
+## How StorageClass syncing works
 
-The following configuration syncs all `StorageClasses` that match the specified labels and expressions from the host cluster to the virtual cluster:
+When StorageClass sync is enabled, vCluster uses selector criteria to control which StorageClasses are synced between clusters. This affects two different resource flows:
 
-```YAML
+**StorageClass resources (host → virtual)**: Only StorageClasses matching the selector criteria are synced from the host cluster to the virtual cluster. You cannot create StorageClass resources directly in the virtual cluster. If no selector is specified, all StorageClass resources from the host cluster are synced.
+
+**PersistentVolume and PersistentVolumeClaim resources (virtual → host)**: PersistentVolume and PersistentVolumeClaim resources created in the virtual cluster are synced to the host only if they reference StorageClasses that match the selector criteria. These resources also sync if they have an empty storageClassName field or if no selector is specified.
+
+**Unified selector control**: The same selector determines which StorageClass resources are imported into the virtual cluster and which PersistentVolume and PersistentVolumeClaim resources can sync to the host cluster. If a PersistentVolumeClaim references a StorageClass that was not synced to the virtual cluster, that PersistentVolumeClaim cannot sync to the host cluster.
+
+## Using selectors to filter StorageClasses
+
+Selectors provide precise control over which StorageClass resources get synced from the host cluster. vCluster supports two types of selector criteria that follow standard Kubernetes label selector syntax.
+
+The `matchLabels` selector defines exact label key-value pairs that must be present on a StorageClass for it to be synced. This provides straightforward filtering based on specific label values and is ideal for simple categorization schemes.
+
+The `matchExpressions` selector allows more flexible, set-based filtering with support for multiple operators:
+
+- `In`: Matches StorageClass resources where the label value exists within a specified list
+- `NotIn`: Excludes resources with certain label values
+- `Exists`: Requires the presence of a label key regardless of its value
+- `DoesNotExist`: Excludes resources that have a particular label key
+
+All specified label conditions must match for a StorageClass to be included in the sync. This means that if you define both `matchLabels` and `matchExpressions`, a StorageClass must satisfy all criteria to be synced to the virtual cluster.
+
+For more details on label selectors, refer to the [Kubernetes documentation on label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements).
+
+## Sync behavior and considerations
+
+### Resource lifecycle and validation
+
+Synced StorageClass resources function like any other Kubernetes resource in the virtual cluster. You can view them with `kubectl get storageclass` and reference them in PersistentVolumeClaim specifications using the storageClassName field.
+
+When a StorageClass in the host cluster is modified, vCluster re-evaluates whether it still matches the selector criteria. If the StorageClass continues to match, vCluster updates the corresponding resource in the virtual cluster. If the StorageClass no longer matches the selector criteria, vCluster removes it from the virtual cluster.
+
+The selector system acts as both a resource filter and a validation mechanism. As a resource filter, it ensures that vCluster makes only StorageClass resources matching the selector criteria available in the virtual cluster. The selector also functions as a creation validation mechanism - PersistentVolume and PersistentVolumeClaim resources in the virtual cluster can only reference StorageClass resources that exist in the filtered set.
+
+### Error handling and troubleshooting
+
+When a StorageClass fails to meet the selector criteria during evaluation, vCluster logs a warning in the syncer pod's output. When you create a PersistentVolume or PersistentVolumeClaim resource that references a StorageClass not matching the selector criteria, several things occur:
+
+- The PersistentVolume and PersistentVolumeClaim sync to the host cluster fails
+- vCluster records an event on the PersistentVolume and PersistentVolumeClaim resource in the virtual cluster
+- The event indicates that the specified StorageClass is not available according to the current selector configuration
+
+The error output appears as a Kubernetes event that you can view using `kubectl describe`.
+
+### Orphaned resources and cleanup
+
+When vCluster removes a synced StorageClass from the virtual cluster due to selector changes or deletion from the host cluster, any PersistentVolume and PersistentVolumeClaim resources that reference it remain in the virtual cluster. These orphaned resources stop receiving updates but vCluster does not automatically delete them to prevent unintended data loss. To remove these orphaned resources, you must delete them manually in the host cluster.
+
+## Examples
+
+### Filter with matchLabels
+
+To sync only StorageClass resources labeled `environment: development`:
+
+```yaml title="Filter example for storageClass"
 sync:
+  toHost:
+    persistentVolumes:
+      enabled: true
+    persistentVolumeClaims:
+      enabled: true
   fromHost:
     storageClasses:
       enabled: true
       selector:
         matchLabels:
-          # Match all StorageClasses with the label `environment` with value `development`
+          environment: development
+```
+
+### Flexible filter with matchExpressions
+
+To sync StorageClass resources where the label `kubernetes.io/storage.class` is either `network-nas` or `fast-ssd`:
+
+```yaml title="Flexible filter example for storageClass"
+sync:
+  toHost:
+    persistentVolumes:
+      enabled: true
+    persistentVolumeClaims:
+      enabled: true
+  fromHost:
+    storageClasses:
+      enabled: true
+      selector:
+        matchExpressions:
+          - key: kubernetes.io/storage.class
+            operator: In
+            values:
+              - network-nas
+              - fast-ssd
+```
+
+### Combined filter criteria
+
+The following configuration syncs StorageClass resources that match both label and expression criteria:
+
+```yaml title="Combined filter example for storageClass"
+sync:
+  toHost:
+    persistentVolumes:
+      enabled: true
+    persistentVolumeClaims:
+      enabled: true
+  fromHost:
+    storageClasses:
+      enabled: true
+      selector:
+        matchLabels:
           environment: "development"
         matchExpressions:
-          # Match StorageClasses with the label `kubernetes.io/storage.class` that are either `network-nas` or `fast-sdd`
           - key: "kubernetes.io/storage.class"
             operator: In
             values:
@@ -64,87 +156,11 @@ sync:
               - fast-ssd
 ```
 
-The `selector` field follows the same syntax as Kubernetes label selectors. Use it to filter which `StorageClass` resources are synced from the host cluster based on their labels.
+### Error handling
 
-:::note
-All specified label conditions must match for an `StorageClass` to be included in the sync.
-:::
+When a PersistentVolumeClaim resource references a StorageClass that doesn't match the selector criteria, the error output looks like this:
 
-
-## Use selectors to filter StorageClasses
-
-Use `matchLabels` and `matchExpressions` to filter which `StorageClass` resources are synced based on their labels.
-
-- `matchLabels`: Defines exact label key-value pairs.
-
-For example, to sync only `StorageClasses` labeled `environment: development`:
-
-```yaml
-matchLabels:
-  environment: development
-  ```
-
-- `matchExpressions`: Allows more flexible, set-based filtering.
-
-For example, to sync `StorageClasses` where the label `kubernetes.io/storage.class` is either `network-nas` or `fast-ssd`:
-
-```yaml
-matchExpressions:
-  - key: kubernetes.io/storage.class
-    operator: In
-    values:
-      - network-nas
-      - fast-ssd
-  ```
-Supported operators are `In`, `NotIn`, `Exists`, and `DoesNotExist`.
-
-For more details on how to use label selectors effectively, refer to the [Kubernetes documentation on label selectors](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements).
-
-## Sync behavior and considerations
-
-When `StorageClass` synchronization is enabled, the vCluster syncer uses selector criteria to control which `StorageClasses` are synchronized between the host and virtual clusters.
-
-The selector configuration creates a bidirectional filter:
-
-- **From host to virtual cluster**: Only `StorageClasses` matching the selector criteria are synchronized from the host cluster to the virtual cluster.
-
-- **From virtual cluster to host**: `PersistentVolume` and `PersistentVolumeClaim` resources created in the virtual cluster are synchronized to the host only if they reference `StorageClasses` that match the selector criteria.
-
-### Resource availability and updates
-
-- Synced `StorageClass` resources appear in the virtual cluster and can be referenced by `PersistentVolume` or `PersistentVolumeClaim` resources.
-- When an `StorageClass` in the host cluster is modified, the selector is re-evaluated:
-- If it still matches, the resource is updated in the virtual cluster.
-- If it no longer matches, it is removed from the virtual cluster.
-- If an `StorageClass` fails to meet the selector criteria, a warning is logged in the vCluster syncer pod’s output.
-
-### Orphaned PersistentVolume and PersistentVolumeClaim resources
-
-- If a synced `StorageClass` is removed from the virtual cluster (due to selector mismatch or deletion), any `PersistentVolume` or `PersistentVolumeClaim` resources referencing it remain in the virtual cluster.
-- These `PersistentVolume` and `PersistentVolumeClaim` resources stop receiving updates but are not automatically deleted.
-- To remove them, you must delete them manually in the host cluster.
-
-## Constraint enforcement
-
-The selector acts as both a filter and a validation mechanism:
-
-- **Resource filtering**: Only `StorageClasses` that match the selector criteria are made available in the virtual cluster's API server.
-
-- **Creation validation**: `PersistentVolume` and `PersistentVolumeClaim` resources in the virtual cluster can only reference `StorageClasses` that exist in the filtered set.
-
-- **Sync restriction**: `PersistentVolume` and `PersistentVolumeClaim` resources referencing non-matching `StorageClasses` are blocked from synchronizing to the host cluster.
-
-## Error handling
-
-When a `PersistentVolume` or `PersistentVolumeClaim` resource references a `StorageClass` that doesn't match the selector criteria:
-
-- The `PersistentVolume` and `PersistentVolumeClaim` synchronization to the host cluster fails.
-- An event is recorded on the `PersistentVolume` and `PersistentVolumeClaim` resource in the virtual cluster.
-- The event indicates that the specified `StorageClass` is not available in the host.
-
-The event output looks similar to the following:
-
-```shell
+```bash title="Error handling example for storageClass"
 vcluster-virtual-cluster-1:~$ kubectl describe pvc my-pvc
 Name:             my-pvc
 Namespace:        default
@@ -152,7 +168,7 @@ Storage Class:    fast-ssd
 Events:
   Type     Reason            Age   From                Message
   ----     ------            ----  ----                -------
-  Warning  SyncWarning       10s   pvc-syncer          did not sync pvc "my-pvc" to host because it does not match the selector under 'sync.fromHost.StorageClasses.selector'
+  Warning  SyncWarning       10s   pvc-syncer          did not sync pvc "my-pvc" to host because it does not match the selector under 'sync.fromHost.storageClasses.selector'
 ```
 
 ## Config reference


### PR DESCRIPTION
This PR includes docs for the new limiting feature for :
- `ingressClasses`
- `storageClasses`
- `runtimeClasses`
- `priorityClasses`

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

[Link to Preview](https://deploy-preview-748--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/sync/from-host/ingress-classes)


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-586

