### PR TITLE
add docs for setting project for external vclusters

### DIFF
--- a/platform/api/_partials/resources/config/external/platform/project.mdx
+++ b/platform/api/_partials/resources/config/external/platform/project.mdx
@@ -1,7 +1,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="true" className="config-field-pro">pro</span> {#project}
+## `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#project}
 
 Project specifies which platform project the vcluster should be imported to.
 

--- a/platform/api/_partials/resources/config/external/platform/project.mdx
+++ b/platform/api/_partials/resources/config/external/platform/project.mdx
@@ -1,0 +1,10 @@
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+## `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="true" className="config-field-pro">pro</span> {#project}
+
+Project specifies which platform project the vcluster should be imported to.
+
+</summary>
+
+</details>

--- a/vcluster/configure/vcluster-yaml/external/platform/project.mdx
+++ b/vcluster/configure/vcluster-yaml/external/platform/project.mdx
@@ -23,7 +23,7 @@ Add the project assignment to your `vcluster.yaml` file:
 <br />
 
 <InterpolatedCodeBlock 
-  code={`external:
+  code={`
   external: 
     platform:
       apiKey: [[VAR:API KEY:vcluster-platform-api-key]]

--- a/vcluster/configure/vcluster-yaml/external/platform/project.mdx
+++ b/vcluster/configure/vcluster-yaml/external/platform/project.mdx
@@ -5,7 +5,7 @@ sidebar_position: 4
 ---
 import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 
-import Project from '@site/platform/api/_partials/resources/config/external/platform/project.mdx'
+import Project from '../../../../../platform/api/_partials/resources/config/external/platform/project.mdx'
 
 <ProAdmonition/>
 
@@ -27,7 +27,7 @@ Once set, you cannot change the project for a vCluster
 :::
 
 If project in `vcluster.yaml` is modified, there wont be any project change on the platform UI. 
-However, there will be an warning shown in the vCluster pod running on the host cluster
+However, there would be an warning shown in the vCluster pod running on the host cluster
 
 ## Example
 The vCluster is imported to project `development` by using following `vcluster.yaml`
@@ -41,7 +41,7 @@ external:
     project: development
 ```
 
-Using the following updated `vcluster.yaml` to change the project will result into a warning as shown below
+Using the following updated `vcluster.yaml` to change the project would result into a warning as shown below
 
 ```yaml
 external:

--- a/vcluster/configure/vcluster-yaml/external/platform/project.mdx
+++ b/vcluster/configure/vcluster-yaml/external/platform/project.mdx
@@ -29,7 +29,7 @@ Add the project assignment to your `vcluster.yaml` file:
     apiKey:
       secretName: [[VAR:API KEY SECRET:vcluster-platform-api-key]]
       namespace: [[VAR:NAMESPACE:vcluster-platform]]
-    project: [[VAR:PROJECT ID:production]]
+    project: [[VAR:PROJECT ID:production]]`}
   language="yaml" 
 />
 

--- a/vcluster/configure/vcluster-yaml/external/platform/project.mdx
+++ b/vcluster/configure/vcluster-yaml/external/platform/project.mdx
@@ -20,12 +20,15 @@ When you create a vCluster without specifying a project, vCluster automatically 
 
 Add the project assignment to your `vcluster.yaml` file:
 
+<br />
+
 <InterpolatedCodeBlock 
   code={`external:
-  platform:
-    apiKey: [[VAR:API KEY:vcluster-platform-api-key]]
-    namespace: [[VAR:NAMESPACE:vcluster-namespace]]
-  project: [[VAR:PROJECT ID:platform-project-id]]`} 
+  external: 
+    platform:
+      apiKey: [[VAR:API KEY:vcluster-platform-api-key]]
+      namespace: [[VAR:NAMESPACE:vcluster-namespace]]
+      project: [[VAR:PROJECT ID:platform-project-id]]`} 
   language="yaml" 
 />
 
@@ -50,7 +53,7 @@ external:
     project: development
 ```
 
-Then, you later modify the configuration to move the vCluster to the `production` project:
+Then, if you later modify the configuration to move the vCluster to the `production` project:
 
 ```yaml title="vcluster.yaml"
 external:

--- a/vcluster/configure/vcluster-yaml/external/platform/project.mdx
+++ b/vcluster/configure/vcluster-yaml/external/platform/project.mdx
@@ -1,38 +1,44 @@
 ---
-title: project
+title: Project
 sidebar_label: project
 sidebar_position: 4
+sidebar_class_name: pro
+description: Learn how to assign virtual clusters to platform projects and manage project configurations.
 ---
-import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 
+import InterpolatedCodeBlock from "@site/src/components/InterpolatedCodeBlock";
+import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
 import Project from '../../../../../platform/api/_partials/resources/config/external/platform/project.mdx'
+
 
 <ProAdmonition/>
 
-A vCluster can be added to a platform project by specifying the project ID in `vcluster.yaml`. By default,
-if you dont set any project in `vcluster.yaml`, vCluster is added to `default` project.
+You can assign a vCluster to a specific platform project by adding the project ID to your `vcluster.yaml` configuration file. This assignment happens when you first create the vCluster and connects it to the designated project in the platform interface.
+
+When you create a vCluster without specifying a project, vCluster automatically assigns it to the default project. This ensures every vCluster belongs to a project for proper organization and access control.
 
 ## Example
 
-```yaml
-external:
-  platform:
-    apiKey: vcluster-platform-api-key
-    namespace: vcluster-namespace
-  project: platform-project-id
+Add the project assignment to your `vcluster.yaml` file:
 
-```
-:::note
-Once set, you cannot change the project for a vCluster
+<InterpolatedCodeBlock
+code={`external:   platform:     apiKey: [[VAR:API KEY:vcluster-platform-api-key]]     namespace: [[VAR:NAMESPACE:vcluster-namespace]]   project: [[VAR:PROJECT ID:platform-project-id]]`}
+language="yaml"
+/>
+
+:::note Project assignment permanence
+You cannot change the project assignment after creating the vCluster. This restriction maintains data integrity and prevents accidental resource movement.
 :::
 
-If project in `vcluster.yaml` is modified, there wont be any project change on the platform UI. 
-However, there would be an warning shown in the vCluster pod running on the host cluster
+## Change projects
 
-## Example
-The vCluster is imported to project `development` by using following `vcluster.yaml`
+If you modify the project ID in `vcluster.yaml` after creating the vCluster, the platform interface does not reflect this change. Instead, the vCluster pod generates a warning message in its logs to alert you about the invalid configuration.
 
-```yaml
+### Change projects example
+
+You create a vCluster assigned to the `development` project:
+
+```yaml title="vcluster.yaml"
 external:
   platform:
     apiKey:
@@ -41,9 +47,9 @@ external:
     project: development
 ```
 
-Using the following updated `vcluster.yaml` to change the project would result into a warning as shown below
+Then, you later modify the configuration to move the vCluster to the `production` project:
 
-```yaml
+```yaml title="vcluster.yaml"
 external:
   platform:
     apiKey:
@@ -52,10 +58,14 @@ external:
     project: production
 ```
 
-```console
+The vCluster pod detects this invalid change and logs an error:
+
+```bash
 2025-06-19 07:53:38	INFO	online/license.go:174	Trying to register vCluster in the Platform	{"component": "vcluster"}
 2025-06-19 07:53:39	ERROR	online/license.go:442		{"component": "vcluster", "error": "vcluster is currently imported in project \"development\", it cannot be moved to \"production\""}
 ```
+
+This warning confirms that the vCluster remains in its original project despite the configuration change.
 
 ## Config reference
 

--- a/vcluster/configure/vcluster-yaml/external/platform/project.mdx
+++ b/vcluster/configure/vcluster-yaml/external/platform/project.mdx
@@ -28,7 +28,7 @@ Add the project assignment to your `vcluster.yaml` file:
     platform:
       apiKey: [[VAR:API KEY:vcluster-platform-api-key]]
       namespace: [[VAR:NAMESPACE:vcluster-namespace]]
-      project: [[VAR:PROJECT ID:platform-project-id]]`} 
+    project: [[VAR:PROJECT ID:platform-project-id]]`} 
   language="yaml" 
 />
 

--- a/vcluster/configure/vcluster-yaml/external/platform/project.mdx
+++ b/vcluster/configure/vcluster-yaml/external/platform/project.mdx
@@ -1,0 +1,62 @@
+---
+title: project
+sidebar_label: project
+sidebar_position: 4
+---
+import ProAdmonition from '../../../../_partials/admonitions/pro-admonition.mdx'
+
+import Project from '@site/platform/api/_partials/resources/config/external/platform/project.mdx'
+
+<ProAdmonition/>
+
+A vCluster can be added to a platform project by specifying the project ID in `vcluster.yaml`. By default,
+if you dont set any project in `vcluster.yaml`, vCluster is added to `default` project.
+
+## Example
+
+```yaml
+external:
+  platform:
+    apiKey: vcluster-platform-api-key
+    namespace: vcluster-namespace
+  project: platform-project-id
+
+```
+:::note
+Once set, you cannot change the project for a vCluster
+:::
+
+If project in `vcluster.yaml` is modified, there wont be any project change on the platform UI. 
+However, there will be an warning shown in the vCluster pod running on the host cluster
+
+## Example
+The vCluster is imported to project `development` by using following `vcluster.yaml`
+
+```yaml
+external:
+  platform:
+    apiKey:
+      secretName: vcluster-platform-api-key
+      namespace: vcluster-platform
+    project: development
+```
+
+Using the following updated `vcluster.yaml` to change the project will result into a warning as shown below
+
+```yaml
+external:
+  platform:
+    apiKey:
+      secretName: vcluster-platform-api-key
+      namespace: vcluster-platform
+    project: production
+```
+
+```console
+2025-06-19 07:53:38	INFO	online/license.go:174	Trying to register vCluster in the Platform	{"component": "vcluster"}
+2025-06-19 07:53:39	ERROR	online/license.go:442		{"component": "vcluster", "error": "vcluster is currently imported in project \"development\", it cannot be moved to \"production\""}
+```
+
+## Config reference
+
+<Project />

--- a/vcluster/configure/vcluster-yaml/external/platform/project.mdx
+++ b/vcluster/configure/vcluster-yaml/external/platform/project.mdx
@@ -2,7 +2,6 @@
 title: Project
 sidebar_label: project
 sidebar_position: 4
-sidebar_class_name: pro
 description: Learn how to assign virtual clusters to platform projects and manage project configurations.
 ---
 
@@ -21,9 +20,13 @@ When you create a vCluster without specifying a project, vCluster automatically 
 
 Add the project assignment to your `vcluster.yaml` file:
 
-<InterpolatedCodeBlock
-code={`external:   platform:     apiKey: [[VAR:API KEY:vcluster-platform-api-key]]     namespace: [[VAR:NAMESPACE:vcluster-namespace]]   project: [[VAR:PROJECT ID:platform-project-id]]`}
-language="yaml"
+<InterpolatedCodeBlock 
+  code={`external:
+  platform:
+    apiKey: [[VAR:API KEY:vcluster-platform-api-key]]
+    namespace: [[VAR:NAMESPACE:vcluster-namespace]]
+  project: [[VAR:PROJECT ID:platform-project-id]]`} 
+  language="yaml" 
 />
 
 :::note Project assignment permanence

--- a/vcluster/configure/vcluster-yaml/external/platform/project.mdx
+++ b/vcluster/configure/vcluster-yaml/external/platform/project.mdx
@@ -24,11 +24,12 @@ Add the project assignment to your `vcluster.yaml` file:
 
 <InterpolatedCodeBlock 
   code={`
-  external: 
-    platform:
-      apiKey: [[VAR:API KEY:vcluster-platform-api-key]]
-      namespace: [[VAR:NAMESPACE:vcluster-namespace]]
-    project: [[VAR:PROJECT ID:platform-project-id]]`} 
+ external:
+  platform:
+    apiKey:
+      secretName: [[VAR:API KEY SECRET:vcluster-platform-api-key]]
+      namespace: [[VAR:NAMESPACE:vcluster-platform]]
+    project: [[VAR:PROJECT ID:production]]
   language="yaml" 
 />
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Link to Preview](https://deploy-preview-817--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/external/platform/project)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-631

