### PR TITLE
feat: add llm.txt endpoint for LLMs discovery

### DIFF
--- a/static/llm.txt
+++ b/static/llm.txt
@@ -1,0 +1,101 @@
+# vCluster
+
+> vCluster is an open-source project by LoftLabs that creates lightweight, fully functional Kubernetes clusters that run inside namespaces of other Kubernetes clusters.
+
+Virtual clusters are certified Kubernetes distributions that run as isolated, virtual environments nested inside a physical host cluster. They improve isolation and flexibility for multi-tenancy by allowing multiple teams to operate independently on the same infrastructure, minimizing conflicts, increasing autonomy, and reducing costs.
+
+## Getting Started
+
+- [Quick Start Guide](https://www.vcluster.com/docs/vcluster/quick-start-guide): Create your first virtual cluster in minutes
+- [Installation](https://www.vcluster.com/docs/vcluster/deploy/basics): Installation options and requirements
+- [What are Virtual Clusters](https://www.vcluster.com/docs/vcluster/introduction/what-are-virtual-clusters): Core concepts and benefits
+
+## Core Documentation
+
+- [Architecture](https://www.vcluster.com/docs/vcluster/introduction/architecture): How vCluster works under the hood
+- [vCluster Configuration](https://www.vcluster.com/docs/vcluster/configure/what-is-vcluster-yaml): Customize virtual clusters with vcluster.yaml
+- [Networking](https://www.vcluster.com/docs/vcluster/configure/vcluster-yaml/networking): DNS, services, and ingress configuration
+- [Storage](https://www.vcluster.com/docs/vcluster/configure/vcluster-yaml/sync/to-host/storage): Persistent volumes and storage classes
+- [Security](https://www.vcluster.com/docs/vcluster/deploy/security/rootless-mode): Rootless mode and security best practices
+
+## CLI Reference
+
+- [vCluster CLI](https://www.vcluster.com/docs/vcluster/cli/vcluster_create): Complete command reference
+- [vcluster create](https://www.vcluster.com/docs/vcluster/cli/vcluster_create): Create virtual clusters
+- [vcluster connect](https://www.vcluster.com/docs/vcluster/cli/vcluster_connect): Connect to virtual clusters
+- [vcluster list](https://www.vcluster.com/docs/vcluster/cli/vcluster_list): List virtual clusters
+
+## vCluster Platform
+
+- [Platform Overview](https://www.vcluster.com/docs/platform): Multi-cluster management platform
+- [Platform Installation](https://www.vcluster.com/docs/platform/install/quick-start-guide): Deploy the platform
+- [Platform API](https://www.vcluster.com/docs/platform/api/authentication): REST API reference
+- [GitOps Integration](https://www.vcluster.com/docs/platform/install/gitops): Deploy with ArgoCD or Flux
+
+## Use Cases
+
+- [Development Environments](https://www.vcluster.com/docs/vcluster/introduction/what-are-virtual-clusters#development-environments): Isolated dev clusters for each engineer
+- [CI/CD Pipelines](https://www.vcluster.com/docs/vcluster/integrations/github-actions/pull-requests): Ephemeral clusters for testing
+- [Multi-Tenancy](https://www.vcluster.com/docs/vcluster/introduction/what-are-virtual-clusters#multi-tenancy): Secure tenant isolation
+- [Version Testing](https://www.vcluster.com/docs/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s): Test different Kubernetes versions
+
+## Integrations
+
+- [GitHub Actions](https://www.vcluster.com/docs/vcluster/integrations/github-actions/pull-requests): CI/CD integration
+- [ArgoCD](https://www.vcluster.com/docs/platform/integrations/argocd): GitOps deployment
+- [Flux](https://www.vcluster.com/docs/vcluster/deploy/flux): GitOps with Flux
+- [External Secrets](https://www.vcluster.com/docs/vcluster/integrations/external-secrets/guide): Secret management
+- [Cert Manager](https://www.vcluster.com/docs/vcluster/integrations/certManager): Certificate management
+- [Istio](https://www.vcluster.com/docs/vcluster/integrations/istio): Service mesh integration
+
+## Advanced Topics
+
+- [High Availability](https://www.vcluster.com/docs/vcluster/deploy/topologies/high-availability): Multi-replica deployments
+- [Air-Gapped Environments](https://www.vcluster.com/docs/vcluster/deploy/topologies/air-gapped): Offline installations
+- [Sleep Mode](https://www.vcluster.com/docs/vcluster/configure/vcluster-yaml/sleep-mode): Auto-scaling to zero
+- [Multi-Namespace Mode](https://www.vcluster.com/docs/vcluster/configure/vcluster-yaml/experimental/isolated-control-plane): Enhanced workload isolation
+- [Monitoring](https://www.vcluster.com/docs/platform/administer/monitoring/metrics): Metrics and observability
+
+## Troubleshooting
+
+- [Troubleshooting Guide](https://www.vcluster.com/docs/vcluster/troubleshoot): Common issues and solutions
+- [Memory Limits](https://www.vcluster.com/docs/vcluster/troubleshoot/configure-memory-limits): Resource configuration
+- [Syncer Issues](https://www.vcluster.com/docs/vcluster/troubleshoot/sync-labels): Sync troubleshooting
+
+## Quick Start
+
+```bash
+# Install vCluster CLI
+curl -L -o vcluster "https://github.com/loft-sh/vcluster/releases/latest/download/vcluster-$(uname -s)-$(uname -m)"
+sudo install -c -m 0755 vcluster /usr/local/bin
+
+# Create a virtual cluster
+vcluster create my-vcluster
+
+# Connect to the virtual cluster
+vcluster connect my-vcluster
+
+# Use kubectl with the virtual cluster
+kubectl get namespaces
+```
+
+## Architecture Overview
+
+vCluster consists of:
+- **Control Plane**: Runs inside a StatefulSet/Deployment in the host cluster
+- **API Server**: Kubernetes API (k3s/k8s/k0s) serving the virtual cluster
+- **Data Store**: SQLite (default), etcd, PostgreSQL, or MySQL
+- **Syncer**: Synchronizes resources between virtual and host clusters
+- **Scheduler**: Optional virtual scheduler or reuses host scheduler
+
+## Community & Support
+
+- [GitHub Repository](https://github.com/loft-sh/vcluster): Source code and issues
+- [Slack Community](https://slack.loft.sh): Get help and discuss with users
+- [Documentation](https://www.vcluster.com/docs): Complete documentation
+- [Blog](https://loft.sh/blog): Technical articles and updates
+- [YouTube](https://www.youtube.com/@loft-sh): Video tutorials and demos
+
+---
+
+*vCluster is a product of LoftLabs


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- adding llm.txt to help LLMs discover and reason about vCluster/platform
- for now it's manually curated, but in the future we can add CI updates if needed

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-674

