### PR TITLE
feat: add rate limiting configuration

### DIFF
--- a/scripts/wrap-glossary-terms.js
+++ b/scripts/wrap-glossary-terms.js
@@ -88,6 +88,20 @@ function isInProtectedArea(content, position, term) {
     }
   }
   
+  // Check if inside an import statement
+  const lineStart = content.lastIndexOf('\n', position) + 1;
+  const lineEnd = content.indexOf('\n', position);
+  const currentLine = content.substring(lineStart, lineEnd === -1 ? content.length : lineEnd);
+  if (currentLine.trim().startsWith('import ')) {
+    return true;
+  }
+  
+  // Check if inside a markdown header (# ## ### etc.)
+  const headerPattern = /^#{1,6}\s/;
+  if (headerPattern.test(currentLine.trim())) {
+    return true;
+  }
+  
   // Check if inside code blocks (backticks)
   let insideCode = false;
   let backticksCount = 0;

--- a/src/data/glossary.yaml
+++ b/src/data/glossary.yaml
@@ -103,3 +103,23 @@ sleep-mode:
   definition: "A platform feature that allows virtual clusters or namespaces to be paused when inactive, conserving resources and reducing costs."
   related: ["platform"]
   type: "platform"
+
+api-server:
+  term: "API Server"
+  definition: "The core component of Kubernetes that exposes the Kubernetes API. It is the front-end for the Kubernetes control plane and handles all REST operations, validating and configuring data for API objects."
+  related: ["control-plane", "rate-limiting"]
+  type: ["vcluster", "platform"]
+  url: "https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/"
+
+control-plane:
+  term: "Control Plane"
+  definition: "The container orchestration layer that exposes the API and interfaces to define, deploy, and manage the lifecycle of containers. In vCluster, each virtual cluster has its own control plane components."
+  related: ["api-server", "vcluster"]
+  type: ["vcluster", "platform"]
+
+admission-control:
+  term: "Admission Control"
+  definition: "A Kubernetes feature that intercepts requests to the API server prior to persistence of the object, allowing for validation, mutation, or rejection of requests based on configured policies."
+  related: ["api-server", "control-plane"]
+  type: ["vcluster", "platform"]
+  url: "/docs/vcluster/configure/vcluster-yaml/policies/admission-control"

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
@@ -43,6 +43,46 @@ The `tag` field specifies the Kubernetes version to use. By default, it uses v1.
 The `controlPlane.distro.k8s.version` field is deprecated. Use `controlPlane.distro.k8s.image.tag` instead to specify the Kubernetes version.
 :::
 
+## Configure API server rate limiting {#api-server-rate-limiting}
+
+You can configure rate limiting for the vCluster API server to control the maximum number of requests it handles. This helps prevent the virtual cluster from overwhelming the host cluster's control plane and ensures stable performance under high load.
+
+Use the `extraArgs` field to pass rate limiting flags to the API server:
+
+```yaml title="vcluster.yaml"
+controlPlane:
+  distro:
+    k8s:
+      apiServer:
+        extraArgs:
+          - --max-requests-inflight=300
+          - --max-mutating-requests-inflight=100
+```
+
+### Rate limiting options {#rate-limiting-options}
+
+The [Kubernetes API server](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/) supports these rate limiting flags:
+
+- `--max-requests-inflight`: Maximum number of non-mutating requests (GET, LIST) that can be served at the same time. Default is 400.
+- `--max-mutating-requests-inflight`: Maximum number of mutating requests (POST, PUT, PATCH, DELETE) that can be served at the same time. Default is 200.
+
+:::info API Priority and Fairness
+Starting with Kubernetes 1.20, the [API Priority and Fairness](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/) feature changes how these limits work. When enabled, the total concurrency limit becomes the sum of both flags, and requests are distributed across configurable priority levels.
+:::
+
+### Choose appropriate values {#choosing-values}
+
+When setting rate limits, consider:
+
+- **Workload patterns**: Higher limits for read-heavy workloads, balanced limits for mixed workloads
+- **Available resources**: Ensure the host cluster has sufficient CPU and memory to handle the configured limits
+- **Client behavior**: Applications with many concurrent API calls may need higher limits
+- **Platform limits**: Some managed Kubernetes platforms (like [EKS](https://docs.aws.amazon.com/eks/latest/best-practices/scale-control-plane.html)) may scale these values automatically
+
+:::tip
+Start with conservative values and monitor the API server's performance. Increase limits gradually based on actual usage patterns and available resources. Consider implementing [resource quotas](../../../policies/resource-quota.mdx) and [CPU/memory limits](../../../../../troubleshoot/configure-memory-limits.mdx) alongside rate limiting for comprehensive resource management. You can also configure [admission control policies](../../../policies/admission-control.mdx) to further control resource usage.
+:::
+
 ## Config reference
 
 <DistroK8s/>

--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
@@ -11,7 +11,7 @@ import DefaultDistroNote from '../../../../../_fragments/default-distro-note.mdx
 
 <DefaultDistroNote/>
 
-By default, vCluster uses an embedded SQLite as the [backing store](../backing-store/README.mdx) when you use the K8s distribution.
+By default, <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> uses an embedded SQLite as the [backing store](../backing-store/README.mdx) when you use the <GlossaryTerm term="k8s">K8s</GlossaryTerm> distribution.
 
 :::warning
 After deploying your vCluster, there are limited migration paths to change your backing store. Review the backing store migration options before deploying.
@@ -23,7 +23,7 @@ After deploying your vCluster, there are limited migration paths to change your 
 
 ## Configure Kubernetes version and image options {#setting-kubernetes-version}
 
-When using the K8s distribution, you can configure the container image for the Kubernetes components. The K8s distribution deploys the API server, controller manager, and scheduler as a single container from the [loft-sh/kubernetes](https://github.com/loft-sh/kubernetes) repository.
+When using the K8s distribution, you can configure the container image for the Kubernetes components. The K8s distribution deploys the <GlossaryTerm term="api-server">API server</GlossaryTerm>, controller manager, and scheduler as a single container from the [loft-sh/kubernetes](https://github.com/loft-sh/kubernetes) repository.
 
 You can customize the container image by specifying the registry, repository, and tag in your vCluster configuration:
 
@@ -37,7 +37,7 @@ controlPlane:
         tag: v1.32.1                # Default: v1.32.1 (or matches host Kubernetes version)
 ```
 
-The `tag` field specifies the Kubernetes version to use. By default, it uses v1.32.1 or matches the host cluster's Kubernetes version.
+The `tag` field specifies the Kubernetes version to use. By default, it uses v1.32.1 or matches the <GlossaryTerm term="host-cluster">host cluster</GlossaryTerm>'s Kubernetes version.
 
 :::note
 The `controlPlane.distro.k8s.version` field is deprecated. Use `controlPlane.distro.k8s.image.tag` instead to specify the Kubernetes version.
@@ -45,7 +45,7 @@ The `controlPlane.distro.k8s.version` field is deprecated. Use `controlPlane.dis
 
 ## Configure API server rate limiting {#api-server-rate-limiting}
 
-You can configure rate limiting for the vCluster API server to control the maximum number of requests it handles. This helps prevent the virtual cluster from overwhelming the host cluster's control plane and ensures stable performance under high load.
+You can configure rate limiting for the vCluster API server to control the maximum number of requests it handles. This helps prevent the <GlossaryTerm term="virtual-cluster">virtual cluster</GlossaryTerm> from overwhelming the host cluster's <GlossaryTerm term="control-plane">control plane</GlossaryTerm> and ensures stable performance under high load.
 
 Use the `extraArgs` field to pass rate limiting flags to the API server:
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- tested locally on KIND cluster
- minor fix in the `glossary-wrapper` to prevent tags wrapping in import paths and markdown headers
- extending glossary with related terms

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-868--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/control-plane/components/distro/k8s#api-server-rate-limiting

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-765

