### PR TITLE
fix: Update and add docs to main for follow up for agent link

### DIFF
--- a/platform/configure/config.mdx
+++ b/platform/configure/config.mdx
@@ -11,13 +11,13 @@ This document explains how to configure the platform, including its operational 
 
 ## Understand platform configuration {#understanding-platform-configuration}
 
-The platform is configured through the `vcluster-platform` Helm chart, which comes from the [loft-sh/loft](https://github.com/loft-sh/loft/tree/master/chart) repository. The default configuration values can be found in the chart's [values.yaml](https://github.com/loft-sh/loft/blob/master/chart/values.yaml) file.
+Configure the platform through the `vcluster-platform` Helm chart, which comes from the [loft-sh/loft](https://github.com/loft-sh/loft/tree/master/chart) repository. Find the default configuration values in the chart's [values.yaml](https://github.com/loft-sh/loft/blob/master/chart/values.yaml) file.
 
-### Types of platform configuration {#types-of-platform-configuration}
+### Identify configuration types {#types-of-platform-configuration}
 
 The platform's `values.yaml` file contains multiple configuration sections:
 
-1. **Installation settings** - Control how the platform is deployed
+1. **Installation settings** - Control how the platform deploys
    - Top-level fields in the `vcluster-platform` chart's `values.yaml`
    - Located in the platform Helm chart ([loft-sh/loft](https://github.com/loft-sh/loft/tree/master/chart))
    - Examples: `replicaCount`, `resources`, `ingress`, `persistence`, etc.
@@ -28,55 +28,56 @@ The platform's `values.yaml` file contains multiple configuration sections:
    - These are grouped under the `config:` section of the `vcluster-platform` chart
    - Located in the platform Helm chart ([loft-sh/loft](https://github.com/loft-sh/loft/tree/master/chart))
    - Examples: `config.auth`, `config.audit`, `config.loftHost`
-   - Can also be managed through the UI in **Admin > Config**
+   - You can also manage these through the UI in **Admin > Config**
 <!-- vale on -->
 
-3. **Agent settings** - Control how the platform agent operates in connected clusters
+3. **Agent settings** - Control how the [platform agent](#work-with-the-platform-agent) operates in connected clusters
    - Set through the top-level `agentValues:` section of the `vcluster-platform` chart
    - Located in the platform Helm chart ([loft-sh/loft](https://github.com/loft-sh/loft/tree/master/chart))
-   - Can be overridden per-cluster with annotations
+   - You can override these per-cluster with annotations
 
-### Difference between values.yaml and config section {#understanding-the-difference}
+### Distinguish between values.yaml and config sections {#understanding-the-difference}
 
-When configuring the platform, it's important to understand the difference between the main `values.yaml` settings and the `config` section inside it:
+When configuring the platform, understand the difference between the main `values.yaml` settings and the `config` section inside it:
 
-- **values.yaml (installation settings)** - Controls **how** the platform itself is installed
+- **values.yaml (installation settings)** - Controls **how** the platform itself installs
   - Affects the Kubernetes resources created during installation
   - Examples: replica count, resource limits, persistence settings, ingress configuration
-  - These options are typically set once during deployment
+  - You typically set these options once during deployment
   - Not accessible through the UI after installation
   - Requires a Helm upgrade to change after initial deployment
 
 <!-- vale off -->
 - **config section** - Controls **what** the platform does after installation
   - Located in the `vcluster-platform` chart's `values.yaml` as the `config:` key
-  - Defined in [loft-sh/loft/chart/values.yaml](https://github.com/loft-sh/loft/blob/07ee94fecd7265607f6c4a3ec42b14d3ef87391f/chart/values.yaml#L167)
+  - Defined in [`loft-sh/loft/chart/values.yaml`](https://github.com/loft-sh/loft/blob/07ee94fecd7265607f6c4a3ec42b14d3ef87391f/chart/values.yaml#L167)
   - Stores settings in a dedicated Kubernetes resource that persists across platform upgrades
   - Contains settings that the platform reads and applies at runtime
   - Affects the platform's behavior, features, and integrations
   - Examples: authentication options, audit settings, UI customization
-  - Can be changed any time through the UI in **Admin > Config**
+  - You can change these any time through the UI in **Admin > Config**
   - Changes are detected and applied without requiring a restart or redeployment
 <!-- vale on -->
 
-#### Common configuration tasks {#common-configuration-tasks}
+#### Complete common configuration tasks {#common-configuration-tasks}
 
-For common tasks, here's which part to configure:
+For common tasks, configure the following:
 
 | Task | Configuration location | Example |
 |------|------------------------|---------|
-| Setting admin credentials | `admin:` section (top-level) | `admin.username`, `admin.password` |
-| Configuring replicas for HA | `replicaCount:` (top-level) | `replicaCount: 2` |
-| Setting up ingress | `ingress:` section (top-level) | `ingress.enabled: true` |
+| Setting admin credentials | `admin:` section (root level) | `admin.username`, `admin.password` |
+| Configuring replicas for HA | `replicaCount:` setting (root level) | `replicaCount: 2` |
+| Setting up ingress | `ingress:` section (root level) | `ingress.enabled: true` |
+| Setting resource limits | `resources:` section (root level) | `resources.limits.memory` |
 | Configuring auth providers | `config.auth:` section | `config.auth.github` |
 | Setting custom domain | `config:` section | `config.loftHost` |
-| Resource limits | `resources:` section (top-level) | `resources.limits.memory` |
 
-### Platform configuration example {#platform-configuration-example}
+### Review platform configuration example {#platform-configuration-example}
 
-Here's an example of a platform `values.yaml` file showing all these configuration sections:
+The following example is of a platform `values.yaml` file showing the configuration sections:
 
-```yaml title="Platform values.yaml structure"
+```yaml title="Example platform values.yaml with all configuration sections"
+
 # Installation settings (top-level)
 replicaCount: 2
 resources:
@@ -114,7 +115,7 @@ config:
 ## Apply configuration {#applying-configuration}
 
 <!-- vale off -->
-The platform configuration can be applied in two ways:
+Apply the platform configuration in two ways:
 - Through `helm` values when installing or upgrading the platform
 - Through the UI in **Admin > Config** after installation (operational settings only)
 <!-- vale on -->
@@ -123,7 +124,7 @@ Using `helm` values allows you to manage configuration declaratively and enables
 
 Here's an example of applying platform configuration with `helm`:
 
-```bash title="Apply configuration with Helm"
+```bash title="Apply platform configuration using Helm"
 RELEASE_NAME=vcluster-platform
 RELEASE_NAMESPACE=vcluster-platform
 PLATFORM_VERSION='' # Set this to a specific version or leave empty for latest
@@ -139,34 +140,34 @@ helm upgrade $RELEASE_NAME vcluster-platform \
 
 ## Set a custom domain {#setting-a-custom-domain}
 
-A critical configuration setting is the `loftHost` variable, which defines the domain where users access the platform.
+The `loftHost` variable is a critical configuration setting that defines the domain where users access the platform.
 
-### When to set this value {#when-to-set-this-value}
+### Determine when to set this value {#when-to-set-this-value}
 
 Set the `loftHost` value after:
 1. Installing the platform
 2. Configuring TLS certificates
 3. Setting up ingress with a [custom domain](./domain.mdx)
 
-### What to set {#what-to-set}
+### Define what to set {#what-to-set}
 
 The `loftHost` value should be:
 - The same hostname specified in your ingress resource
 - Only the hostname (e.g., `platform.example.com`)
-- Not contain protocols (e.g., no `https://`)
-- Not contain subpaths (e.g., no `/platform`)
+- Without protocols (e.g., no `https://`)
+- Without subpaths (e.g., no `/platform`)
 
-```yaml title="Setting a custom domain"
+```yaml title="Configure custom domain in platform config"
 config:
   loftHost: platform.example.com
 ```
 
-### After changing the domain {#after-changing-the-domain}
+### Reconnect clusters after changing the domain {#after-changing-the-domain}
 
 After updating the `loftHost` value, you must reconnect all clusters to the platform by running the same connection commands in each Kubernetes context. See [connecting clusters](../administer/clusters/connect-cluster.mdx) for detailed instructions.
 
 :::info Important
-Clusters must also be reconnected if you change the `additionalCA` or `insecureSkipVerify` values after the initial setup.
+You must also reconnect clusters if you change the `additionalCA` or `insecureSkipVerify` values after the initial setup.
 :::
 
 ## Manage sensitive information {#managing-sensitive-information}
@@ -177,7 +178,7 @@ Many configuration options require sensitive information such as API keys or tok
 
 To securely provide sensitive information, store it in a Kubernetes secret and reference it in your configuration:
 
-```yaml title="Securely managing sensitive configuration"
+```yaml title="Store sensitive values using Kubernetes secrets"
 # Secret references
 envValueFrom:
   CLIENT_ID:
@@ -198,7 +199,7 @@ config:
       redirectURI: https://my-platform.example.com/auth/github/callback
 ```
 
-## Custom HTTP headers {#custom-http-headers}
+## Configure custom HTTP headers {#custom-http-headers}
 
 You can configure the platform to add custom HTTP headers to all API responses. This is useful for security-related headers or when integrating with specific environments.
 
@@ -211,7 +212,7 @@ config:
       Content-Security-Policy: default-src 'self'
 ```
 
-## Certificate management {#certificate-management}
+## Manage certificates {#certificate-management}
 
 ### Use a custom certificate authority {#using-a-custom-certificate-authority}
 
@@ -245,20 +246,22 @@ vcluster platform add vcluster <VCLUSTER_NAME> \
 --ca-data <BASE64_CA_VALUE>
 ```
 
-The imported virtual cluster restarts and report `Ready` once it establishes a secure connection to the platform.
+The imported virtual cluster restarts and reports `Ready` once it establishes a secure connection to the platform.
 
-## The platform agent {#the-platform-agent}
+## Work with the platform agent {#the-platform-agent}
 
-### What is the platform agent? {#what-is-the-platform-agent}
+### Understand what the platform agent does {#what-is-the-platform-agent}
 
 The platform agent is a component that runs in each connected Kubernetes cluster. It handles:
 - Cluster resource management
 - Communication with the platform
 - Reconciliation of cluster-scoped resources
 
+:::important
 Every cluster connected to the platform, including the cluster where the platform itself runs, must have the platform agent installed.
+:::
 
-### Default agent deployment {#default-agent-deployment}
+### Use default agent deployment {#default-agent-deployment}
 
 By default, the platform automatically installs the agent in:
 1. The cluster where the platform is deployed
@@ -282,7 +285,7 @@ env:
 Even if you disable automatic deployment, the platform agent is still required in every connected cluster. You must deploy it manually or through GitOps tools.
 :::
 
-### Manual agent installation {#manual-agent-installation}
+### Install the agent manually {#manual-agent-installation}
 
 To manually install the platform agent:
 
@@ -300,21 +303,21 @@ helm upgrade $RELEASE_NAME vcluster-platform \
   ${PLATFORM_VERSION:+--version $PLATFORM_VERSION}
 ```
 
-## Agent configuration {#agent-configuration}
+## Configure the agent {#agent-configuration}
 
 ### Understand agent values {#understanding-agent-values}
 
-The platform agent uses its own set of configuration values, which can be specified in several ways:
+The platform agent uses its own set of configuration values, which you can specify in several ways:
 
-1. **Default behavior**: By default, the agent inherits values from the platform configuration
-2. **Global agent values**: The `agentValues:` section in the platform `values.yaml` specifies default values for all agents
-3. **Cluster-specific values**: The `loft.sh/agent-values` annotation on a Cluster resource overrides global values for that specific cluster
+1. **Default behavior**: By default, the agent inherits values from the platform configuration.
+2. **Global agent values**: The `agentValues:` section in the platform `values.yaml` specifies default values for all agents.
+3. **Cluster-specific values**: The `loft.sh/agent-values` annotation on a Cluster resource overrides global values for that specific cluster.
 
 When the platform upgrades an agent, it uses the values from the `agentValues` section (or from the cluster annotation if present).
 
 ### Configure the agent through the platform {#configuring-the-agent-through-the-platform}
 
-To customize the agent configuration when it's deployed by the platform, use the `agentValues` section in your platform configuration:
+To customize the agent configuration when deployed by the platform, use the `agentValues` section in your platform configuration:
 
 ```yaml title="Customizing agent configuration"
 # Agent-specific configuration - top-level setting, not in config: section
@@ -333,11 +336,11 @@ agentValues:
       memory: 128Mi
 ```
 
-### Cluster-specific agent configuration {#cluster-specific-agent-configuration}
+### Configure cluster-specific agents {#cluster-specific-agent-configuration}
 
 To apply different configuration to the agent in specific clusters, set the `loft.sh/agent-values` annotation on the Cluster resource. These values override any settings from the platform's `agentValues`.
 
-## Configuration reference {#configuration-reference}
+## Review configuration reference {#configuration-reference}
 
 For a complete reference of all platform configuration options under the `config:` section, see below:
 

--- a/platform_versioned_docs/version-4.3.0/configure/config.mdx
+++ b/platform_versioned_docs/version-4.3.0/configure/config.mdx
@@ -11,13 +11,13 @@ This document explains how to configure the platform, including its operational 
 
 ## Understand platform configuration {#understanding-platform-configuration}
 
-The platform is configured through the `vcluster-platform` Helm chart, which comes from the [loft-sh/loft](https://github.com/loft-sh/loft/tree/master/chart) repository. The default configuration values can be found in the chart's [values.yaml](https://github.com/loft-sh/loft/blob/master/chart/values.yaml) file.
+Configure the platform through the `vcluster-platform` Helm chart, which comes from the [loft-sh/loft](https://github.com/loft-sh/loft/tree/master/chart) repository. Find the default configuration values in the chart's [values.yaml](https://github.com/loft-sh/loft/blob/master/chart/values.yaml) file.
 
-### Types of platform configuration {#types-of-platform-configuration}
+### Identify configuration types {#types-of-platform-configuration}
 
 The platform's `values.yaml` file contains multiple configuration sections:
 
-1. **Installation settings** - Control how the platform is deployed
+1. **Installation settings** - Control how the platform deploys
    - Top-level fields in the `vcluster-platform` chart's `values.yaml`
    - Located in the platform Helm chart ([loft-sh/loft](https://github.com/loft-sh/loft/tree/master/chart))
    - Examples: `replicaCount`, `resources`, `ingress`, `persistence`, etc.
@@ -28,55 +28,56 @@ The platform's `values.yaml` file contains multiple configuration sections:
    - These are grouped under the `config:` section of the `vcluster-platform` chart
    - Located in the platform Helm chart ([loft-sh/loft](https://github.com/loft-sh/loft/tree/master/chart))
    - Examples: `config.auth`, `config.audit`, `config.loftHost`
-   - Can also be managed through the UI in **Admin > Config**
+   - You can also manage these through the UI in **Admin > Config**
 <!-- vale on -->
 
-3. **Agent settings** - Control how the platform agent operates in connected clusters
+3. **Agent settings** - Control how the [platform agent](#work-with-the-platform-agent) operates in connected clusters
    - Set through the top-level `agentValues:` section of the `vcluster-platform` chart
    - Located in the platform Helm chart ([loft-sh/loft](https://github.com/loft-sh/loft/tree/master/chart))
-   - Can be overridden per-cluster with annotations
+   - You can override these per-cluster with annotations
 
-### Difference between values.yaml and config section {#understanding-the-difference}
+### Distinguish between values.yaml and config sections {#understanding-the-difference}
 
-When configuring the platform, it's important to understand the difference between the main `values.yaml` settings and the `config` section inside it:
+When configuring the platform, understand the difference between the main `values.yaml` settings and the `config` section inside it:
 
-- **values.yaml (installation settings)** - Controls **how** the platform itself is installed
+- **values.yaml (installation settings)** - Controls **how** the platform itself installs
   - Affects the Kubernetes resources created during installation
   - Examples: replica count, resource limits, persistence settings, ingress configuration
-  - These options are typically set once during deployment
+  - You typically set these options once during deployment
   - Not accessible through the UI after installation
   - Requires a Helm upgrade to change after initial deployment
 
 <!-- vale off -->
 - **config section** - Controls **what** the platform does after installation
   - Located in the `vcluster-platform` chart's `values.yaml` as the `config:` key
-  - Defined in [loft-sh/loft/chart/values.yaml](https://github.com/loft-sh/loft/blob/07ee94fecd7265607f6c4a3ec42b14d3ef87391f/chart/values.yaml#L167)
+  - Defined in [`loft-sh/loft/chart/values.yaml`](https://github.com/loft-sh/loft/blob/07ee94fecd7265607f6c4a3ec42b14d3ef87391f/chart/values.yaml#L167)
   - Stores settings in a dedicated Kubernetes resource that persists across platform upgrades
   - Contains settings that the platform reads and applies at runtime
   - Affects the platform's behavior, features, and integrations
   - Examples: authentication options, audit settings, UI customization
-  - Can be changed any time through the UI in **Admin > Config**
+  - You can change these any time through the UI in **Admin > Config**
   - Changes are detected and applied without requiring a restart or redeployment
 <!-- vale on -->
 
-#### Common configuration tasks {#common-configuration-tasks}
+#### Complete common configuration tasks {#common-configuration-tasks}
 
-For common tasks, here's which part to configure:
+For common tasks, configure the following:
 
 | Task | Configuration location | Example |
 |------|------------------------|---------|
-| Setting admin credentials | `admin:` section (top-level) | `admin.username`, `admin.password` |
-| Configuring replicas for HA | `replicaCount:` (top-level) | `replicaCount: 2` |
-| Setting up ingress | `ingress:` section (top-level) | `ingress.enabled: true` |
+| Setting admin credentials | `admin:` section (root level) | `admin.username`, `admin.password` |
+| Configuring replicas for HA | `replicaCount:` setting (root level) | `replicaCount: 2` |
+| Setting up ingress | `ingress:` section (root level) | `ingress.enabled: true` |
+| Setting resource limits | `resources:` section (root level) | `resources.limits.memory` |
 | Configuring auth providers | `config.auth:` section | `config.auth.github` |
 | Setting custom domain | `config:` section | `config.loftHost` |
-| Resource limits | `resources:` section (top-level) | `resources.limits.memory` |
 
-### Platform configuration example {#platform-configuration-example}
+### Review platform configuration example {#platform-configuration-example}
 
-Here's an example of a platform `values.yaml` file showing all these configuration sections:
+The following example is of a platform `values.yaml` file showing the configuration sections:
 
-```yaml title="Platform values.yaml structure"
+```yaml title="Example platform values.yaml with all configuration sections"
+
 # Installation settings (top-level)
 replicaCount: 2
 resources:
@@ -114,7 +115,7 @@ config:
 ## Apply configuration {#applying-configuration}
 
 <!-- vale off -->
-The platform configuration can be applied in two ways:
+Apply the platform configuration in two ways:
 - Through `helm` values when installing or upgrading the platform
 - Through the UI in **Admin > Config** after installation (operational settings only)
 <!-- vale on -->
@@ -123,7 +124,7 @@ Using `helm` values allows you to manage configuration declaratively and enables
 
 Here's an example of applying platform configuration with `helm`:
 
-```bash title="Apply configuration with Helm"
+```bash title="Apply platform configuration using Helm"
 RELEASE_NAME=vcluster-platform
 RELEASE_NAMESPACE=vcluster-platform
 PLATFORM_VERSION='' # Set this to a specific version or leave empty for latest
@@ -139,34 +140,34 @@ helm upgrade $RELEASE_NAME vcluster-platform \
 
 ## Set a custom domain {#setting-a-custom-domain}
 
-A critical configuration setting is the `loftHost` variable, which defines the domain where users access the platform.
+The `loftHost` variable is a critical configuration setting that defines the domain where users access the platform.
 
-### When to set this value {#when-to-set-this-value}
+### Determine when to set this value {#when-to-set-this-value}
 
 Set the `loftHost` value after:
 1. Installing the platform
 2. Configuring TLS certificates
 3. Setting up ingress with a [custom domain](./domain.mdx)
 
-### What to set {#what-to-set}
+### Define what to set {#what-to-set}
 
 The `loftHost` value should be:
 - The same hostname specified in your ingress resource
 - Only the hostname (e.g., `platform.example.com`)
-- Not contain protocols (e.g., no `https://`)
-- Not contain subpaths (e.g., no `/platform`)
+- Without protocols (e.g., no `https://`)
+- Without subpaths (e.g., no `/platform`)
 
-```yaml title="Setting a custom domain"
+```yaml title="Configure custom domain in platform config"
 config:
   loftHost: platform.example.com
 ```
 
-### After changing the domain {#after-changing-the-domain}
+### Reconnect clusters after changing the domain {#after-changing-the-domain}
 
 After updating the `loftHost` value, you must reconnect all clusters to the platform by running the same connection commands in each Kubernetes context. See [connecting clusters](../administer/clusters/connect-cluster.mdx) for detailed instructions.
 
 :::info Important
-Clusters must also be reconnected if you change the `additionalCA` or `insecureSkipVerify` values after the initial setup.
+You must also reconnect clusters if you change the `additionalCA` or `insecureSkipVerify` values after the initial setup.
 :::
 
 ## Manage sensitive information {#managing-sensitive-information}
@@ -177,7 +178,7 @@ Many configuration options require sensitive information such as API keys or tok
 
 To securely provide sensitive information, store it in a Kubernetes secret and reference it in your configuration:
 
-```yaml title="Securely managing sensitive configuration"
+```yaml title="Store sensitive values using Kubernetes secrets"
 # Secret references
 envValueFrom:
   CLIENT_ID:
@@ -198,7 +199,7 @@ config:
       redirectURI: https://my-platform.example.com/auth/github/callback
 ```
 
-## Custom HTTP headers {#custom-http-headers}
+## Configure custom HTTP headers {#custom-http-headers}
 
 You can configure the platform to add custom HTTP headers to all API responses. This is useful for security-related headers or when integrating with specific environments.
 
@@ -211,7 +212,7 @@ config:
       Content-Security-Policy: default-src 'self'
 ```
 
-## Certificate management {#certificate-management}
+## Manage certificates {#certificate-management}
 
 ### Use a custom certificate authority {#using-a-custom-certificate-authority}
 
@@ -245,20 +246,22 @@ vcluster platform add vcluster <VCLUSTER_NAME> \
 --ca-data <BASE64_CA_VALUE>
 ```
 
-The imported virtual cluster restarts and report `Ready` once it establishes a secure connection to the platform.
+The imported virtual cluster restarts and reports `Ready` once it establishes a secure connection to the platform.
 
-## The platform agent {#the-platform-agent}
+## Work with the platform agent {#the-platform-agent}
 
-### What is the platform agent? {#what-is-the-platform-agent}
+### Understand what the platform agent does {#what-is-the-platform-agent}
 
 The platform agent is a component that runs in each connected Kubernetes cluster. It handles:
 - Cluster resource management
 - Communication with the platform
 - Reconciliation of cluster-scoped resources
 
+:::important
 Every cluster connected to the platform, including the cluster where the platform itself runs, must have the platform agent installed.
+:::
 
-### Default agent deployment {#default-agent-deployment}
+### Use default agent deployment {#default-agent-deployment}
 
 By default, the platform automatically installs the agent in:
 1. The cluster where the platform is deployed
@@ -282,7 +285,7 @@ env:
 Even if you disable automatic deployment, the platform agent is still required in every connected cluster. You must deploy it manually or through GitOps tools.
 :::
 
-### Manual agent installation {#manual-agent-installation}
+### Install the agent manually {#manual-agent-installation}
 
 To manually install the platform agent:
 
@@ -300,21 +303,21 @@ helm upgrade $RELEASE_NAME vcluster-platform \
   ${PLATFORM_VERSION:+--version $PLATFORM_VERSION}
 ```
 
-## Agent configuration {#agent-configuration}
+## Configure the agent {#agent-configuration}
 
 ### Understand agent values {#understanding-agent-values}
 
-The platform agent uses its own set of configuration values, which can be specified in several ways:
+The platform agent uses its own set of configuration values, which you can specify in several ways:
 
-1. **Default behavior**: By default, the agent inherits values from the platform configuration
-2. **Global agent values**: The `agentValues:` section in the platform `values.yaml` specifies default values for all agents
-3. **Cluster-specific values**: The `loft.sh/agent-values` annotation on a Cluster resource overrides global values for that specific cluster
+1. **Default behavior**: By default, the agent inherits values from the platform configuration.
+2. **Global agent values**: The `agentValues:` section in the platform `values.yaml` specifies default values for all agents.
+3. **Cluster-specific values**: The `loft.sh/agent-values` annotation on a Cluster resource overrides global values for that specific cluster.
 
 When the platform upgrades an agent, it uses the values from the `agentValues` section (or from the cluster annotation if present).
 
 ### Configure the agent through the platform {#configuring-the-agent-through-the-platform}
 
-To customize the agent configuration when it's deployed by the platform, use the `agentValues` section in your platform configuration:
+To customize the agent configuration when deployed by the platform, use the `agentValues` section in your platform configuration:
 
 ```yaml title="Customizing agent configuration"
 # Agent-specific configuration - top-level setting, not in config: section
@@ -333,11 +336,11 @@ agentValues:
       memory: 128Mi
 ```
 
-### Cluster-specific agent configuration {#cluster-specific-agent-configuration}
+### Configure cluster-specific agents {#cluster-specific-agent-configuration}
 
 To apply different configuration to the agent in specific clusters, set the `loft.sh/agent-values` annotation on the Cluster resource. These values override any settings from the platform's `agentValues`.
 
-## Configuration reference {#configuration-reference}
+## Review configuration reference {#configuration-reference}
 
 For a complete reference of all platform configuration options under the `config:` section, see below:
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Just update for doc as follow up

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-610

