### PR TITLE
Fix: Follow up to fix vale issues for capture-pprof-vcluster.mdx

### DIFF
--- a/vcluster/learn-how-to/capture-pprof-vcluster.mdx
+++ b/vcluster/learn-how-to/capture-pprof-vcluster.mdx
@@ -4,9 +4,9 @@ sidebar_label: Capture pprof profiles
 description: How to capture CPU and memory profiles in vCluster to diagnose performance issues.
 ---
 
-Capturing [pprof](https://github.com/google/pprof) is important for identifying performance bottlenecks and optimizing resource usage, ultimately enhancing application performance. pprof, or Performance Profiling in Go, plays a crucial role in this process.
+This guide shows how to use Performance Profiling in Go (pprof) to capture CPU and memory profiles from vCluster. Capturing [pprof](https://github.com/google/pprof) is important for identifying performance bottlenecks and optimizing resource usage. 
 
-In vCluster, users occasionally encounter performance challenges due to high CPU and memory usage. In such cases, pinpointing potential bottlenecks and optimizing performance is key to ensuring smooth application operation.
+When vCluster experiences high CPU or memory usage, use profiling to identify performance bottlenecks and optimize resource consumption.
 
 ## Setup and capture pprof on vCluster 
 
@@ -23,27 +23,30 @@ controlPlane:
 ```
 
 :::note
-You must be on the kube-context of the host cluster where the vCluster is running. If you're not using the templates from the UI, you can execute the following commands from your terminal:
+You must be on the kube-context of the host cluster where the vCluster is running. 
+:::
+
+### Port forwarding
+
+If you're not using the templates from the UI, you can execute the following commands from your terminal:
 
 ```bash
 kubectl port-forward -n vclusternamespace pod/vclustername-0 10443:8443
 ```
 
-This command allows accessing services running inside the virtual cluster from your local machine without exposing them publicly through the host Kubernetes cluster’s services or ingress.
+This command allows you to access services running inside the virtual cluster from your local machine without exposing them publicly through the host Kubernetes cluster’s services or ingress.
 
 If a template is not used, the values should be added directly to `.spec.template.helmRelease.values` in the `VirtualClusterInstance`.
-:::
-
 
 ### Capture CPU profile
 
-In the terminal from your local, execute:
+Run the following command locally:
 
 ```sh
 curl -k "https://localhost:10443/debug/pprof/profile?second=60" > profile60.prof
 ```
 
-This command fetches a CPU profile of the vCluster pod's processes (such as the virtual Kubernetes API server) for the past 60 seconds. You should see a `profile60.prof` file created on your local system.
+This command fetches a CPU profile of the vCluster pod's processes (such as the virtual Kubernetes API server) for the past 60 seconds. A `profile60.prof` file is created on your local system.
 
 ### Capture memory profile
 
@@ -58,4 +61,4 @@ This command fetches a heap profile from the vCluster pod by sending a request t
 
 ## Next steps
 
-After you've captured these files, you can [send them to us](https://loft-sh.slack.com/). This enables us to identify opportunities for optimization and enhance the performance of your application.
+After you've captured these files, you can [send them with support](https://loft-sh.slack.com/). This enables us to identify opportunities for optimization and enhance the performance of your application.

--- a/vcluster/learn-how-to/capture-pprof-vcluster.mdx
+++ b/vcluster/learn-how-to/capture-pprof-vcluster.mdx
@@ -61,4 +61,6 @@ This command fetches a heap profile from the vCluster pod by sending a request t
 
 ## Next steps
 
-After you've captured these files, you can [send them with support](https://loft-sh.slack.com/). This enables us to identify opportunities for optimization and enhance the performance of your application.
+<!-- vale off -->
+
+After you've captured these files, you can [send them to us](https://loft-sh.slack.com/). This enables us to identify opportunities for optimization and enhance the performance of your application.


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Just a follow up to address vale issues


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-663

