### PR TITLE
feat: add sitemap for better search engine crawling results

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -84,7 +84,44 @@ const config = {
             },
           },
         },
+        sitemap: {
+          changefreq: 'weekly',
+          priority: 0.5,
+          ignorePatterns: ['/tags/**', '/search/**', '*/page/*'],
+          filename: 'sitemap.xml',
+          createSitemapItems: async (params) => {
+            const { defaultCreateSitemapItems, ...rest } = params;
+            const items = await defaultCreateSitemapItems(rest);
 
+            // Filter out pagination and unwanted pages
+            const filteredItems = items.filter((item) => !item.url.includes('/page/'));
+
+            // Enhance items with custom priorities and change frequencies
+            return filteredItems.map((item) => {
+              // Main landing pages get highest priority
+              if (item.url === 'https://vcluster.com/docs/' ||
+                  item.url === 'https://vcluster.com/docs/vcluster/' ||
+                  item.url === 'https://vcluster.com/docs/platform/') {
+                return { ...item, priority: 1.0, changefreq: 'daily' };
+              }
+
+              // Current versions (non-versioned URLs) get high priority
+              if ((item.url.includes('/vcluster/') && !item.url.match(/\/vcluster\/\d+\.\d+\.\d+\//)) ||
+                  (item.url.includes('/platform/') && !item.url.match(/\/platform\/\d+\.\d+\.\d+\//))) {
+                return { ...item, priority: 0.8, changefreq: 'weekly' };
+              }
+
+              // All versioned docs get lower priority
+              if (item.url.match(/\/vcluster\/\d+\.\d+\.\d+\//) ||
+                  item.url.match(/\/platform\/\d+\.\d+\.\d+\//)) {
+                return { ...item, priority: 0.3, changefreq: 'monthly' };
+              }
+
+              // Default priority for other pages
+              return item;
+            });
+          },
+        },
         theme: {
           customCss: resolveGlob.sync(["./src/css/**/*.scss"]),
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@docusaurus/core": "3.8.0",
         "@docusaurus/faster": "^3.8.0",
+        "@docusaurus/plugin-sitemap": "^3.8.1",
         "@docusaurus/preset-classic": "3.8.0",
         "@docusaurus/theme-classic": "3.8.0",
         "@docusaurus/theme-mermaid": "3.8.0",
@@ -2188,9 +2189,9 @@
       }
     },
     "node_modules/@csstools/postcss-cascade-layers": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-cascade-layers/-/postcss-cascade-layers-5.0.1.tgz",
-      "integrity": "sha512-XOfhI7GShVcKiKwmPAnWSqd2tBR0uxt+runAxttbSp/LY2U16yAVPmAf7e9q4JJ0d+xMNmpwNDLBXnmRCl3HMQ==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-cascade-layers/-/postcss-cascade-layers-5.0.2.tgz",
+      "integrity": "sha512-nWBE08nhO8uWl6kSAeCx4im7QfVko3zLrtgWZY4/bP87zrSPpSyN/3W3TDqz1jJuH+kbKOHXg5rJnK+ZVYcFFg==",
       "funding": [
         {
           "type": "github",
@@ -2551,9 +2552,9 @@
       }
     },
     "node_modules/@csstools/postcss-is-pseudo-class": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-5.0.1.tgz",
-      "integrity": "sha512-JLp3POui4S1auhDR0n8wHd/zTOWmMsmK3nQd3hhL6FhWPaox5W7j1se6zXOG/aP07wV2ww0lxbKYGwbBszOtfQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-5.0.3.tgz",
+      "integrity": "sha512-jS/TY4SpG4gszAtIg7Qnf3AS2pjcUM5SzxpApOrlndMeGhIbaTzWBzzP/IApXoNWEW7OhcjkRT48jnAUIFXhAQ==",
       "funding": [
         {
           "type": "github",
@@ -3632,17 +3633,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.8.0.tgz",
-      "integrity": "sha512-fGpOIyJvNiuAb90nSJ2Gfy/hUOaDu6826e5w5UxPmbpCIc7KlBHNAZ5g4L4ZuHhc4hdfq4mzVBsQSnne+8Ze1g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.8.1.tgz",
+      "integrity": "sha512-+9YV/7VLbGTq8qNkjiugIelmfUEVkTyLe6X8bWq7K5qPvGXAjno27QAfFq63mYfFFbJc7z+pudL63acprbqGzw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.8.0",
-        "@docusaurus/logger": "3.8.0",
-        "@docusaurus/types": "3.8.0",
-        "@docusaurus/utils": "3.8.0",
-        "@docusaurus/utils-common": "3.8.0",
-        "@docusaurus/utils-validation": "3.8.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -3653,6 +3654,302 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/babel": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.8.1.tgz",
+      "integrity": "sha512-3brkJrml8vUbn9aeoZUlJfsI/GqyFcDgQJwQkmBtclJgWDEQBKKeagZfOgx0WfUQhagL1sQLNW0iBdxnI863Uw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.9",
+        "@babel/generator": "^7.25.9",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+        "@babel/plugin-transform-runtime": "^7.25.9",
+        "@babel/preset-env": "^7.25.9",
+        "@babel/preset-react": "^7.25.9",
+        "@babel/preset-typescript": "^7.25.9",
+        "@babel/runtime": "^7.25.9",
+        "@babel/runtime-corejs3": "^7.25.9",
+        "@babel/traverse": "^7.25.9",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "babel-plugin-dynamic-import-node": "^2.3.3",
+        "fs-extra": "^11.1.1",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/bundler": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.8.1.tgz",
+      "integrity": "sha512-/z4V0FRoQ0GuSLToNjOSGsk6m2lQUG4FRn8goOVoZSRsTrU8YR2aJacX5K3RG18EaX9b+52pN4m1sL3MQZVsQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.25.9",
+        "@docusaurus/babel": "3.8.1",
+        "@docusaurus/cssnano-preset": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "babel-loader": "^9.2.1",
+        "clean-css": "^5.3.3",
+        "copy-webpack-plugin": "^11.0.0",
+        "css-loader": "^6.11.0",
+        "css-minimizer-webpack-plugin": "^5.0.1",
+        "cssnano": "^6.1.2",
+        "file-loader": "^6.2.0",
+        "html-minifier-terser": "^7.2.0",
+        "mini-css-extract-plugin": "^2.9.2",
+        "null-loader": "^4.0.1",
+        "postcss": "^8.5.4",
+        "postcss-loader": "^7.3.4",
+        "postcss-preset-env": "^10.2.1",
+        "terser-webpack-plugin": "^5.3.9",
+        "tslib": "^2.6.0",
+        "url-loader": "^4.1.1",
+        "webpack": "^5.95.0",
+        "webpackbar": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/faster": "*"
+      },
+      "peerDependenciesMeta": {
+        "@docusaurus/faster": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/core": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.8.1.tgz",
+      "integrity": "sha512-ENB01IyQSqI2FLtOzqSI3qxG2B/jP4gQPahl2C3XReiLebcVh5B5cB9KYFvdoOqOWPyr5gXK4sjgTKv7peXCrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/babel": "3.8.1",
+        "@docusaurus/bundler": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
+        "boxen": "^6.2.1",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.3",
+        "cli-table3": "^0.6.3",
+        "combine-promises": "^1.1.0",
+        "commander": "^5.1.0",
+        "core-js": "^3.31.1",
+        "detect-port": "^1.5.1",
+        "escape-html": "^1.0.3",
+        "eta": "^2.2.0",
+        "eval": "^0.1.8",
+        "execa": "5.1.1",
+        "fs-extra": "^11.1.1",
+        "html-tags": "^3.3.1",
+        "html-webpack-plugin": "^5.6.0",
+        "leven": "^3.1.0",
+        "lodash": "^4.17.21",
+        "open": "^8.4.0",
+        "p-map": "^4.0.0",
+        "prompts": "^2.4.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
+        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
+        "react-router": "^5.3.4",
+        "react-router-config": "^5.1.1",
+        "react-router-dom": "^5.3.4",
+        "semver": "^7.5.4",
+        "serve-handler": "^6.1.6",
+        "tinypool": "^1.0.2",
+        "tslib": "^2.6.0",
+        "update-notifier": "^6.0.2",
+        "webpack": "^5.95.0",
+        "webpack-bundle-analyzer": "^4.10.2",
+        "webpack-dev-server": "^4.15.2",
+        "webpack-merge": "^6.0.1"
+      },
+      "bin": {
+        "docusaurus": "bin/docusaurus.mjs"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "@mdx-js/react": "^3.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/cssnano-preset": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.8.1.tgz",
+      "integrity": "sha512-G7WyR2N6SpyUotqhGznERBK+x84uyhfMQM2MmDLs88bw4Flom6TY46HzkRkSEzaP9j80MbTN8naiL1fR17WQug==",
+      "license": "MIT",
+      "dependencies": {
+        "cssnano-preset-advanced": "^6.1.2",
+        "postcss": "^8.5.4",
+        "postcss-sort-media-queries": "^5.2.0",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/logger": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.8.1.tgz",
+      "integrity": "sha512-2wjeGDhKcExEmjX8k1N/MRDiPKXGF2Pg+df/bDDPnnJWHXnVEZxXj80d6jcxp1Gpnksl0hF8t/ZQw9elqj2+ww==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/mdx-loader": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.8.1.tgz",
+      "integrity": "sha512-DZRhagSFRcEq1cUtBMo4TKxSNo/W6/s44yhr8X+eoXqCLycFQUylebOMPseHi5tc4fkGJqwqpWJLz6JStU9L4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
+        "@mdx-js/mdx": "^3.0.0",
+        "@slorber/remark-comment": "^1.0.0",
+        "escape-html": "^1.0.3",
+        "estree-util-value-to-estree": "^3.0.1",
+        "file-loader": "^6.2.0",
+        "fs-extra": "^11.1.1",
+        "image-size": "^2.0.2",
+        "mdast-util-mdx": "^3.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "rehype-raw": "^7.0.0",
+        "remark-directive": "^3.0.0",
+        "remark-emoji": "^4.0.0",
+        "remark-frontmatter": "^5.0.0",
+        "remark-gfm": "^4.0.0",
+        "stringify-object": "^3.3.0",
+        "tslib": "^2.6.0",
+        "unified": "^11.0.3",
+        "unist-util-visit": "^5.0.0",
+        "url-loader": "^4.1.1",
+        "vfile": "^6.0.1",
+        "webpack": "^5.88.1"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/types": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.8.1.tgz",
+      "integrity": "sha512-ZPdW5AB+pBjiVrcLuw3dOS6BFlrG0XkS2lDGsj8TizcnREQg3J8cjsgfDviszOk4CweNfwo1AEELJkYaMUuOPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@mdx-js/mdx": "^3.0.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "commander": "^5.1.0",
+        "joi": "^17.9.2",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.95.0",
+        "webpack-merge": "^5.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/types/node_modules/webpack-merge": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+      "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/utils": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.8.1.tgz",
+      "integrity": "sha512-P1ml0nvOmEFdmu0smSXOqTS1sxU5tqvnc0dA4MTKV39kye+bhQnjkIKEE18fNOvxjyB86k8esoCIFM3x4RykOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "escape-string-regexp": "^4.0.0",
+        "execa": "5.1.1",
+        "file-loader": "^6.2.0",
+        "fs-extra": "^11.1.1",
+        "github-slugger": "^1.5.0",
+        "globby": "^11.1.0",
+        "gray-matter": "^4.0.3",
+        "jiti": "^1.20.0",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "micromatch": "^4.0.5",
+        "p-queue": "^6.6.2",
+        "prompts": "^2.4.2",
+        "resolve-pathname": "^3.0.0",
+        "tslib": "^2.6.0",
+        "url-loader": "^4.1.1",
+        "utility-types": "^3.10.0",
+        "webpack": "^5.88.1"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/utils-common": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.8.1.tgz",
+      "integrity": "sha512-zTZiDlvpvoJIrQEEd71c154DkcriBecm4z94OzEE9kz7ikS3J+iSlABhFXM45mZ0eN5pVqqr7cs60+ZlYLewtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/types": "3.8.1",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/utils-validation": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.8.1.tgz",
+      "integrity": "sha512-gs5bXIccxzEbyVecvxg6upTwaUbfa0KMmTj7HhHzc016AGyxH2o73k1/aOD0IFrdCsfJNt37MqNI47s2MgRZMA==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "fs-extra": "^11.2.0",
+        "joi": "^17.9.2",
+        "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
       }
     },
     "node_modules/@docusaurus/plugin-svgr": {
@@ -3699,6 +3996,30 @@
         "@docusaurus/theme-common": "3.8.0",
         "@docusaurus/theme-search-algolia": "3.8.0",
         "@docusaurus/types": "3.8.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-sitemap": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.8.0.tgz",
+      "integrity": "sha512-fGpOIyJvNiuAb90nSJ2Gfy/hUOaDu6826e5w5UxPmbpCIc7KlBHNAZ5g4L4ZuHhc4hdfq4mzVBsQSnne+8Ze1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.8.0",
+        "@docusaurus/logger": "3.8.0",
+        "@docusaurus/types": "3.8.0",
+        "@docusaurus/utils": "3.8.0",
+        "@docusaurus/utils-common": "3.8.0",
+        "@docusaurus/utils-validation": "3.8.0",
+        "fs-extra": "^11.1.1",
+        "sitemap": "^7.1.1",
+        "tslib": "^2.6.0"
       },
       "engines": {
         "node": ">=18.0"
@@ -7051,9 +7372,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.24.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
-      "integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
+      "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
       "funding": [
         {
           "type": "opencollective",
@@ -7070,8 +7391,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001716",
-        "electron-to-chromium": "^1.5.149",
+        "caniuse-lite": "^1.0.30001726",
+        "electron-to-chromium": "^1.5.173",
         "node-releases": "^2.0.19",
         "update-browserslist-db": "^1.1.3"
       },
@@ -7230,9 +7551,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001718",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
-      "integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
+      "version": "1.0.30001727",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001727.tgz",
+      "integrity": "sha512-pB68nIHmbN6L/4C6MH1DokyR3bYqFwjaSs/sWDHGj4CTcFtQUQMuJftVwWkXq7mNWOybD3KhUv3oWHoGxgP14Q==",
       "funding": [
         {
           "type": "opencollective",
@@ -9478,9 +9799,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.159",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.159.tgz",
-      "integrity": "sha512-CEvHptWAMV5p6GJ0Lq8aheyvVbfzVrv5mmidu1D3pidoVNkB3tTBsTMVtPJ+rzRK5oV229mCLz9Zj/hNvU8GBA==",
+      "version": "1.5.181",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.181.tgz",
+      "integrity": "sha512-+ISMj8OIQ+0qEeDj14Rt8WwcTOiqHyAB+5bnK1K7xNNLjBJ4hRCQfUkw8RWtcLbfBzDwc15ZnKH0c7SNOfwiyA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -16197,9 +16518,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.3.tgz",
-      "integrity": "sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==",
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
       "funding": [
         {
           "type": "opencollective",
@@ -16216,7 +16537,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.8",
+        "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -16437,9 +16758,9 @@
       }
     },
     "node_modules/postcss-custom-properties": {
-      "version": "14.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-14.0.5.tgz",
-      "integrity": "sha512-UWf/vhMapZatv+zOuqlfLmYXeOhhHLh8U8HAKGI2VJ00xLRYoAJh4xv8iX6FB6+TLXeDnm0DBLMi00E0hodbQw==",
+      "version": "14.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-14.0.6.tgz",
+      "integrity": "sha512-fTYSp3xuk4BUeVhxCSJdIPhDLpJfNakZKoiTDx7yRGCdlZrSJR7mWKVOBS4sBF+5poPQFMj2YdXx1VHItBGihQ==",
       "funding": [
         {
           "type": "github",
@@ -17043,9 +17364,9 @@
       }
     },
     "node_modules/postcss-nesting": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.1.tgz",
-      "integrity": "sha512-VbqqHkOBOt4Uu3G8Dm8n6lU5+9cJFxiuty9+4rcoyRPO9zZS1JIs6td49VIoix3qYqELHlJIn46Oih9SAKo+yQ==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.2.tgz",
+      "integrity": "sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ==",
       "funding": [
         {
           "type": "github",
@@ -17058,7 +17379,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/selector-resolve-nested": "^3.0.0",
+        "@csstools/selector-resolve-nested": "^3.1.0",
         "@csstools/selector-specificity": "^5.0.0",
         "postcss-selector-parser": "^7.0.0"
       },
@@ -17070,9 +17391,9 @@
       }
     },
     "node_modules/postcss-nesting/node_modules/@csstools/selector-resolve-nested": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.0.0.tgz",
-      "integrity": "sha512-ZoK24Yku6VJU1gS79a5PFmC8yn3wIapiKmPgun0hZgEI5AOqgH2kiPRsPz1qkGv4HL+wuDLH83yQyk6inMYrJQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-resolve-nested/-/selector-resolve-nested-3.1.0.tgz",
+      "integrity": "sha512-mf1LEW0tJLKfWyvn5KdDrhpxHyuxpbNwTIwOYLIvsTffeyOf85j5oIzfG0yosxDgx/sswlqBnESYUcQH0vgZ0g==",
       "funding": [
         {
           "type": "github",
@@ -17366,9 +17687,9 @@
       }
     },
     "node_modules/postcss-preset-env": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.2.0.tgz",
-      "integrity": "sha512-cl13sPBbSqo1Q7Ryb19oT5NZO5IHFolRbIMdgDq4f9w1MHYiL6uZS7uSsjXJ1KzRIcX5BMjEeyxmAevVXENa3Q==",
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.2.4.tgz",
+      "integrity": "sha512-q+lXgqmTMdB0Ty+EQ31SuodhdfZetUlwCA/F0zRcd/XdxjzI+Rl2JhZNz5US2n/7t9ePsvuhCnEN4Bmu86zXlA==",
       "funding": [
         {
           "type": "github",
@@ -17381,7 +17702,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/postcss-cascade-layers": "^5.0.1",
+        "@csstools/postcss-cascade-layers": "^5.0.2",
         "@csstools/postcss-color-function": "^4.0.10",
         "@csstools/postcss-color-mix-function": "^3.0.10",
         "@csstools/postcss-color-mix-variadic-function-arguments": "^1.0.0",
@@ -17393,7 +17714,7 @@
         "@csstools/postcss-hwb-function": "^4.0.10",
         "@csstools/postcss-ic-unit": "^4.0.2",
         "@csstools/postcss-initial": "^2.0.1",
-        "@csstools/postcss-is-pseudo-class": "^5.0.1",
+        "@csstools/postcss-is-pseudo-class": "^5.0.3",
         "@csstools/postcss-light-dark-function": "^2.0.9",
         "@csstools/postcss-logical-float-and-clear": "^3.0.0",
         "@csstools/postcss-logical-overflow": "^2.0.0",
@@ -17415,7 +17736,7 @@
         "@csstools/postcss-trigonometric-functions": "^4.0.9",
         "@csstools/postcss-unset-value": "^4.0.0",
         "autoprefixer": "^10.4.21",
-        "browserslist": "^4.24.5",
+        "browserslist": "^4.25.0",
         "css-blank-pseudo": "^7.0.1",
         "css-has-pseudo": "^7.0.2",
         "css-prefers-color-scheme": "^10.0.0",
@@ -17426,7 +17747,7 @@
         "postcss-color-hex-alpha": "^10.0.0",
         "postcss-color-rebeccapurple": "^10.0.0",
         "postcss-custom-media": "^11.0.6",
-        "postcss-custom-properties": "^14.0.5",
+        "postcss-custom-properties": "^14.0.6",
         "postcss-custom-selectors": "^8.0.5",
         "postcss-dir-pseudo-class": "^9.0.1",
         "postcss-double-position-gradients": "^6.0.2",
@@ -17437,7 +17758,7 @@
         "postcss-image-set-function": "^7.0.0",
         "postcss-lab-function": "^7.0.10",
         "postcss-logical": "^8.1.0",
-        "postcss-nesting": "^13.0.1",
+        "postcss-nesting": "^13.0.2",
         "postcss-opacity-percentage": "^3.0.0",
         "postcss-overflow-shorthand": "^6.0.0",
         "postcss-page-break": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@docusaurus/core": "3.8.0",
     "@docusaurus/faster": "^3.8.0",
+    "@docusaurus/plugin-sitemap": "^3.8.1",
     "@docusaurus/preset-classic": "3.8.0",
     "@docusaurus/theme-classic": "3.8.0",
     "@docusaurus/theme-mermaid": "3.8.0",

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -15,4 +15,4 @@ Disallow: /docs/vcluster/0.19.0/
 # - /docs/vcluster/0.21.0/ -> canonicalized to /docs/vcluster/
 # - /docs/vcluster/0.22.0/ -> canonicalized to /docs/vcluster/
 
-Sitemap: https://www.vcluster.com/sitemap.xml
+Sitemap: https://vcluster.com/docs/sitemap.xml


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Adding [sitemap plugin](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-sitemap) for better search engine indexing. Each page has its own canonical link generated. Added config for dynamic priorities based on content type.

- Guide search engines to prioritize important content
- Downrank EOL versions while keeping them indexed
  - **Priorities**: Home (1.0) → Current (stable) versions (0.9) → All other versions (0.3)
  - **Changefreq**: Daily for home, weekly for active docs, older versions

## Note for testing

- verify that the sitemap is there `curl -s https://deploy-preview-863--vcluster-docs-site.netlify.app/docs/sitemap.xml | head -100`
- and has correct priorities and frequencies (spot checks)
- verify docs work as expected (spot checks)

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-863--vcluster-docs-site.netlify.app/docs/

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
References DOC-789

