### PR TITLE
fix: old docs versions should be indexed

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -175,19 +175,16 @@ const config = {
             label: "v0.22 (EOL)",
             banner: "unmaintained",
             badge: true,
-            noIndex: true,
           },
           "0.21.0": {
             label: "v0.21 (EOL)",
             banner: "unmaintained",
             badge: true,
-            noIndex: true,
           },
           "0.20.0": {
             label: "v0.20 (EOL)",
             banner: "unmaintained",
             badge: true,
-            noIndex: true,
           },
         },
       },
@@ -216,7 +213,6 @@ const config = {
             label: "v4.2",
             banner: "none",
             badge: true,
-            noIndex: true,
           },
         },
       },
@@ -346,13 +342,6 @@ const config = {
         textColor: "#ffffff",
         isCloseable: true,
       },
-      metadata: [
-        // Add canonical URL for all pages
-        {
-          name: 'canonical',
-          content: 'https://www.vcluster.com/docs',
-        },
-      ],
     }
   ),
 

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,18 +1,18 @@
 User-agent: *
 
-# Block v0.19 - End of Life
+# Block v0.19 - Non Supported Version
 Disallow: /docs/v0.19/
-
-# Block specific EOL platform versions
-Disallow: /docs/platform/4.1.0/
-
-# Block specific EOL vCluster versions from versioned docs
 Disallow: /docs/vcluster/0.19.0/
-Disallow: /docs/vcluster/0.20.0/
-Disallow: /docs/vcluster/0.21.0/
-Disallow: /docs/vcluster/0.22.0/
 
-# Allow crawling of actively maintained versions (0.23+)
-# These will use canonical tags to point to latest for generic searches
+# Allow crawling of EOL versions that have canonical tags
+
+# Platform versions with canonical tags (allowed to crawl)
+# - /docs/platform/4.1.0/ -> canonicalized to /docs/platform/
+# - /docs/platform/4.2.0/ -> canonicalized to /docs/platform/
+
+# vCluster versions with canonical tags (allowed to crawl)
+# - /docs/vcluster/0.20.0/ -> canonicalized to /docs/vcluster/
+# - /docs/vcluster/0.21.0/ -> canonicalized to /docs/vcluster/
+# - /docs/vcluster/0.22.0/ -> canonicalized to /docs/vcluster/
 
 Sitemap: https://www.vcluster.com/sitemap.xml


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
We want to keep indexing old docs versions, not to lose SEO. Since `docusaurus` generates [automatically canonical links](https://docusaurus.io/docs/seo#single-page-metadata) for every page, we do not need to specify additional configuration.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-862--vcluster-docs-site.netlify.app/docs/

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
References DOC-789

