### PR TITLE
update compatibility matrix for 1.33

### DIFF
--- a/vcluster/deploy/upgrade/supported_versions.mdx
+++ b/vcluster/deploy/upgrade/supported_versions.mdx
@@ -41,7 +41,7 @@ Kubernetes versions that are no longer supported upstream can still be used but 
   <tbody>
     <tr>
       <td><b>v1.33</b></td>
-      <td>🆗</td>
+      <td>✅</td>
       <td>🆗</td>
       <td>🆗</td>
       <td>🆗</td>


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

Updates compatibility matrix for k8s 1.33 to `Officially tested and supported`

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENG-6637

