### PR TITLE
fix: Update namespaces

### DIFF
--- a/vcluster/configure/vcluster-yaml/sync/to-host/advanced/namespaces.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/advanced/namespaces.mdx
@@ -24,11 +24,13 @@ For example, if you have a virtual cluster, `my-vcluster`, vCluster transforms a
 
 Since vCluster rewrites resource names to avoid conflicts, any references to those resources must also be updated. vCluster handles this automatically for core Kubernetes resources. For example, when a Pod mounts a Secret, vCluster ensures the reference maps to the correct Secret name on the host cluster—without exposing this complexity inside the vCluster.
 
-However, tasks like setting up IAM integrations with cloud providers or using custom schedulers can be more complex. For instance, when configuring Workload Identity in Google Cloud Platform (GCP), you need to link a GCP Service Account to a Kubernetes Service Account. This is essential for securely authenticating workloads, but it requires predictable resource names in the host cluster to establish the necessary IAM policy bindings. 
+## How namespace syncing works
 
-Similarly, custom schedulers like Run:ai—which manage resources for AI/ML workloads—depend on a structured hierarchy of projects, departments, and node pools with defined quotas and priorities. Without a consistent naming and configuration strategy for synced resources, managing these setups at scale becomes tedious, error-prone, or even impossible.
+Namespace syncing provides an alternative approach by creating dedicated namespaces on the host cluster that correspond to namespaces in the virtual cluster. Instead of rewriting resource names and placing everything in the vCluster's namespace, namespace syncing maintains the original resource names within their mapped host namespaces.
 
-To handle these cases, vCluster supports namespace sync with custom mapping rules. These rules give you more control over how resources and their references are mapped between the virtual and host clusters. This is especially useful for complex workloads involving custom or non-standard Kubernetes resources.
+When namespace syncing is enabled, vCluster creates corresponding namespaces on the host cluster based on defined mapping rules. Resources from each virtual namespace are synced to their designated host namespace without name transformation, preserving predictable resource names and references.
+
+This approach enables complex scenarios like IAM integrations with cloud providers and custom schedulers. For instance, when configuring Workload Identity in Google Cloud Platform (GCP), you can link a GCP Service Account to a Kubernetes `ServiceAccoun` using predictable names. Similarly, custom schedulers like Run:ai can manage structured hierarchies of projects, departments, and node pools with defined quotas and priorities.
 
 :::note
 If namespace syncing is not enabled or if a namespace doesn't match any mapping rule, vCluster syncs resources into the vCluster control plane's namespace on the host using rewritten names to avoid conflicts.
@@ -36,7 +38,7 @@ If namespace syncing is not enabled or if a namespace doesn't match any mapping 
 
 ## Enable namespace syncing
 
-Configure namespace syncing by enabling the feature and selecting how to map namespaces from the virtual cluster to the host cluster. 
+Configure namespace syncing by enabling the feature and selecting how to map namespaces from the virtual cluster to the host cluster.
 
 ```yaml
 sync:
@@ -58,13 +60,13 @@ Namespace syncing configuration cannot be modified after vCluster deployment. Yo
 Plan your namespace mapping strategy carefully before initial deployment.
 :::
 
-## Existing host namespace expectations
+## Existing namespaces
 
 Any host namespace that matches a defined mapping—either exact or pattern—is automatically imported into the vCluster.
 This means if a matching namespace already exists on the host or is created later, vCluster recognizes it and syncs it into the virtual environment.
 Importantly, any workloads (such as Pods) created in that host namespace are also imported into the vCluster and appear just like native vCluster resources.
 
-## Mapping Rule Types
+## Mapping rule types
 
 Namespace syncing supports several mapping rule types with the `mappings.byName` field:
 
@@ -132,7 +134,7 @@ sync:
           "important-configs": "host-configs-critical"
 ```
 
-## Deleting a vCluster
+## Delete a vCluster
 
 When you delete a vCluster, the namespaces and resources in those namespaces that were created on the host cluster due to the syncing from the virtual cluster are removed. Any namespaces and resources that originated from the host cluster and were imported into the virtual cluster remain unchanged. vCluster only cleans up the resources including namespaces that it created while leaving anything that was created outside of the vCluster. 
 
@@ -151,7 +153,7 @@ sync:
 
 ## Examples 
 
-These are end to end examples of how to use the features and test out what happens to the namespaces and resources in the virtual and host clusters. 
+The following end-to-end examples demonstrate namespace syncing behavior in both virtual and host clusters.
 
 ### Enable namespace mappings 
 
@@ -277,7 +279,7 @@ The pod from the mapped namespace syncs directly without renaming, while the pod
 </Step>
 </Flow>
 
-### Importing existing host namespaces 
+### Import existing host namespaces 
 
 The following example shows what happens to existing namespaces on the host cluster and how they are imported into the virtual cluster.
 
@@ -332,7 +334,7 @@ nginx-from-host   1/1     Running   0          36s
 </Step>
 </Flow>
 
-### Syncing only mapped namespaces
+### Sync only mapped namespaces
 
 The following example shows how `mappingsOnly: true` restricts operations within vCluster to only mapped namespaces.
 
@@ -372,7 +374,7 @@ vCluster blocks this namespace. Any operation on namespaces not defined in mappi
 </Step>
 </Flow>
 
-### Deleting a vCluster
+### Delete a vCluster
 
 The following example shows what happens to the namespaces on the host cluster when you delete a vCluster and have enabled namespace syncing. 
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Edits to align for style. Shorten intro/overview- overwhelming 

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Link to Preview](https://deploy-preview-813--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/sync/to-host/advanced/namespaces)


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

