### PR TITLE
fix: update air-gap docs to include `images.txt`

### DIFF
--- a/platform/install/advanced/air-gapped.mdx
+++ b/platform/install/advanced/air-gapped.mdx
@@ -156,7 +156,7 @@ Follow these steps to populate the registry with the required platform images.
   :::
 
   ```bash title="Download assets and prepare scripts"
-  wget https://github.com/loft-sh/loft/releases/download/v${PLATFORM_VERSION}/loft-images.txt
+  wget https://github.com/loft-sh/loft/releases/download/v${PLATFORM_VERSION}/images.txt
   wget https://github.com/loft-sh/loft/releases/download/v${PLATFORM_VERSION}/download-images.sh
   wget https://github.com/loft-sh/loft/releases/download/v${PLATFORM_VERSION}/push-images.sh
 
@@ -172,7 +172,7 @@ Follow these steps to populate the registry with the required platform images.
   Review the output to confirm all images were pulled successfully and packaged in the tarball.
 
   ```bash title="Download and package images"
-  ./download-images.sh --image-list loft-images.txt --images loft-images.tar.gz
+  ./download-images.sh --image-list images.txt --images loft-images.tar.gz
   ```
 
   </Step>

--- a/platform/install/advanced/air-gapped.mdx
+++ b/platform/install/advanced/air-gapped.mdx
@@ -183,7 +183,7 @@ Follow these steps to populate the registry with the required platform images.
   When pushing images to your private registry, references to the original (public) image registry are removed. Only the image name and repository are preserved. This enables vCluster to pull all images from your configured private registry.
 
   ```bash title="Push images to private registry"
-  ./push-images.sh --registry ${REGISTRY} --images loft-images.tar.gz
+  ./push-images.sh --registry ${REGISTRY} --images loft-images.tar.gz --image-list images.txt
   ```
 
   </Step>

--- a/vcluster/deploy/topologies/air-gapped.mdx
+++ b/vcluster/deploy/topologies/air-gapped.mdx
@@ -31,7 +31,7 @@ If you deploy a vCluster in an air-gapped environment and want to use enterprise
 
 When deploying vCluster, there are artifacts that are typically accessed using an internet connection, but without access to the internet, these artifacts need to be available to the Kubernetes cluster through a private registry:
 
-- **vCluster Helm chart**—Typically retrieved from the LoftLabs Helm chart repository.
+- **vCluster Helm chart**—Typically retrieved from the [LoftLabs Helm chart repository](https://charts.loft.sh/).
 - **Container images referenced in the Helm chart**—Usually pulled from various public container registries.
 
 After uploading the required artifacts to your private registry, create the `vcluster.yaml` configuration file and prepare the host cluster for deployment.
@@ -239,8 +239,7 @@ controlPlane:
 <details>
   <summary>Replace the alpine image</summary>
 
-If you use the `sync.toHost.pods.rewriteHosts` feature, manually replace the full path of the [alpine image](https://hub.docker.com/_/alpine) with your private registry path.
-The `defaultImageRegistry` setting does not apply to this image.
+If you use the `sync.toHost.pods.rewriteHosts` feature, manually replace the full path of the [alpine image](https://hub.docker.com/_/alpine) with your private registry path. The `defaultImageRegistry` setting does not apply to this image.
 
 ```yaml title="Replace the alpine image"
 sync:


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->

- Remove references of the old image `loft-image.tXt`


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

[Link to Preview](https://deploy-preview-860--vcluster-docs-site.netlify.app/docs/platform/next/install/advanced/air-gapped)


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-790

