### PR TITLE
fix: yaml indentation in the eks cluster creation examples

### DIFF
--- a/vcluster/deploy/environment/eks.mdx
+++ b/vcluster/deploy/environment/eks.mdx
@@ -42,32 +42,38 @@ Start by creating EKS cluster using `eksctl`. This command creates a file named
 
 <!-- vale off -->
 <InterpolatedCodeBlock
-  code={`# This will create a file with your custom values
-cat << EOF > cluster.yaml
-apiVersion: eksctl.io/v1alpha5
-kind: ClusterConfig
-metadata:
-  name: [[VAR:CLUSTER_NAME:vcluster-demo]]
-  region: [[VAR:REGION:eu-central-1]]
-nodeGroups:
-  - name: ng-1
-    instanceType: [[VAR:INSTANCE_TYPE:t3.medium]]
-    desiredCapacity: 2
-    iam:
-      withAddonPolicies:
-        ebs: true
-    volumeSize: 80
-
-addons:
-- name: aws-ebs-csi-driver
-  wellKnownPolicies:      # this setting adds IAM and service account
-    ebsCSIController: true
-EOF`}
+  code={'# This will create a file with your custom values\n' +
+'cat << EOF > cluster.yaml\n' +
+'apiVersion: eksctl.io/v1alpha5\n' +
+'kind: ClusterConfig\n' +
+'metadata:\n' +
+'  name: [[VAR:CLUSTER_NAME:vcluster-demo]]\n' +
+'  region: [[VAR:REGION:eu-central-1]]\n' +
+'iam:\n' +
+'  withOIDC: true\n' +
+'nodeGroups:\n' +
+'  - name: ng-1\n' +
+'    instanceType: [[VAR:INSTANCE_TYPE:t3.medium]]\n' +
+'    desiredCapacity: 2\n' +
+'    iam:\n' +
+'      withAddonPolicies:\n' +
+'        ebs: true\n' +
+'    volumeSize: 80\n' +
+'\n' +
+'addons:\n' +
+'  - name: aws-ebs-csi-driver\n' +
+'    version: latest\n' +
+'    attachPolicyARNs:\n' +
+'      - arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy\n' +
+'EOF'}
   language="bash"
 />
 <!-- vale on -->
 
-The file defines a cluster with two `t3.medium` instances located in the `eu-central-1` region. The `aws-ebs-csi-driver` add-on is enabled to ensure proper EBS storage provisioning, which is required by `vCluster` to store data for virtual clusters.
+The file defines a cluster with two `t3.medium` instances located in the `eu-central-1` region. The configuration includes:
+- OIDC provider enabled for IAM roles for service accounts
+- Node group with EBS addon policy for volume management
+- EBS CSI driver addon with the official AWS managed IAM policy
 
 Create the cluster by running:
 

--- a/vcluster_versioned_docs/version-0.22.0/deploy/environment/eks.mdx
+++ b/vcluster_versioned_docs/version-0.22.0/deploy/environment/eks.mdx
@@ -60,9 +60,9 @@ nodeGroups:
    volumeSize: 80
 
 addons:
-- name: aws-ebs-csi-driver
-  wellKnownPolicies:      # this setting adds IAM and service account
-    ebsCSIController: true
+  - name: aws-ebs-csi-driver
+    wellKnownPolicies:      # this setting adds IAM and service account
+      ebsCSIController: true
 EOF
 ```
 

--- a/vcluster_versioned_docs/version-0.23.0/deploy/environment/eks.mdx
+++ b/vcluster_versioned_docs/version-0.23.0/deploy/environment/eks.mdx
@@ -60,9 +60,9 @@ nodeGroups:
    volumeSize: 80
 
 addons:
-- name: aws-ebs-csi-driver
-  wellKnownPolicies:      # this setting adds IAM and service account
-    ebsCSIController: true
+  - name: aws-ebs-csi-driver
+    wellKnownPolicies:      # this setting adds IAM and service account
+      ebsCSIController: true
 EOF
 ```
 

--- a/vcluster_versioned_docs/version-0.24.0/deploy/environment/eks.mdx
+++ b/vcluster_versioned_docs/version-0.24.0/deploy/environment/eks.mdx
@@ -63,9 +63,9 @@ nodeGroups:
    volumeSize: 80
 
 addons:
-- name: aws-ebs-csi-driver
-  wellKnownPolicies:      # this setting adds IAM and service account
-    ebsCSIController: true
+  - name: aws-ebs-csi-driver
+    wellKnownPolicies:      # this setting adds IAM and service account
+      ebsCSIController: true
 EOF
 ```
 

--- a/vcluster_versioned_docs/version-0.25.0/deploy/environment/eks.mdx
+++ b/vcluster_versioned_docs/version-0.25.0/deploy/environment/eks.mdx
@@ -42,32 +42,35 @@ Start by creating EKS cluster using `eksctl`. This command creates a file named
 
 <!-- vale off -->
 <InterpolatedCodeBlock
-  code={`# This will create a file with your custom values
-cat << EOF > cluster.yaml
-apiVersion: eksctl.io/v1alpha5
-kind: ClusterConfig
-metadata:
-  name: [[VAR:CLUSTER_NAME:vcluster-demo]]
-  region: [[VAR:REGION:eu-central-1]]
-nodeGroups:
-  - name: ng-1
-    instanceType: [[VAR:INSTANCE_TYPE:t3.medium]]
-    desiredCapacity: 2
-    iam:
-      withAddonPolicies:
-        ebs: true
-    volumeSize: 80
-
-addons:
-- name: aws-ebs-csi-driver
-  wellKnownPolicies:      # this setting adds IAM and service account
-    ebsCSIController: true
-EOF`}
+  code={'# This will create a file with your custom values\n' +
+'cat << EOF > cluster.yaml\n' +
+'apiVersion: eksctl.io/v1alpha5\n' +
+'kind: ClusterConfig\n' +
+'metadata:\n' +
+'  name: [[VAR:CLUSTER_NAME:vcluster-demo]]\n' +
+'  region: [[VAR:REGION:eu-central-1]]\n' +
+'iam:\n' +
+'  withOIDC: true\n' +
+'nodeGroups:\n' +
+'  - name: ng-1\n' +
+'    instanceType: [[VAR:INSTANCE_TYPE:t3.medium]]\n' +
+'    desiredCapacity: 2\n' +
+'    iam:\n' +
+'      withAddonPolicies:\n' +
+'        ebs: true\n' +
+'    volumeSize: 80\n' +
+'\n' +
+'addons:\n' +
+'  - name: aws-ebs-csi-driver\n' +
+'    version: latest\n' +
+'    attachPolicyARNs:\n' +
+'      - arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy\n' +
+'EOF'}
   language="bash"
 />
 <!-- vale on -->
 
-The file defines a cluster with two `t3.medium` instances located in the `eu-central-1` region. The `aws-ebs-csi-driver` add-on is enabled to ensure proper EBS storage provisioning, which is required by `vCluster` to store data for virtual clusters.
+The file defines a cluster with two `t3.medium` instances located in the `eu-central-1` region. The cluster is configured with IAM OIDC provider support, which enables fine-grained IAM role permissions for service accounts. The `aws-ebs-csi-driver` add-on is configured with the appropriate IAM policy to ensure proper EBS storage provisioning, which is required by `vCluster` to store data for virtual clusters.
 
 Create the cluster by running:
 

--- a/vcluster_versioned_docs/version-0.26.0/deploy/environment/eks.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/deploy/environment/eks.mdx
@@ -42,32 +42,35 @@ Start by creating EKS cluster using `eksctl`. This command creates a file named
 
 <!-- vale off -->
 <InterpolatedCodeBlock
-  code={`# This will create a file with your custom values
-cat << EOF > cluster.yaml
-apiVersion: eksctl.io/v1alpha5
-kind: ClusterConfig
-metadata:
-  name: [[VAR:CLUSTER_NAME:vcluster-demo]]
-  region: [[VAR:REGION:eu-central-1]]
-nodeGroups:
-  - name: ng-1
-    instanceType: [[VAR:INSTANCE_TYPE:t3.medium]]
-    desiredCapacity: 2
-    iam:
-      withAddonPolicies:
-        ebs: true
-    volumeSize: 80
-
-addons:
-- name: aws-ebs-csi-driver
-  wellKnownPolicies:      # this setting adds IAM and service account
-    ebsCSIController: true
-EOF`}
+  code={'# This will create a file with your custom values\n' +
+'cat << EOF > cluster.yaml\n' +
+'apiVersion: eksctl.io/v1alpha5\n' +
+'kind: ClusterConfig\n' +
+'metadata:\n' +
+'  name: [[VAR:CLUSTER_NAME:vcluster-demo]]\n' +
+'  region: [[VAR:REGION:eu-central-1]]\n' +
+'iam:\n' +
+'  withOIDC: true\n' +
+'nodeGroups:\n' +
+'  - name: ng-1\n' +
+'    instanceType: [[VAR:INSTANCE_TYPE:t3.medium]]\n' +
+'    desiredCapacity: 2\n' +
+'    iam:\n' +
+'      withAddonPolicies:\n' +
+'        ebs: true\n' +
+'    volumeSize: 80\n' +
+'\n' +
+'addons:\n' +
+'  - name: aws-ebs-csi-driver\n' +
+'    version: latest\n' +
+'    attachPolicyARNs:\n' +
+'      - arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy\n' +
+'EOF'}
   language="bash"
 />
 <!-- vale on -->
 
-The file defines a cluster with two `t3.medium` instances located in the `eu-central-1` region. The `aws-ebs-csi-driver` add-on is enabled to ensure proper EBS storage provisioning, which is required by `vCluster` to store data for virtual clusters.
+The file defines a cluster with two `t3.medium` instances located in the `eu-central-1` region. The cluster is configured with IAM OIDC provider support, which enables fine-grained IAM role permissions for service accounts. The `aws-ebs-csi-driver` add-on is configured with the appropriate IAM policy to ensure proper EBS storage provisioning, which is required by `vCluster` to store data for virtual clusters.
 
 Create the cluster by running:
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- fixes indentation issues when YAML snippets are wrapped in bash here docs
- the InterpolatedCodeBlock component works correctly, however it needs string literals in the above case
- further adjustments to the component planned to improve tech writer's design time flow


## Note for the reviewer
- test the YAML commands for correctness
- ensure no regression bugs were introduced
- confirm older versions are correct as well

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-870--vcluster-docs-site.netlify.app/docs/vcluster/next/deploy/environment/eks

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-800

