### PR TITLE
feat(dns): redirect next.vcluster.com directly to docs path

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -61,6 +61,12 @@ command = """
   from = "/docs/deploy/basics/*"
   to = "/docs/vcluster/deploy/basics/"
 
+[[redirects]]
+  from = "https://next.vcluster.com/"
+  to = "https://next.vcluster.com/docs/"
+  status = 301
+  force = true
+
 ### Permalinks for the platform UI.
 ## The purpose of this is to keep the platform resilient against changes in the docs,
 ## such that we can fix routing of docs links here, rather than requiring customers


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-781--next-vcluster-docs-site.netlify.app/docs/

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-698

