### PR TITLE
fix: multi level menu nativation

### DIFF
--- a/src/theme/DocSidebarItem/Category/index.tsx
+++ b/src/theme/DocSidebarItem/Category/index.tsx
@@ -8,37 +8,64 @@ type Props = WrapperProps<typeof CategoryType>;
 
 export default function CategoryWrapper(props: Props): ReactNode {
   const history = useHistory();
-  const categoryRef = React.useRef<HTMLDivElement>(null);
-  
+  const wrapperRef = React.useRef<HTMLDivElement>(null);
+
+  // Known limitation: After navigating to a category and collapsing it,
+  // clicking the category again won't expand it (only navigates).
+  // Workaround: Click elsewhere first, then click the category.
+  // TODO:(piotr1215): Investigate Docusaurus state management for a complete fix.
+
   React.useEffect(() => {
-    if (!categoryRef.current || !props.item.href) return;
-    
+    if (!props.item.href) {
+      return;
+    }
+
     const handleClick = (e: MouseEvent) => {
       const target = e.target as HTMLElement;
-      const categoryLink = categoryRef.current?.querySelector('a.menu__link--sublist');
-      
-      if (!categoryLink || !categoryLink.contains(target)) {
+
+      // FIRST: Check if we clicked on the chevron/toggle button or its children
+      // This must be checked before anything else to avoid interference
+      const isChevronClick = target.closest('button.menu__caret') ||
+                           target.closest('svg.menu__link-icon') ||
+                           target.classList.contains('menu__caret') ||
+                           target.classList.contains('menu__link-icon');
+
+      if (isChevronClick) {
+        // Don't do anything - let Docusaurus handle the toggle
         return;
       }
-      
-      const clickedOnLink = target.tagName === 'A' || target.closest('a') === categoryLink;
-      
-      if (clickedOnLink) {
-        e.preventDefault();
-        history.push(props.item.href);
+
+      // Check if we clicked on a link
+      const clickedLink = target.closest('a');
+      if (!clickedLink) {
+        return;
       }
+
+      // Get the href from the clicked link
+      const clickedHref = clickedLink.getAttribute('href');
+
+      // Check if this matches our category's href
+      if (clickedHref !== props.item.href) {
+        return;
+      }
+
+      // Only prevent default and navigate if we're sure this is a category link click
+      // (not a chevron click)
+      e.preventDefault();
+      e.stopPropagation();
+      history.push(props.item.href);
     };
-    
-    const element = categoryRef.current;
-    element.addEventListener('click', handleClick);
-    
+
+    // Use capture phase to intercept before other handlers
+    document.addEventListener('click', handleClick, true);
+
     return () => {
-      element.removeEventListener('click', handleClick);
+      document.removeEventListener('click', handleClick, true);
     };
   }, [props.item.href, history]);
-  
+
   return (
-    <div ref={categoryRef}>
+    <div ref={wrapperRef}>
       <Category {...props} />
     </div>
   );


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

## Note to Reviewers

Menu navigation has a known limitation, after navigating to a category and collapsing it, clicking the category again won't expand it (only navigates). Workaround: Click elsewhere first, then click the category.

To test, click on every nested menu category and see if it behaves as expected.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-855--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml/

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-763

