### PR TITLE
fix(kai-scheduler): add enterprise admonition

### DIFF
--- a/vcluster/learn-how-to/configure-kai-scheduler.mdx
+++ b/vcluster/learn-how-to/configure-kai-scheduler.mdx
@@ -40,7 +40,7 @@ Add the following to your vCluster configuration (`values.yaml` for Helm or vClu
 <ProAdmonition />
 
 :::info
-Learn more about [syncing custom resources](/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources).
+For more information on syncing custom resources, see the [Custom resources](/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources) documentation. 
 :::
 
 ```yaml title="Complete vCluster configuration for KAI scheduler"

--- a/vcluster/learn-how-to/configure-kai-scheduler.mdx
+++ b/vcluster/learn-how-to/configure-kai-scheduler.mdx
@@ -5,6 +5,7 @@ description: Learn how to configure vCluster to work with NVIDIA KAI scheduler f
 ---
 
 import BasePrerequisites from '@site/docs/_partials/base-prerequisites.mdx';
+import ProAdmonition from '../_partials/admonitions/pro-admonition.mdx';
 
 # Configure NVIDIA KAI scheduler with vCluster {#configure-kai-scheduler-with-vCluster}
 
@@ -35,6 +36,12 @@ To properly integrate vCluster with KAI scheduler, you need to configure two thi
 2. **Sync PodGroup resources** to prevent controller conflicts
 
 Add the following to your vCluster configuration (`values.yaml` for Helm or vCluster config):
+
+<ProAdmonition />
+
+:::info
+Learn more about [syncing custom resources](/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources).
+:::
 
 ```yaml title="Complete vCluster configuration for KAI scheduler"
 # highlight-start


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-865--vcluster-docs-site.netlify.app/docs/vcluster/next/learn-how-to/configure-kai-scheduler

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-787

