### PR TITLE
docs(platform): clarify backup scope

### DIFF
--- a/platform/administer/backup-restore/backup-restore-platform.mdx
+++ b/platform/administer/backup-restore/backup-restore-platform.mdx
@@ -4,9 +4,9 @@ sidebar_label: Backup & Restore
 sidebar_position: 1
 ---
 
-This guide describes how to backup and restore the vCluster Platform management plane. For backing up the connected clusters, please reuse a regular Kubernetes backup solution such as [velero](https://velero.io/).
+This guide describes how to backup and restore the vCluster Platform management plane. For backing up the connected clusters, reuse a regular Kubernetes backup solution such as [Velero](https://velero.io/).
 
-vCluster Platform saves its state as Kubernetes CRD objects.  These can be either backed up via [velero](https://velero.io) or through a special vCluster CLI command that we have created for convenience that saves all relevant Kubernetes resources to a single file. vCluster CLI allows you to backup these components whenever required. Below Resources will be part of the backup:
+vCluster Platform saves its state as Kubernetes CRD objects.  These can be either backed up via [Velero](https://velero.io) or through a special vCluster CLI command that we have created for convenience that saves all relevant Kubernetes resources to a single file. vCluster CLI allows you to backup these components whenever required. The backup includes these resources:
 - ClusterRoleTemplates
 - ClusterAccesses
 - SpaceConstraints
@@ -23,7 +23,9 @@ vCluster Platform saves its state as Kubernetes CRD objects.  These can be eithe
 - SpaceInstances
 - ProjectSecrets
 
-To take a backup using the defaults, you can run the following command. This will dump the manifests of all the above listed components to a file in the current directory named 'backup.yaml'
+The platform backup includes only CRDs and does not cover other resources used by the platform deployment or connected clusters, such as persistent volumes storing cost data. Use a Kubernetes backup solution like [Velero](https://velero.io) to back up these resources separately.
+
+To take a backup using the defaults, you can run the following command. This dumps the manifests of all the above listed components to a file in the current directory named 'backup.yaml'
 ```
 vcluster platform backup management
 ```
@@ -38,29 +40,29 @@ In some scenarios, vCluster Platform may have been installed in a different name
 vcluster platform backup management --namespace my-namespace
 ```
 
-You can also choose to exclude certain components from the backup by supplying the names as a comma-seperated string like below. This will exclude users and teams from the backup.
+You can also choose to exclude certain components from the backup by supplying the names as a comma-separated string like below. This excludes users and teams from the backup.
 ```
 vcluster platform backup management --skip users,teams
 ```
 
-### Restoring vCluster Platform from backup
+### Restore vCluster Platform from backup
 
-The backup YAML file contains the manifests for the resources of the vCluster Platform Management plane. Hence, it can be used as any other Kubernetes manifest file.
+The backup yaml file contains the manifests for the resources of the vCluster Platform Management plane. Hence, it can be used as any other Kubernetes manifest file.
 To restore, simply apply the backup to your cluster using the below command:
 
 
 :::note
-The backup contains vCluster Platform custom resource definitions (CRDs) that will have to be installed in the cluster for the restore to succeed.
+The backup contains vCluster Platform custom resource definitions (CRDs) that need to be installed in the cluster for the restore to succeed.
 :::
 
 ```
 kubectl apply -f <backup-filename>.yaml
 ```
 
-Note that you will likely see lots of warning messages similar to the following:
+Note that you might see lots of warning messages similar to the following:
 
 ```
-Warning: resource apps/argocd is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation will be patched automatically.
+Warning: resource apps/argocd is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation is patched automatically.
 ```
 
 These are just warnings and should not affect the restoration task.
@@ -68,6 +70,6 @@ These are just warnings and should not affect the restoration task.
 :::warning Multiple Kubernetes Clusters with the same vCluster Platform Config
 Make sure that you are not installing vCluster Platform (and vCluster Platform Agents) into clusters with vCluster Platform already
 running. Multiple vCluster Platform instances running on the same clusters can lead to conflicts in
-reconciliation and could cause unexpected problems.
+reconciliation and may cause unexpected problems.
 :::
 

--- a/platform/administer/backup-restore/backup-restore-platform.mdx
+++ b/platform/administer/backup-restore/backup-restore-platform.mdx
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 This guide describes how to backup and restore the vCluster Platform management plane. To back up the connected clusters, reuse a regular Kubernetes backup solution such as [Velero](https://velero.io/).
 
-The vCluster Platform saves its state as Kubernetes Custom Resource Definition (CRD) objects. You can back up this state using [Velero](https://velero.io) or a special vCluster CLI command we created for convenience. This command saves all relevant Kubernetes resources to a single file.
+The vCluster Platform saves its state as Kubernetes Custom Resource Definition (CRD) objects. You can back up this state using [Velero](https://velero.io) or the vCluster CLI command we created for convenience. This command saves all relevant Kubernetes resources to a single file.
 
 You can run the vCluster CLI to back up these components at any time. The backup includes the following resources:
 

--- a/platform/administer/backup-restore/backup-restore-platform.mdx
+++ b/platform/administer/backup-restore/backup-restore-platform.mdx
@@ -54,7 +54,7 @@ vcluster platform backup management --skip users,teams
 
 ### Restore vCluster Platform from backup
 
-The backup YAML file contains the resource manifests for the vCluster Platform management plane. You can apply it like any standard Kubernetes manifest.
+The backup file contains the resource manifests for the vCluster Platform management plane. You can apply it like any standard Kubernetes manifest.
 
 To restore, apply the backup to your cluster using the following command:
 

--- a/platform/administer/backup-restore/backup-restore-platform.mdx
+++ b/platform/administer/backup-restore/backup-restore-platform.mdx
@@ -1,65 +1,72 @@
 ---
-title: Backup & Restore vCluster Platform
-sidebar_label: Backup & Restore
+title: Backup and restore vCluster Platform
+sidebar_label: Backup and Restore
 sidebar_position: 1
 ---
 
-This guide describes how to backup and restore the vCluster Platform management plane. For backing up the connected clusters, reuse a regular Kubernetes backup solution such as [Velero](https://velero.io/).
+This guide describes how to backup and restore the vCluster Platform management plane. To back up the connected clusters, reuse a regular Kubernetes backup solution such as [Velero](https://velero.io/).
 
-vCluster Platform saves its state as Kubernetes CRD objects.  These can be either backed up via [Velero](https://velero.io) or through a special vCluster CLI command that we have created for convenience that saves all relevant Kubernetes resources to a single file. vCluster CLI allows you to backup these components whenever required. The backup includes these resources:
-- ClusterRoleTemplates
-- ClusterAccesses
-- SpaceConstraints
-- Users
-- Teams
-- SharedSecrets
-- AccessKeys
-- Apps
-- SpaceTemplates
-- VirtualClusterTemplates
-- Clusters & Cluster Secrets
-- Projects
-- VirtualClusterInstances
-- SpaceInstances
-- ProjectSecrets
+The vCluster Platform saves its state as Kubernetes Custom Resource Definition (CRD) objects. You can back up this state using [Velero](https://velero.io) or a special vCluster CLI command we created for convenience. This command saves all relevant Kubernetes resources to a single file.
 
-The platform backup includes only CRDs and does not cover other resources used by the platform deployment or connected clusters, such as persistent volumes storing cost data. Use a Kubernetes backup solution like [Velero](https://velero.io) to back up these resources separately.
+You can run the vCluster CLI to back up these components at any time. The backup includes the following resources:
 
-To take a backup using the defaults, you can run the following command. This dumps the manifests of all the above listed components to a file in the current directory named 'backup.yaml'
-```
+- `ClusterRoleTemplates`
+- `ClusterAccesses`
+- `SpaceConstraints`
+- `Users`
+- `Teams`
+- `SharedSecrets`
+- `AccessKeys`
+- `Apps`
+- `SpaceTemplates`
+- `VirtualClusterTemplates`
+- `Clusters` and associated Kubernetes `Secret` objects
+- `Projects`
+- `VirtualClusterInstances`
+- `SpaceInstances`
+- `ProjectSecrets`
+
+The platform backup includes only Custom Resource Definitions (CRDs). It does not include other resources used by the platform deployment or connected clusters, such as persistent volumes that store cost data. Use a Kubernetes backup solution such as [Velero](https://velero.io) to back up these resources separately.
+
+To create a backup using the default settings, run the following command. It saves the manifests for all of the components listed above to a file named `backup.yaml` in the current directory:
+
+```bash
 vcluster platform backup management
 ```
 
-Alternatively, you may specify the name for the backup file by running the command as:
-```
+Alternatively, you cab specify the name for the backup file by running the command as:
+
+```bash
 vcluster platform backup management --filename vcluster-platform-backup.yaml
 ```
 
-In some scenarios, vCluster Platform may have been installed in a different namespace instead of the default `vcluster-platform` namespace. You can provide this to the command as below:
-```
+In some cases, the vCluster Platform might have been installed in a different namespace instead of the default `vcluster-platform`. If so, you can specify the correct namespace as shown in the following command:
+
+```bash
 vcluster platform backup management --namespace my-namespace
 ```
 
-You can also choose to exclude certain components from the backup by supplying the names as a comma-separated string like below. This excludes users and teams from the backup.
-```
+You can also exclude specific components from the backup by passing their names as a comma-separated list. The following example excludes `users` and `teams` from the backup:
+
+```bash
 vcluster platform backup management --skip users,teams
 ```
 
 ### Restore vCluster Platform from backup
 
-The backup yaml file contains the manifests for the resources of the vCluster Platform Management plane. Hence, it can be used as any other Kubernetes manifest file.
-To restore, simply apply the backup to your cluster using the below command:
+The backup YAML file contains the resource manifests for the vCluster Platform management plane. You can apply it like any standard Kubernetes manifest.
 
+To restore, apply the backup to your cluster using the following command:
 
 :::note
-The backup contains vCluster Platform custom resource definitions (CRDs) that need to be installed in the cluster for the restore to succeed.
+The backup contains vCluster Platform Custom Resource Definitions (CRDs), which must be installed in the cluster for the restore to succeed.
 :::
 
-```
+```bash
 kubectl apply -f <backup-filename>.yaml
 ```
 
-Note that you might see lots of warning messages similar to the following:
+You might see warning messages similar to the following:
 
 ```
 Warning: resource apps/argocd is missing the kubectl.kubernetes.io/last-applied-configuration annotation which is required by kubectl apply. kubectl apply should only be used on resources created declaratively by either kubectl create --save-config or kubectl apply. The missing annotation is patched automatically.
@@ -67,9 +74,7 @@ Warning: resource apps/argocd is missing the kubectl.kubernetes.io/last-applied-
 
 These are just warnings and should not affect the restoration task.
 
-:::warning Multiple Kubernetes Clusters with the same vCluster Platform Config
-Make sure that you are not installing vCluster Platform (and vCluster Platform Agents) into clusters with vCluster Platform already
-running. Multiple vCluster Platform instances running on the same clusters can lead to conflicts in
-reconciliation and may cause unexpected problems.
+:::warning Multiple Kubernetes clusters with the same vCluster Platform config
+Do not install vCluster Platform (or its agents) into a cluster where it is already running. Running multiple vCluster Platform instances in the same cluster can cause reconciliation conflicts and lead to unexpected issues.
 :::
 


### PR DESCRIPTION
# Content Description
Clarifies that the platform backup covers only CRDs and does not include other resources used by the platform deployment or connected clusters.

## Preview Link 
[Document Preview](https://deploy-preview-841--vcluster-docs-site.netlify.app/docs/platform/next/administer/backup-restore/backup-restore-platform)

## Internal Reference
Closes DOC-735

