### PR TITLE
remove mentiones of Cluster API as there aren't working yet

### DIFF
--- a/vcluster/_fragments/private-nodes.mdx
+++ b/vcluster/_fragments/private-nodes.mdx
@@ -35,7 +35,7 @@ alt="Overview"
 
 ## Compare private nodes and resource syncing
 
-The following table outlines the differences between using private nodes and using resource syncing: 
+The following table outlines the differences between using private nodes and using resource syncing:
 
 | Feature                            | Private Nodes | Resource Syncing |
 |------------------------------------|---------------|------------------|
@@ -51,7 +51,7 @@ The following table outlines the differences between using private nodes and usi
 
 ## vcluster.yaml Configuration
 
-To create a vCluster with private nodes, you'll need to enable the feature as well as set some other configuration options in preparation for worker nodes to join. 
+To create a vCluster with private nodes, you'll need to enable the feature as well as set some other configuration options in preparation for worker nodes to join.
 
 ```yaml title="Enable private nodes"
 # Enable private nodes
@@ -112,7 +112,7 @@ controlPlane:
   # Embedded coreDNS is not supported as changing CNI options is one of the benefits of private nodes
   coredns:
     embedded: true
-      
+
   advanced:
     # Disabling the virtual scheduler is not possible
     virtualScheduler:
@@ -125,11 +125,11 @@ controlPlane:
 
 * vCluster CLI installed on your local machine
 * Access to a Host Cluster
-* Worker Nodes 
+* Worker Nodes
 
 ### Create the vCluster Control Plane
 
-Before joining private nodes to a vCluster, you need to create vCluster to deploy the control plane on a host cluster. 
+Before joining private nodes to a vCluster, you need to create vCluster to deploy the control plane on a host cluster.
 
 ```yaml title="vcluster.yaml for private nodes"
 # Enable private nodes
@@ -162,37 +162,15 @@ Follow [this guide](https://www.vcluster.com/docs/vcluster/next/configure/vclust
 
 vCluster allows two methods to join worker nodes:
 
-- Automatically add worker nodes using [Cluster API](https://github.com/kubernetes-sigs/cluster-api)
-- Manually add worker nodes 
+- Manually add worker nodes
 
-#### Join worker nodes using Cluster API
-
-For automatically joining nodes using the Cluster API, set up the cluster using the following command to install the [vCluster Cluster API provider](https://github.com/loft-sh/cluster-api-provider-vcluster):
-
-```bash title="Initialize Cluster API with vCluster provider"
-clusterctl init --infrastructure vcluster
-```
-
-As soon as the Cluster API provider is running, you can install a provider to handle node creation—for example, KubeVirt.
-
-```bash title="Generate cluster configuration with KubeVirt"
-VCLUSTER_VERSION=v0.26.0-alpha.9
-
-clusterctl generate cluster test \
-  --kubernetes-version v1.31.2 \
-  -n test \
-  --from https://raw.githubusercontent.com/loft-sh/cluster-api-provider-vcluster/refs/heads/main/hack/kubevirt/template.yaml
-```
-
-Then apply the manifests to the cluster and Cluster API should create the vCluster and join the worker nodes using the KubeVirt provider.
-
-#### Join worker nodes 
+#### Join worker nodes
 
 *Pre-requisities on worker nodes*
 
-- `curl` installed 
+- `curl` installed
 
-In order to join worker nodes, a token from the vCluster must be created to provide access and permissions to join the vCluster. A single token can be used for any worker nodes to join, or if you wanted to, you could create a token for each node. 
+In order to join worker nodes, a token from the vCluster must be created to provide access and permissions to join the vCluster. A single token can be used for any worker nodes to join, or if you wanted to, you could create a token for each node.
 
 ```bash title="Create a token for worker nodes"
 export VCLUSTER_NAME=my-vcluster
@@ -204,13 +182,13 @@ vcluster connect $VCLUSTER_NAME
 vcluster token create
 ```
 
-The output provided will give you a command to run on your worker node. 
+The output provided will give you a command to run on your worker node.
 
 ```bash title="Example output from creating a token"
 curl -sfLk https://<vcluster-endpoint>/node/join?token=<token> | sh -
 ```
 
-For each worker node that you want to join vCluster, run the command on the worker node. 
+For each worker node that you want to join vCluster, run the command on the worker node.
 
 ```bash title="Example output on worker node"
 Preparing node for Kubernetes installation...
@@ -284,7 +262,7 @@ You can also skip specific nodes from the automatic update by adding the label `
 
 <AutoUpgrade />
 
-:::warning 
+:::warning
 Node upgrades typically do not restart pods. However, depending on the Kubernetes version change, restarts might occur in some cases.
 :::
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-715

