### PR TITLE
refactor: clarify API server rate limiting

### DIFF
--- a/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/distro/k8s.mdx
@@ -67,7 +67,7 @@ The [Kubernetes API server](https://kubernetes.io/docs/reference/command-line-to
 - `--max-mutating-requests-inflight`: Maximum number of mutating requests (POST, PUT, PATCH, DELETE) that can be served at the same time. Default is 200.
 
 :::note Impact on host cluster requests
-The `--max-requests-inflight` and `--max-mutating-requests-inflight` flags impact the number of requests to the host cluster only indirectly. With the exception of Service creation, all resource creation is handled by the syncer asynchronously, and it self-throttles at 40 QPS by default.
+The `--max-requests-inflight` and `--max-mutating-requests-inflight` flags only indirectly affect the number of requests sent to the host cluster. With the exception of Service creation, vCluster handles all resource creation asynchronously through the syncer, which self-throttles at a default rate of 40 QPS.
 :::
 
 :::info API Priority and Fairness


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-876--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/control-plane/components/distro/k8s#api-server-rate-limiting

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-805

