### PR TITLE
fix: add pro

### DIFF
--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling.mdx
@@ -5,7 +5,7 @@ sidebar_class_name: pro
 description: Configure hybrid scheduling to use both host and virtual cluster schedulers for workload placement.
 ---
 
-import ProAdmonition from '../../../../../_partials/admonitions/pro-admonition.mdx'
+import ProAdmonition from '../../../../../../_partials/admonitions/pro-admonition.mdx'
 
 <ProAdmonition/>
 

--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling.mdx
@@ -1,8 +1,13 @@
 ---
 title: Hybrid Scheduling
 sidebar_label: hybridScheduling
+sidebar_class_name: pro
 description: Configure hybrid scheduling to use both host and virtual cluster schedulers for workload placement.
 ---
+
+import ProAdmonition from '../../../../../_partials/admonitions/pro-admonition.mdx'
+
+<ProAdmonition/>
 
 Hybrid scheduling enables virtual clusters to use multiple schedulers simultaneously - both from the host cluster and virtual cluster. Pods within the virtual cluster can use different schedulers based on their individual configuration.
 
@@ -20,6 +25,7 @@ sync:
     nodes:
       enabled: true
 ```
+
 You must also enable syncing of real nodes from the host to the virtual cluster. If you don’t, the virtual cluster displays an error.
 
 By default, all nodes from the host cluster are synced to the virtual cluster. To sync only specific nodes, you can define a label selector as shown in the following example:


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- add pro admonition for hybrid scheduling

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Link to Preview](https://deploy-preview-825--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/sync/to-host/core/pods/hybrid-scheduling)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

