### PR TITLE
fix: Follow up for private node vale

### DIFF
--- a/vcluster/_fragments/private-nodes.mdx
+++ b/vcluster/_fragments/private-nodes.mdx
@@ -1,4 +1,3 @@
-
 import PrivateNodes from '../_partials/config/privateNodes.mdx'
 import AutoUpgrade from '../_partials/config/privateNodes/autoUpgrade.mdx'
 import Networking from '../_partials/config/networking.mdx'
@@ -7,9 +6,20 @@ import ProAdmonition from '../_partials/admonitions/pro-admonition.mdx'
 
 <ProAdmonition/>
 
-Using private nodes is another use case for vCluster, where instead of taking advantage of sharing worker nodes of a host cluster, you dedicate worker nodes to be bound to a single vCluster. In this use case, the control plane still runs as a pod in a host cluster and there is no ability to use the worker nodes of the host cluster. Instead, dedicated worker nodes need to be added to the vCluster before being able to deploy resources. Since the dedicated worker nodes are real nodes, there is no need to "sync" resources to the physical node as that node is treated as the virtual cluster's worker node. Another way to think about this use case is that the control plane runs as a pod on a host cluster creating a virtual cluster context, but the workers nodes are private physical nodes in that virtual cluster context. One of the benefits of adding private nodes to a vCluster is that vCluster can automatically manage the lifecycle of the worker node.
+## Use private nodes
 
-To allow nodes to join the virtual cluster, the virtual cluster needs to be exposed and accessible. One option is to expose a LoadBalancer use this endpoint for the worker nodes. vCluster does not need to reach the nodes directly and instead uses [konnectivity](https://kubernetes.io/docs/tasks/extend-kubernetes/setup-konnectivity/) to tunnel requests from the vCluster to the nodes (e.g. for `kubectl logs` etc.).
+Using private nodes is a deployment mode for vCluster where, instead of sharing the host cluster’s worker nodes, you assign dedicated worker nodes to a single vCluster instance.
+
+In this setup, the control plane runs as a Pod in the host cluster, but host cluster worker nodes are not used for scheduling workloads. Instead, you must attach dedicated physical nodes to the vCluster. These private nodes act as the vCluster’s worker nodes and are treated as part of the virtual cluster environment.
+
+Because the dedicated nodes are real Kubernetes nodes, vCluster does not need to sync workloads to the host. All workloads run directly on the attached nodes as if they were native to the virtual cluster.
+
+This approach can be understood as follows: the control plane runs in the host cluster, creating a virtual Kubernetes context, while the workloads run on separate physical nodes that exist entirely within that virtual context.
+
+One key benefit of using private nodes is that vCluster can automatically manage the lifecycle of the worker nodes.
+
+To allow nodes to join the virtual cluster, the cluster must be exposed and accessible. One option is to expose a `LoadBalancer` service and use its endpoint for the worker nodes. vCluster does not need direct access to the nodes; instead, it uses [Konnectivity](https://kubernetes.io/docs/tasks/extend-kubernetes/setup-konnectivity/) to tunnel requests—such as `kubectl logs`—from the control plane to the nodes.
+
 
 <br />
 
@@ -21,55 +31,51 @@ alt="Overview"
 />
 </center>
 
-## Comparison Private Nodes vs Resource Syncing
+## Compare private nodes and resource syncing
 
-For an overview of what is possible with private nodes mode vs regular resource syncing, see the following table:
+The following table outlines the differences between using private nodes and using resource syncing: 
 
-<br />
+| Feature                            | Private Nodes | Resource Syncing |
+|------------------------------------|---------------|------------------|
+| Control plane runs as Pods         | Yes           | Yes              |
+| Isolated control plane             | Yes           | Yes              |
+| Install custom CNI                 | Yes           | No               |
+| Install custom CSI drivers         | Yes           | No               |
+| Separate network                   | Yes           | No               |
+| Completely isolated nodes          | Yes           | No               |
+| Reuse host nodes                   | No            | Yes              |
+| Reuse host controllers             | No            | Yes              |
+| View vCluster resources in host    | No            | Yes              |
 
-|  | Private Nodes | Resource Syncing |
-|---|---|---|
-| Control Plane as Pods | Yes | Yes |
-| Isolated Control Plane | Yes | Yes |
-| Install Custom CNI | Yes | No |
-| Install Custom CSI Drivers | Yes | No |
-| Separate Network | Yes | No |
-| Completely Isolated Nodes | Yes | No |
-| Reuse Host Nodes | No | Yes |
-| Reuse Host Controllers | No | Yes |
-| See vCluster Resources in Host Cluster | No | Yes |
+## Configure vcluster.yaml behavior
 
-## vcluster.yaml behavior
+### Enable scheduling
 
-### Enable Scheduling
+When private nodes are enabled, scheduling is handled by the virtual cluster. As a result, the virtual scheduler is automatically enabled. You do not need to manually configure this in your `vcluster.yaml`.
 
-By enabling private nodes, scheduling must now be owned by the virtual cluster, and therefore, the virtual scheduler is automatically enabled. This yaml doesn't need to be included in your `vcluster.yaml`. 
-
-```yaml
+```yaml title="Virtual scheduler automatically enabled with private nodes"
 # Enabling private nodes enables the virtual scheduler
 # Disabling the virtual scheduler is not possible
 controlPlane:
   advanced:
     virtualScheduler:
       enabled: true
-
 ```
 
-### Other Feature Limitations
+### Understand feature limitations
 
 When private nodes are enabled, the following `vcluster.yaml` options are no longer supported.
 
-```yaml
+```yaml title="Unsupported vcluster.yaml options with private nodes"
 # No syncing is supported
 sync:
 
 # No integration is supported as integrations rely on syncing
 integrations:
 
-# No services will be replicated
+# No services are replicated
 networking:
   replicateServices:
-
 
 controlPlane:
   distro:
@@ -86,11 +92,11 @@ controlPlane:
       enabled: false
 ```
 
-## Create vCluster with Private Nodes
+## Create vCluster with private nodes
 
-To create a virtual cluster with private nodes, it's as simple as enabling the feature. 
+To create a virtual cluster with private nodes, enable the feature:
 
-```yaml
+```yaml title="Enable private nodes in vCluster configuration"
 # Enable private nodes
 privateNodes:
   enabled: true
@@ -113,32 +119,34 @@ networking:
   serviceCIDR: 10.128.0.0/16
 ```
 
-:::info Connecting to the Platform
-Follow [this guide](https://www.vcluster.com/docs/vcluster/next/configure/vcluster-yaml/external/platform/api-key#connect-virtual-clusters-to-the-vcluster-platform) to create an access key and setup the vCluster for deployment via Helm or other tools.
+:::info Connecting to the platform
+Follow [this guide](https://www.vcluster.com/docs/vcluster/next/configure/vcluster-yaml/external/platform/api-key#connect-virtual-clusters-to-the-vcluster-platform) to create an access key and set up the vCluster for deployment using Helm or other tools.
 :::
 
-## Joining Worker Nodes into the vCluster
+## Join worker nodes to the vCluster
 
 vCluster currently supports two modes of joining nodes into it:
-* Automatically via [cluster api](https://github.com/kubernetes-sigs/cluster-api)
-* Manually via [kubeadm](https://kubernetes.io/docs/reference/setup-tools/kubeadm/)
+- Automatically using the [Cluster API](https://github.com/kubernetes-sigs/cluster-api)
+- Manually using [`kubeadm`](https://kubernetes.io/docs/reference/setup-tools/kubeadm/)
 
-### Join Worker Node via Kubeadm
+### Join worker nodes using kubeadm
 
-Before you can join actual nodes into the vCluster, first you need to create a token for the nodes to join. You can either use a single token for all nodes or create a token per node, this is up to you.
+Before you can join actual nodes into the vCluster, you must create a token for the nodes to join. You can either use a single token for all nodes or create a token for each node.
 
-To create a new token, simply run the following command while connected to the vCluster:
-```bash
+To create a new token, run the following command while connected to the vCluster:
+
+```bash title="Create a join token for worker nodes"
 vcluster token create
 ```
 
-This will print a command similar to:
-```bash
+The output is similar to the following:
+```bash title="Example join command output"
 curl -sfLk https://<vcluster-endpoint>/node/join?token=<token> | sh -
 ```
 
-Simply run the command to join a node into the vCluster:
-```bash
+Run the command to join a node into the vCluster:
+
+```bash title="Example successful node join output"
 Preparing node for Kubernetes installation...
 Kubernetes version: v1.30.1
 Installing Kubernetes binaries...
@@ -158,68 +166,77 @@ Joining node into cluster...
 
 This node has joined the cluster:
 * Certificate signing request was sent to apiserver and a response was received.
-* The Kubelet was informed of the new secure connection details.
+* The kubelet was informed of the new secure connection details.
 
 Run 'kubectl get nodes' on the control-plane to see this node join the cluster.
 ```
 
 :::info Using vanilla kubeadm
-If you want to see the raw kubeadm join command you can use the `--kubeadm` flag instead.
+To view the raw `kubeadm join` command, use the `--kubeadm` flag.
 :::
 
-### Join Worker Nodes via Cluster API
+### Join worker nodes using the Cluster API
 
-For automatically joining nodes via Cluster API, please setup the cluster via the following command to install the [vCluster Cluster API provider](https://github.com/loft-sh/cluster-api-provider-vcluster):
-```yaml
+For automatically joining nodes using the Cluster API, set up the cluster using the following command to install the [vCluster Cluster API provider](https://github.com/loft-sh/cluster-api-provider-vcluster):
+
+```bash title="Initialize Cluster API with vCluster provider"
 clusterctl init --infrastructure vcluster
 ```
 
-As soon as the cluster-api provider is running, you can install a provider to do the actual node creation, e.g. KubeVirt.
-```bash
+As soon as the Cluster API provider is running, you can install a provider to handle node creation—for example, KubeVirt.
+
+```bash title="Generate cluster configuration with KubeVirt"
 VCLUSTER_VERSION=v0.26.0-alpha.9
 
-clusterctl generate cluster test --kubernetes-version v1.31.2 -n test --from https://raw.githubusercontent.com/loft-sh/cluster-api-provider-vcluster/refs/heads/main/hack/kubevirt/template.yaml
+clusterctl generate cluster test \
+  --kubernetes-version v1.31.2 \
+  -n test \
+  --from https://raw.githubusercontent.com/loft-sh/cluster-api-provider-vcluster/refs/heads/main/hack/kubevirt/template.yaml
 ```
 
-Then apply the manifests to the cluster and Cluster API should create the vCluster and join the worker nodes via the KubeVirt provider.
+Then apply the manifests to the cluster and Cluster API should create the vCluster and join the worker nodes using the KubeVirt provider.
 
-## vCluster Control Plane upgrades
+## Upgrade vCluster control plane
 
 :::warning Kubernetes Version Skew Policy applies
-Keep in mind to not upgrade multiple minor versions at the same time for the control plane as outlined in the [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/). Instead always upgrade a single minor version, wait until the cluster becomes healthy and then upgrade to the next minor version. E.g. v1.26 -> v1.27 -> v1.28
+Do not upgrade multiple minor versions at the same time for the control plane as outlined in the [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/). Instead always upgrade a single minor version, wait until the cluster becomes healthy and then upgrade to the next minor version. For example: `v1.26` -> `v1.27` -> `v1.28`.
 :::
 
-Upgrading the vCluster control plane is super simple and only requires exchanging the Kubernetes init container version, vCluster will then automatically upgrade the control plane and if configured automatically upgrade all the worker nodes. To exchange the Kubernetes version, specify the following in your `vcluster.yaml`:
-```yaml
+To upgrade the vCluster control plane, update the Kubernetes `init` container version in your `vcluster.yaml` file.
+After the change, vCluster upgrades the control plane automatically. If automatic worker node upgrades are configured, those nodes are also upgraded.
+
+To change the Kubernetes version, add the following to your `vcluster.yaml`:
+
+```yaml title="Upgrade control plane Kubernetes version"
 ...
 controlPlane:
   statefulSet:
     image:
-      tag: v1.31.1 # or any other kubernetes version
+      tag: v1.31.1 # Or any other Kubernetes version
 ...
 ```
 
-## vCluster Worker upgrades
+## Upgrade vCluster workers
 
 :::warning Kubernetes Version Skew Policy applies
-Keep in mind to follow the [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/) for worker upgrades.
+Use the [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/) for worker upgrades.
 :::
 
-There is two modes of how worker upgrades can be done:
-* Automatically by vCluster when the control-plane was updated (recommended)
-* Manually via vCluster CLI or kubeadm
+There are two modes of how worker upgrades can be done:
+- (_Recommended_) Automatically by vCluster when the control-plane was updated
+- Manually using vCluster CLI or kubeadm
 
-### Automatic Upgrades by vCluster
+### Use automatic upgrades
 
-Automatic worker node upgrades are enabled by default and vCluster will try to upgrade nodes as soon as it detects a mismatch between control-plane and worker nodes. By default vCluster will upgrade a single node at a time.
+Automatic worker node upgrades are enabled by default. vCluster upgrades each node when it detects a version mismatch between the control plane and the worker node. By default, one node is upgraded at a time.
 
-The upgrade pod will run directly on the node and do the following steps on the node:
+The upgrade Pod runs directly on the node and completes the following steps:
 1. Download the Kubernetes binary bundle from the vCluster control plane
-2. Exchange kubeadm binary
-3. Run kubeadm upgrade node
+2. Replace the `kubeadm` binary
+3. Run `kubeadm upgrade node`
 4. Cordon the node
-5. Exchange other binaries such as containerd, kubelet etc.
-6. Restart containerd and kubelet if needed
+5. Replace other binaries such as `containerd`, `kubelet`, etc.
+6. Restart `containerd` and `kubelet` if necessary
 7. Uncordon the node
 
 You can also skip specific nodes from the automatic update by adding the label `vcluster.loft.sh/skip-auto-upgrade=true` on the node or specifying a `nodeSelector` via the vCluster config.
@@ -227,24 +244,28 @@ You can also skip specific nodes from the automatic update by adding the label `
 <AutoUpgrade />
 
 :::warning 
-Node upgrades usually shouldn't restart any pods, but depending on the Kubernetes version upgrade it might be possible.
+Node upgrades typically do not restart pods. However, depending on the Kubernetes version change, restarts might occur in some cases.
 :::
 
-### Manual Upgrades
+### Perform manual upgrades
 
-You can either upgrade a node via vCluster CLI by running the following command:
-```bash
+You can either upgrade a node using the vCluster CLI by running the following command:
+
+```bash title="Upgrade a specific node manually"
 vcluster node upgrade my-node
 ```
 
-Or by manually using the [Kubeadm Kubernetes guide](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes/) from the official documentation. 
+Alternatively, you can manually upgrade by following the [official Kubeadm Kubernetes guide](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/upgrading-linux-nodes/).
 
-## Addons
+## Configure addons
+
+vCluster supports addons that extend the functionality of your virtual cluster. You can configure these addons during deployment to adjust networking, observability, and other features for your environment and requirements.
 
 ### CNI
 
-vCluster will install [Flannel](https://github.com/flannel-io/flannel) by default, if you want to install your own custom CNI, you can disable that via:
-```yaml
+vCluster installs [Flannel](https://github.com/flannel-io/flannel) by default, if you want to install your own custom CNI, you can disable Flannel using the following:
+
+```yaml title="Disable default Flannel CNI"
 privateNodes:
   cni:
     flannel:
@@ -253,28 +274,29 @@ privateNodes:
 
 ### CoreDNS
 
-vCluster will install [CoreDNS](https://coredns.io/) by default to allow cluster dns resolving of services and pods.
+vCluster installs [CoreDNS](https://coredns.io/) by default to allow cluster DNS resolving of services and pods.
 
 ### Konnectivity
 
-vCluster uses [Konnectivity](https://kubernetes.io/docs/tasks/extend-kubernetes/setup-konnectivity/) to establish a connection between control-plane and worker nodes for commands like `kubectl logs`, `kubectl exec`, `kubectl port-forward` etc. The Konnectivity server runs as part of the vCluster control plane, while an agent is deployed inside the vCluster. If not needed or wanted, you can disable Konnectivity in the vCluster config.
+vCluster uses [Konnectivity](https://kubernetes.io/docs/tasks/extend-kubernetes/setup-konnectivity/) to establish a connection between the control plane and worker nodes for commands such as `kubectl logs`, `kubectl exec`, `kubectl port-forward`. The Konnectivity server runs as part of the vCluster control plane, while an agent is deployed inside the vCluster. If it is not needed or wanted, you can disable Konnectivity in the vCluster config.
 
-### Kube Proxy
+### Kube proxy
 
-vCluster installs [Kube Proxy](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/) by default to ensure that services are configured on the nodes. Some CNI implement their own kube-proxy functionality, so you can optionally disable kube-proxy deployment in the vCluster config.
+vCluster installs [Kube Proxy](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/) by default to ensure that services are configured on the nodes. Some CNI implement their own kube-proxy functionality. Optionally, you can disable kube-proxy deployment in the vCluster config.
 
 ### Local Path Provisioner
 
-vCluster installs [Local Path Provisioner](https://github.com/rancher/local-path-provisioner) by default to allow stateful workloads within the vCluster.
+vCluster installs the [Local Path Provisioner](https://github.com/rancher/local-path-provisioner) by default to allow stateful workloads within the vCluster.
 
-## Load Docker Image into a Node
+## Load Docker images into nodes
 
-To load a local docker image into a worker node you can use the following command:
-```bash
+To load a local Docker image into a worker node you can use the following command:
+
+```bash title="Load Docker image into specific node"
 vcluster node load-image my-node --image nginx:latest
 ```
 
-## Config reference
+## Review configuration reference
 
 <PrivateNodes />
 <Networking />

--- a/vcluster/_fragments/private-nodes.mdx
+++ b/vcluster/_fragments/private-nodes.mdx
@@ -31,6 +31,8 @@ alt="Overview"
 />
 </center>
 
+<!-- vale off -->
+
 ## Compare private nodes and resource syncing
 
 The following table outlines the differences between using private nodes and using resource syncing: 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Follow up to address vale rules

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-673
Closes DOC-699

