### PR TITLE
fix: edits to align GCP docs

### DIFF
--- a/platform/install/environments/gcp.mdx
+++ b/platform/install/environments/gcp.mdx
@@ -20,7 +20,7 @@ import Flow, { Step } from '@site/src/components/Flow';
 import Label from '@site/src/components/Label';
 
 
-This guide provides instructions for deploying the platform on [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine), a managed Kubernetes service on Google Cloud.
+This guide provides instructions for deploying the platform on Google Cloud using [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine).
 
 <!-- vale off -->
 ## Prerequisites

--- a/platform/install/environments/gcp.mdx
+++ b/platform/install/environments/gcp.mdx
@@ -83,7 +83,7 @@ Create the cluster.
   This process typically takes about 10-15 minutes.
   :::
 
-Using default values, this command creates a GKE cluster named `vcluster-demo` in the `europe-west1-b`
+Using the default values, this command creates a GKE cluster named `vcluster-demo` in the `europe-west1-b`
 zone with two nodes of type `e2-standard-4`.
 
 <KubeconfigUpdate />
@@ -232,7 +232,7 @@ kubectl get svc vcluster-platform-loadbalancer -n vcluster-platform
 Navigate to the IP address in your browser `https://<EXTERNAL_IP>`.
 
 :::tip
-The platform uses a self-signed certificate, so you must
+The platform uses a self-signed certificate, so you should
 accept the warning in your browser. For production use, replace the default self-signed certificate with a valid [TLS certificate](/platform/configure/domain#configure-tls).
 :::
 

--- a/platform/install/environments/gcp.mdx
+++ b/platform/install/environments/gcp.mdx
@@ -12,6 +12,8 @@ import BasePrerequisites from '../../_partials/install/base-prerequisites.mdx';
 import InstallCli from '../../../vcluster/_partials/deploy/install-cli.mdx';
 import KubeconfigUpdate from '../../../docs/_partials/kubeconfig_update.mdx';
 import ProAdmonition from '../../../vcluster/_partials/admonitions/pro-admonition.mdx';
+import InterpolatedCodeBlock from "@site/src/components/InterpolatedCodeBlock";
+
 
 import Flow, { Step } from '@site/src/components/Flow';
 
@@ -20,6 +22,7 @@ import Label from '@site/src/components/Label';
 
 This guide provides instructions for deploying the platform on [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine), a managed Kubernetes service on Google Cloud.
 
+<!-- vale off -->
 ## Prerequisites
 
 Ensure you have the following:

--- a/platform/install/environments/gcp.mdx
+++ b/platform/install/environments/gcp.mdx
@@ -176,6 +176,7 @@ When logging in using the UI, provide the following details:
 - **Email** (pre-filled with the address you supplied earlier)
 - **Organization**
 
+
 To log in using the CLI, run the `Login via CLI` command provided above.
 
 This completes the basic platform deployment. For additional configuration and available features, see the [Next steps section](#post-install-steps).

--- a/platform/install/environments/gcp.mdx
+++ b/platform/install/environments/gcp.mdx
@@ -1,8 +1,8 @@
 ---
-title: Deploy vCluster Platform on Google Cloud
-sidebar_label: GCP
+title: Deploy vCluster Platform on Google Cloud using GKE
+sidebar_label: GKE
 sidebar_position: 4
-description: Learn how to deploy and configure vCluster Platform on Google Cloud Platform (GPC)
+description: Learn how to deploy and configure vCluster Platform on Google Cloud with GKE.
 ---
 
 import Image from "@site/src/components/Image";
@@ -18,26 +18,26 @@ import Flow, { Step } from '@site/src/components/Flow';
 import Label from '@site/src/components/Label';
 
 
-This guide provides step-by-step instructions for deploying the platform on [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine).
+This guide provides instructions for deploying the platform on [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine), a managed Kubernetes service on Google Cloud.
 
 ## Prerequisites
 
-Before starting, ensure you have the following tools installed:
+Ensure you have the following:
 <BasePrerequisites />
-- vCluster CLI <InstallCli />
-- [Google Cloud SDK (`gcloud` CLI)](https://cloud.google.com/sdk/docs/install)
-  :::note
-  Ensure you have the necessary IAM permissions to create clusters and manage cloud services.
-  :::
+- vCluster CLI installed: <InstallCli />
+- [Google Cloud SDK (`gcloud` CLI)](https://cloud.google.com/sdk/docs/install) installed.
+:::note
+Ensure you have the necessary IAM permissions to create clusters and manage cloud services.
+:::
 
-## Create GKE cluster
+## Create a GKE cluster
 
 <Flow id="create-gke-cluster">
 
 <Step>
 Prepare the environment.
 
-Start by creating a zonal GKE cluster using the `gcloud` CLI. First, set up your environment variables:
+Start by creating a zonal GKE cluster using the `gcloud` CLI. Set up your environment variables:
 
 :::tip
 Project ID can be found in the Google Cloud Console under the project name.
@@ -45,37 +45,43 @@ Alternatively use `gcloud project list` to list all projects and their IDs.
 To check which project is active, use `gcloud config get-value project`.
 :::
 
-```bash title="Set environment variables"
-export PROJECT_ID=development
-export CLUSTER_NAME=vcluster-demo
-export ZONE=europe-west1-b
-export MACHINE_TYPE=e2-standard-4
-```
+<InterpolatedCodeBlock
+  code={`export PROJECT_ID=[[VAR:PROJECT_ID:development]]
+export CLUSTER_NAME=[[VAR:CLUSTER_NAME:vcluster-demo]]
+export ZONE=[[VAR:ZONE:europe-west1-b]]
+export MACHINE_TYPE=[[VAR:MACHINE_TYPE:e2-standard-4]]`}
+  language="bash"
+  title="Set environment variables"
+/>
 
-Configure `gcloud` and enable the required APIs and set default project:
+Configure `gcloud`, enable the required APIs, and set the default project:
 
-```bash title="Configure gcloud"
-gcloud config set project $PROJECT_ID
-gcloud services enable container.googleapis.com
-```
+<InterpolatedCodeBlock
+  code={`gcloud config set project=[[VAR:PROJECT_ID:your-project-id]]
+gcloud services enable container.googleapis.com`}
+  language="bash"
+  title="Configure gcloud"
+/>
 </Step>
 
 <Step>
 Create the cluster.
 
-```bash title="Create GKE cluster"
-gcloud container clusters create $CLUSTER_NAME \
-    --zone $ZONE \
-    --machine-type $MACHINE_TYPE \
-    --num-nodes 2
-```
+<InterpolatedCodeBlock
+  code={`gcloud container clusters create=[[VAR:CLUSTER_NAME:vcluster-demo]] \\
+    --zone=[[VAR:ZONE:europe-west1-b]] \\
+    --machine-type=[[VAR:MACHINE_TYPE:e2-standard-4]] \\
+    --num-nodes=2`}
+  language="bash"
+  title="Create GKE cluster"
+/>
 
   :::info
   This process typically takes about 10-15 minutes.
   :::
 
-This command creates a GKE cluster named vcluster-demo in the europe-west1-b
-zone with two nodes of type e2-standard-4.
+Using default values, this command creates a GKE cluster named `vcluster-demo` in the `europe-west1-b`
+zone with two nodes of type `e2-standard-4`.
 
 <KubeconfigUpdate />
 
@@ -84,14 +90,15 @@ zone with two nodes of type e2-standard-4.
 <Step>
 Verify the cluster creation.
 
-Verify that the GKE was created successfully by listing the nodes:
+Verify that GKE was created successfully by listing the nodes:
 
 ```bash title="List cluster nodes"
 kubectl get nodes
 ```
 
-You should see output similar to:
-```
+You should see an output similar to the following:
+
+```bash title="Example output"
 NAME           LOCATION        MASTER_VERSION      MASTER_IP      MACHINE_TYPE   NODE_VERSION        NUM_NODES  STATUS
 vcluster-demo  europe-west1-b  1.30.5-gke.1443001  35.187.66.218  e2-standard-4  1.30.5-gke.1443001  2          RUNNING
 ```
@@ -100,50 +107,45 @@ vcluster-demo  europe-west1-b  1.30.5-gke.1443001  35.187.66.218  e2-standard-4 
 
 </Flow>
 
-## Platform setup
+## Set up the platform
 
-With the GKE cluster up and running, you can now deploy the platform in a few
-easy steps.
+After the GKE cluster is running, deploy the platform.
 
-<Flow>
 
 ### Install the platform
 
+<Flow>
 <Step>
-Deploy platform using the vCluster CLI.
-
-Now that you have vCluster running on GKE, set up the [platform
-](/platform/install/quick-start-guide) and configure GPC in the following steps.
-
-Easiest way to deploy a platform is using the `vcluster CLI`
+[Deploy the platform](/platform/install/quick-start-guide) using the vCluster CLI.
 
 :::note idempotency
-Please note that the command is _idempotent_, meaning that running it again does
+The following command is _idempotent_, meaning that running it again does
 not result it creating another cluster with the same name.
 :::
 
-```bash title="deploy the platform using vcluster cli
+```bash title="Deploy the platform using vCluster CLI
 vcluster platform start
 ```
-The command asks you for providing email address for the admin user
 
-```bash title="deployment expected output"
+The command prompts you to enter the email address for the admin user:
+
+```bash title="Expected deployment output"
 By providing your email, you accept our Terms of Service and Privacy Statement:
 Terms of Service: https://www.loft.sh/legal/terms
 Privacy Statement: https://www.loft.sh/legal/privacy
 ? Please specify an email address for the admin user
 ```
 
-:::tip retry
-If the command takes to long to execute, for example due to other cluster
-operations, simply run the command one more time
+:::tip
+If the command takes too long to execute—such as when other cluster operations are in progress—rerun the command.
 :::
+
 </Step>
 
 <Step>
 Connect to the platform.
 
-Once the platform is deployed, default browser with the platform UI opens and you should see the output similar to this:
+After the platform is deployed, your default browser opens with the platform UI, and you should see output similar to the following:
 
 ```bash title="platform deployment output"
 ##########################   LOGIN   ############################
@@ -164,32 +166,34 @@ Thanks for using vCluster Platform!
 - Use `vcluster platform add vcluster` to add an existing virtual cluster to a vCluster platform instance
 ```
 
-When logging in via UI, provide: <Label>First Name</Label>, <Label>Last Name</Label>, <Label>Email</Label> (should default to
-the one supplied earlier) and <Label>Organization</Label>.
+When logging in using the UI, provide the following details:
 
-To login via CLI, simply copy/pasted the `Login via CLI` command.
+- **First Name**
+- **Last Name**
+- **Email** (pre-filled with the address you supplied earlier)
+- **Organization**
 
-This is the basic platform deployment, from there you can refer to the [Next
-steps seciton](#post-install-steps) to learn about platform features.
+To log in using the CLI, run the `Login via CLI` command provided above.
 
-There are a few additional **optional** configuration steps that can be done.
+This completes the basic platform deployment. For additional configuration and available features, see the [Next steps section](#post-install-steps).
 
-- [Expose platform UI via load balancer](#load-balancer)
-- [Setup custom domain and configure DNS](#setup-domain-dns)
+You can _optionally_ perform additional configuration steps:
+
+- [Expose the platform UI using the load balancer](#load-balancer)
+- [Set up a custom domain and configure DNS](#setup-domain-dns)
+
 </Step>
-
 </Flow>
 
+
+### Expose the platform UI using load balancer {#load-balancer}
+
 <Flow>
-
-### [Optional] expose platform UI via load balancer {#load-balancer}
-
 <Step>
-Create a LoadBalancer service to expose the platform UI.
+Optionally, you can expose the platform UI using a LoadBalancer service to make it accessible outside the cluster.
 
 :::note
-Please note that this
-assumes the platform is deployed in the `vcluster-platform` namespace which is a
+This assumes the platform is deployed in the `vcluster-platform` namespace which is a
 default deployment namespace.
 :::
 
@@ -215,71 +219,77 @@ EOF
 </Step>
 
 <Step>
-Once the service is active, obtain the external IP address:
+After the service is active, obtain the external IP address:
 
 ```bash
 kubectl get svc vcluster-platform-loadbalancer -n vcluster-platform
 ```
 
-and navigate to the IP address in your browser `https://<EXTERNAL_IP>`.
+Navigate to the IP address in your browser `https://<EXTERNAL_IP>`.
 
-:::tip certificate
-Note that the platform uses a self-signed certificate, so you need to
-accept the warning in your browser. For production use, you should [replace the certificate with a valid one.](/platform/configure/domain#configure-tls)
+:::tip
+The platform uses a self-signed certificate, so you must
+accept the warning in your browser. For production use, replace the default self-signed certificate with a valid [TLS certificate](/platform/configure/domain#configure-tls).
 :::
 
 </Step>
 
 </Flow>
 
+
+### Set up custom domain and configure DNS {#setup-domain-dns}
+
+Optionally, you can set up a custom domain and configure DNS to provide a secure URL for accessing the platform.
+
 <Flow>
-
-### [Optional] setup custom domain and configure DNS {#setup-domain-dns}
-
 <Step>
-Configure DNS in Google Cloud DNS.
-To use a custom domain, you need to configure the DNS to point to the LoadBalancer IP address.
+[Configure DNS in Google Cloud DNS](https://cloud.google.com/dns/docs/set-up-dns-records-domain-name).
 
-```bash title="Configure DNS"
-EXTERNAL_IP="provide the load balancer external IP"
+To use a custom domain, you must configure the DNS to point to the LoadBalancer IP address.
 
-gcloud dns managed-zones create vcluster-platform --dns-name="yourdomain.tld."
+<InterpolatedCodeBlock
+  code={
+`EXTERNAL_IP=[[VAR:EXTERNAL_IP:load-balancer-external-IP]]
 
-gcloud dns record-sets transaction start --zone=vcluster-platform
+gcloud dns managed-zones create [[VAR:DNS_ZONE_NAME:vcluster-platform]] --dns-name="[[VAR:DOMAIN:yourdomain.tld.]]"
 
-gcloud dns record-sets transaction add "${EXTERNAL_IP}" \
-    --name="vcluster-platform.yourdomain.tld." \
-    --ttl=300 \
-    --type=A \
-    --zone=vcluster-platform
+gcloud dns record-sets transaction start --zone=[[VAR:DNS_ZONE_NAME:vcluster-platform]]
 
-gcloud dns record-sets transaction execute --zone=vcluster-platform
-```
+gcloud dns record-sets transaction add "\${EXTERNAL_IP}" \\
+  --name="[[VAR:FQDN:vcluster-platform.yourdomain.tld.]]" \\
+  --ttl=300 \\
+  --type=A \\
+  --zone=[[VAR:DNS_ZONE_NAME:vcluster-platform]]
+
+gcloud dns record-sets transaction execute --zone=[[VAR:DNS_ZONE_NAME:vcluster-platform]]`}
+  language="bash"
+  title="Configure DNS"
+/>
 </Step>
 
 <Step>
 Connect the platform to the custom domain.
 
-Once the DNS is setup, the platform can be started with the command `vcluster
-platform start --host=vcluster-platform.yourdomain.tld`
+After DNS is set up, you can start the platform using the following command:
+`vcluster platform start --host=vcluster-platform.yourdomain.tld
 
 :::info
-Read more about how to configure a custom [domain](/platform/configure/domain).
+For more information on how to configure a custom domain, see the [Configure external acess and TLS documentation](/platform/configure/domain).
 
-If you do not have a custom domain setup, [follow this
+If you do not have a custom domain setup, follow the [Set up a domain by using Cloud DNS
 tutorial](https://cloud.google.com/dns/docs/tutorials/create-domain-tutorial).
 :::
 
 </Step>
-
 </Flow>
 
 ## Next steps {#post-install-steps}
 
 <InstallNextSteps />
 
-You can also use Google as identity provider and [configure SSO ](/platform/configure/single-sign-on/providers/google)to enable user
+You can also use Google as an identity provider and [configure SSO](/platform/configure/single-sign-on/providers/google) to enable user
 authentication to the platform.
+
 
 ## Cleanup
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Updates to align with EKS docs

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Link to Preview](https://deploy-preview-765--vcluster-docs-site.netlify.app/docs/platform/next/install/environments/gcp)


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

