### PR TITLE
fix: Add key  to tab name

### DIFF
--- a/vcluster/configure/vcluster-yaml/external/platform/api-key.mdx
+++ b/vcluster/configure/vcluster-yaml/external/platform/api-key.mdx
@@ -26,15 +26,15 @@ You can configure the platform to manage and authenticate virtual cluster connec
 
 To connect a virtual cluster to the vCluster Platform, you can use an API key—referred to as an [access key](/platform/next/api/authentication) in the platform's console. There are two authentication methods:
 
-- **Shared access** (_Recommended_): Create a single Kubernetes Secret containing the access key, and reference it in multiple virtual clusters, even if they are deployed in different namespaces. This approach simplifies management, reduces overhead, and eases credential rotation, making it suitable for most users and production environments. For most scenarios, using a shared access key is the preferred approach due to its simplicity and ease of maintenance.
+- **Shared access key** (_Recommended_): Create a single Kubernetes Secret containing the access key, and reference it in multiple virtual clusters, even if they are deployed in different namespaces. This approach simplifies management, reduces overhead, and eases credential rotation, making it suitable for most users and production environments. For most scenarios, using a shared access key is the preferred approach due to its simplicity and ease of maintenance.
 
-- **Dedicated access**: Create separate Kubernetes Secrets, each with a unique access key, for every virtual cluster. This method provides granular access control and allows revocation of access to individual clusters.
+- **Dedicated access key**: Create separate Kubernetes Secrets, each with a unique access key, for every virtual cluster. This method provides granular access control and allows revocation of access to individual clusters.
 
 
 <br />
 
 <Tabs>
-  <TabItem value="shared" label="Shared access" default>
+  <TabItem value="shared" label="Shared access key" default>
     
   ### Connect a virtual cluster to the platform using a shared access key
 
@@ -137,7 +137,7 @@ You can create the Secret in the `vcluster-platform` namespace by default to ens
     </Flow>
   </TabItem>
   
-  <TabItem value="dedicated" label="Dedicated access">
+  <TabItem value="dedicated" label="Dedicated access key">
 
   ### Connect a virtual cluster to the platform with a dedicated access key
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Add key to docs


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

[Link to Preview](https://deploy-preview-753--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml/external/platform/api-key)


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-690

