### PR TITLE
fix(vcluster): shared/dedicated access naming

### DIFF
--- a/vcluster/configure/vcluster-yaml/external/platform/api-key.mdx
+++ b/vcluster/configure/vcluster-yaml/external/platform/api-key.mdx
@@ -19,42 +19,42 @@ import TabItem from '@theme/TabItem';
 
 <!--vale off-->
 
-Enable secure communication between your virtual cluster and the vCluster Platform. 
+Enable secure communication between your virtual cluster and the vCluster Platform.
 You can configure the platform to manage and authenticate virtual cluster connections consistently across different environments.
 
-## Connect virtual clusters to the vCluster Platform 
+## Connect virtual clusters to the vCluster Platform
 
 To connect a virtual cluster to the vCluster Platform, you can use an API key—referred to as an [access key](/platform/next/api/authentication) in the platform's console. There are two authentication methods:
 
-- **Shared access** (_Recommended_): Create a single Kubernetes Secret containing the access key, and reference it in multiple virtual clusters, even if they are deployed in different namespaces. This approach simplifies management, reduces overhead, and eases credential rotation, making it suitable for most users and production environments. For most scenarios, using a shared access key is the preferred approach due to its simplicity and ease of maintenance.
+- ** Shared access key** (_Recommended_): Create a single Kubernetes Secret containing the access key, and reference it in multiple virtual clusters, even if they are deployed in different namespaces. This approach simplifies management, reduces overhead, and eases credential rotation, making it suitable for most users and production environments. For most scenarios, using a shared access key is the preferred approach due to its simplicity and ease of maintenance.
 
-- **Dedicated access**: Create separate Kubernetes Secrets, each with a unique access key, for every virtual cluster. This method provides granular access control and allows revocation of access to individual clusters.
+- **Dedicated access key**: Create separate Kubernetes Secrets, each with a unique access key, for every virtual cluster. This method provides granular access control and allows revocation of access to individual clusters.
 
 
 <br />
 
 <Tabs>
-  <TabItem value="shared" label="Shared access" default>
-    
+  <TabItem value="shared" label="Shared access key" default>
+
   ### Connect a virtual cluster to the platform using a shared access key
 
   Use a shared access key to authenticate and connect your virtual cluster to the platform.
-  
+
   ### Prerequisites
 
-  Before you begin, ensure you have: 
+  Before you begin, ensure you have:
 
   - A vCluster Platform instance set up and accessible.
   - Permissions to create and configure an access key in the platform.
   - Access to create Kubernetes Secrets on the host Kubernetes cluster (where the virtual cluster runs).
-    
+
   ### Configure shared access for a virtual cluster
 
     <Flow>
       <Step title="Create the access key">
-        
-        Log in to vCluster Platform and create an [access key](/platform/next/api/authentication). 
-        
+
+        Log in to vCluster Platform and create an [access key](/platform/next/api/authentication).
+
       </Step>
 
       <Step title="Assign the vCluster role">
@@ -79,13 +79,13 @@ Assigning the `vcluster` role is required. Without it, the vCluster cannot authe
 
       </Step>
       <Step title="Create the Secret">
-        
+
         Create the Secret in a namespace on the host cluster. This defaults to `vcluster-platform-api-key` if undefined.
-        
+
 :::note
 This namespace does **not** need to match the target namespace used by the virtual cluster, but it must exist on the host where the vCluster is deployed.
 :::
-        
+
         Run the create command, ensuring you replace the placeholders with your specific values:
 
         - Replace `ACCESS_KEY` with your API key (also referred to as an access key).
@@ -110,9 +110,9 @@ You can create the Secret in the `vcluster-platform` namespace by default to ens
   <!-- vale on -->
 
       </Step>
-      
+
       <Step title="Reference the Secret in vcluster.yaml">
-        
+
         In your `vcluster.yaml` file, define the following parameters to reference the Secret and configure access control:
 
         - `secretName`: Specifies the name of the Secret containing the API key. Defaults to `vcluster-platform-api-key` if undefined.
@@ -120,7 +120,7 @@ You can create the Secret in the `vcluster-platform` namespace by default to ens
         - `createRBAC`: When set to `true`, vCluster automatically creates the necessary `Role` and `RoleBinding` resources to allow access to the Secret. Defaults to true.
 
         <br />
-        
+
   <!-- vale off -->
   <InterpolatedCodeBlock
     code={
@@ -132,12 +132,12 @@ You can create the Secret in the `vcluster-platform` namespace by default to ens
         createRBAC: [[VAR:CREATE RBAC:true]]
   `}
       language="yaml"
-        />       
+        />
       </Step>
     </Flow>
   </TabItem>
-  
-  <TabItem value="dedicated" label="Dedicated access">
+
+  <TabItem value="dedicated" label="Dedicated access key">
 
   ### Connect a virtual cluster to the platform with a dedicated access key
 
@@ -145,12 +145,12 @@ You can create the Secret in the `vcluster-platform` namespace by default to ens
 
   ### Prerequisites
 
-  Before you begin, ensure you have: 
+  Before you begin, ensure you have:
 
   - Access to the vCluster Platform.
   - The [vCluster CLI installed](/platform/install/quick-start-guide) installed on your local machine.
   - The ability for each user to generate their own access key from the platform console.
-    
+
   ### Connect a virtual cluster to the platform using dedicated access
 
   <Flow>
@@ -236,9 +236,9 @@ To view your generated access keys, navigate to **Users** > **Access Keys**.
 ## Example
 
 <Tabs>
-  <TabItem value="shared" label="Shared access" default>
-  
-    ```yaml title="Shared access example"
+  <TabItem value="shared" label=" Shared access key" default>
+
+    ```yaml title=" Shared access key example"
     external:
       platform:
         apiKey:
@@ -248,9 +248,9 @@ To view your generated access keys, navigate to **Users** > **Access Keys**.
     ```
   </TabItem>
 
-  <TabItem value="dedicated" label="Dedicated access">
+  <TabItem value="dedicated" label="Dedicated access key">
 
-    ```yaml title="Dedicated access example"
+    ```yaml title="Dedicated access key example"
     external:
       platform:
     ```


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-690

