### PR TITLE
Since 0.25 it is not possible to have multiple vCluster instances in a single host namespace

### DIFF
--- a/vcluster/introduction/architecture.mdx
+++ b/vcluster/introduction/architecture.mdx
@@ -48,7 +48,7 @@ You can [read more about how the syncer works in more detail](../configure/vclus
 
 Each virtual cluster runs as a regular StatefulSet (default) or Deployment inside a host cluster namespace. Everything that you create inside the virtual cluster lives either inside the virtual cluster itself and/or inside the host namespace.
 
-It is possible to run multiple virtual clusters inside the same namespace. You can even run a virtual cluster inside another virtual cluster, otherwise known as vCluster nesting.
+A host namespace can only contain a single virtual cluster. However, it is possible to run a virtual cluster within another virtual cluster, a concept known as vCluster nesting.
 
 For certain cases that don't require strong isolation, you can run workloads in [multiple underlying host namespaces](../configure/vcluster-yaml/experimental/multi-namespace-mode). However, this feature is experimental and requires more management overhead.
 

--- a/vcluster_versioned_docs/version-0.25.0/introduction/architecture.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/introduction/architecture.mdx
@@ -48,7 +48,7 @@ You can [read more about how the syncer works in more detail](../configure/vclus
 
 Each virtual cluster runs as a regular StatefulSet (default) or Deployment inside a host cluster namespace. Everything that you create inside the virtual cluster lives either inside the virtual cluster itself and/or inside the host namespace.
 
-It is possible to run multiple virtual clusters inside the same namespace. You can even run a virtual cluster inside another virtual cluster, otherwise known as vCluster nesting.
+A host namespace can only contain a single virtual cluster. However, it is possible to run a virtual cluster within another virtual cluster, a concept known as vCluster nesting.
 
 For certain cases that don't require strong isolation, you can run workloads in [multiple underlying host namespaces](../configure/vcluster-yaml/experimental/multi-namespace-mode). However, this feature is experimental and requires more management overhead.
 


### PR DESCRIPTION
Removed sentence that falsely states running multiple vCluster instances in the same host namespace is possible.

<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

