### PR TITLE
refactor: rewrite page for retrieving the deployed vcluster config

### DIFF
--- a/vcluster/learn-how-to/retrieve-vcluster-config.mdx
+++ b/vcluster/learn-how-to/retrieve-vcluster-config.mdx
@@ -14,7 +14,7 @@ You can deploy vCluster using various tools including Helm charts, the vCluster 
 
 The following methods provide different levels of detail depending on your deployment approach and available tools:
 
-- **Helm**: Use when the vCluster is Helm-compatible (deployed with Helm or vCluster CLI) and structured output distinguishing custom and default values is needed. This method is also recommended when planning to replicate the deployment in another environment or when working with Helm-managed deployments and consistency is required.
+- **Helm (_Recommended_)**: Use when the vCluster is Helm-compatible (deployed with Helm or vCluster CLI) and structured output distinguishing custom and default values is needed. This method is also recommended when planning to replicate the deployment in another environment or when working with Helm-managed deployments and consistency is required.
 
 - **vCluster CLI**: Use when the complete effective configuration as vCluster interprets it is required or when troubleshooting vCluster-specific behavior or issues. This method is also helpful when the original deployment method is unknown or mixed, or when the most comprehensive view of the cluster state is needed.
 
@@ -23,7 +23,7 @@ The following methods provide different levels of detail depending on your deplo
 <br />
 
 <Tabs>
-<TabItem value="helm" label="Helm (Recommended)" default>
+<TabItem value="helm" label="Helm" default>
 
 For Helm-managed deployments, you can retrieve the configuration values used during installation and upgrades.
 
@@ -39,6 +39,8 @@ The following command shows only the values you explicitly set.
   code={`helm get values [[VAR:VCLUSTER NAME:my-vcluster]] -n [[VAR:VCLUSTER NAMESPACE:vcluster-my-vcluster]] -o yaml`}
   language="bash"
 />
+
+<br />
 
 #### Get default and user-defined values
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Update retrieve config


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Link to Preview](https://deploy-preview-824--vcluster-docs-site.netlify.app/docs/vcluster/next/learn-how-to/retrieve-vcluster-config)


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-711

