### PR TITLE
Certificates private nodes

### DIFF
--- a/vcluster/manage/certificates.mdx
+++ b/vcluster/manage/certificates.mdx
@@ -20,7 +20,7 @@ The virtual cluster must run the k8s distribution.
 :::
 
 :::important
-The virtual cluster must be in a
+The virtual cluster Pod must be in a
 [running](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-state-running)
 state otherwise the cert commands below abort the operation. In case of
 certificate expiration during runtime of a virtual cluster it will still be in
@@ -163,6 +163,92 @@ Log out and perform a regular leaf [certificate rotation](#rotate-client-and-ser
   code={`vcluster -n [[VAR:VCLUSTER NAMESPACE:my-vcluster]] certs rotate [[VAR:VCLUSTER NAME:my-vcluster]]`}
   language="bash"
 />
+
+</Step>
+</Flow>
+
+## Rotate the CA when running vCluster with Private Nodes
+
+:::important
+Node deletion should happen before the CA cert rotation. Otherwise the kubelet
+running on the Node is not able to communicate with the apiserver running with
+a new certificate.
+:::
+
+Before rotating the CA you first have to delete all previously joined Private
+Nodes and then after the rotation join them again to the virtual cluster. So
+the steps below have to be performed for each Private Node.
+
+### Steps before CA rotation
+
+<Flow>
+<Step>
+Connect to your virtual cluster:
+
+<InterpolatedCodeBlock
+  code={`vcluster -n [[VAR:VCLUSTER NAMESPACE:my-vcluster]] connect [[VAR:VCLUSTER NAME:my-vcluster]]`}
+  language="bash"
+/>
+
+</Step>
+<Step>
+Delete the previously joined Private Node:
+
+:::info
+`vcluster node delete` will try to evict any workload first before deleting the
+Node. In case there's no other Node left the workload will be stopped
+nevertheless. If you forgot to delete a Node before starting the CA rotation
+you have to append `--drain=false` to the below command.
+:::
+
+<InterpolatedCodeBlock
+  code={`vcluster node delete [[VAR:NODE NAME:my-node]]`}
+  language="bash"
+/>
+
+</Step>
+</Flow>
+
+### Steps after CA rotation
+
+<Flow>
+<Step>
+Connect to your virtual cluster:
+
+<InterpolatedCodeBlock
+  code={`vcluster -n [[VAR:VCLUSTER NAMESPACE:my-vcluster]] connect [[VAR:VCLUSTER NAME:my-vcluster]]`}
+  language="bash"
+/>
+
+</Step>
+<Step>
+Create a new join token:
+
+```bash
+vcluster token create
+```
+
+</Step>
+<Step>
+
+:::warning
+The `--force-join` flag leads to the running containers being killed via the
+container runtime and being restared by the kubelet. In case you have a
+stateful application running that requires graceful termination, please ensure
+that you have performed the necessary steps beforehand (vcluster node delete,
+backups etc.).
+:::
+
+Copy the command and adjust it to include the `--force-join` flag like in the example below:
+
+```bash
+curl -fsSLk "https://example.com:443/node/join?token=d34db33f" | sh -s -- --force-join
+```
+
+</Step>
+
+<Step>
+Login into your Private Node and execute the curl command from the step above.
 
 </Step>
 </Flow>

--- a/vcluster/manage/certificates.mdx
+++ b/vcluster/manage/certificates.mdx
@@ -1,6 +1,6 @@
 ---
-title: Certificates
-sidebar_label: Certificates
+title: Rotate certificates
+sidebar_label: Rotate Certificates
 sidebar_position: 5
 ---
 
@@ -10,13 +10,12 @@ import Flow, { Step } from "@site/src/components/Flow";
 <!--vale off-->
 
 vCluster client and server certificates (also called leaf certificates) remain valid for 1 year from the initial virtual cluster creation.
-By default, vCluster uses a self-signed Certificate Authority (CA) to sign these certificates. The CA remains valid for 10 years.
+By default, vCluster uses a self-signed Certificate Authority (CA) to sign these certificates. The CA certificate remains valid for 10 years.
 
-vCluster provides commands that allow you to check and rotate client, server, and CA certificates.
+vCluster provides commands that allow you to check details about the certificates as well as rotate them. 
 
 :::info
-Certificate rotation requires vCluster version v0.27.0 or higher.
-The virtual cluster must run the k8s distribution.
+Checking and rotating certificates is only supported for virtual clusters using the k8s distribution.
 :::
 
 :::important
@@ -39,7 +38,7 @@ The `vcluster certs check` command provides the following information for each c
 | Filename    | The name of the certificate file.                                                 |
 | Subject     | The common name of the subject of the certificate.                                |
 | Issuer      | The common name of the issuer of the certificate.                                 |
-| Expires On  | The date the certificate expires.                                                 |
+| Expires On  | The date when the certificate expires.                                              |
 | Status      | The expiry status of the certificate (either `OK`, `EXPIRED` or `NOT YET VALID`). |
 
 The following command shows this information as a table. You can change the format by using `--output`:
@@ -91,19 +90,25 @@ The restart does not affect running application workloads because the underlying
 Client and server leaf certificate rotation is less intrusive compared to [CA rotation](#rotate-ca-certificates).
 This means that connecting to the virtual cluster with previously issued kubeconfigs continues to work.
 
-## Rotate CA certificates {#rotate-ca-certificates}
+## Changing the CA certificate
 
 :::warning
 CA rotation replaces the Certificate Authority that validates all certificates in the cluster. This breaks existing client connections and requires regenerating all kubeconfigs. Use this command carefully, as it affects all cluster access.
-
-If the rotation fails, you can restore the previous PKI from the automatically created backup. For more information, see the documentation on [restoring the previous CA from a backup](#restore-the-previous-ca-from-a-backup) for recovery.
 :::
+
+When working with virtual clusters with private nodes, there are extra steps that need to happen before doing any changes to the CA certificate and
+after making the changes to the CA certificate. 
+
+
+### Rotate the CA Certificate
 
 The CA rotation command performs these operations:
 
 - **Creates PKI backup**: Backs up the existing certificate directory to enable recovery if needed.
 - **Generates new Certificate Authority**: Creates a new CA certificate and uses it to sign fresh certificates for all cluster components.
 - **Restarts virtual cluster**: Restarts the cluster to load the new certificates.
+
+If the rotation fails, you can restore the previous PKI from the automatically created backup. For more information, see the documentation on [restoring the previous CA from a backup](#restore-the-previous-ca-from-a-backup) for recovery.
 
 <br />
 <InterpolatedCodeBlock
@@ -113,18 +118,16 @@ The CA rotation command performs these operations:
 
 As this replaces the trust anchor completely, everything configured to trust the old CA becomes invalidated (for instance previously issued kubeconfigs).
 
-## Restore the previous CA from a backup {#restore-the-previous-ca-from-a-backup}
+### Restore the previous CA from a backup {#restore-the-previous-ca-from-a-backup}
 
-:::warning
-Use caution when performing the following operations. Verify each command before execution.
-:::
-
-:::note Backup creation
 The rotation creates a backup in the virtual cluster's data directory using the following pattern:
 
 ```bash
 /data/pki.bak/<unixtimestamp>
 ```
+
+:::warning
+Use caution when performing the following operations. Verify each command before execution.
 :::
 
 <Flow>
@@ -167,19 +170,20 @@ Log out and perform a regular leaf [certificate rotation](#rotate-client-and-ser
 </Step>
 </Flow>
 
-## Rotate the CA when running vCluster with Private Nodes
+## Steps required for private nodes during CA changes
 
 :::important
-Node deletion should happen before the CA cert rotation. Otherwise the kubelet
-running on the Node is not able to communicate with the apiserver running with
-a new certificate.
+Node deletion needs to happen before any CA cert changes whether it's rotating or restoring the cert. Otherwise, the kubelet
+running on the node is not able to communicate with the apiserver running with
+the updated certificate.
 :::
 
-Before rotating the CA you first have to delete all previously joined Private
-Nodes and then after the rotation join them again to the virtual cluster. So
-the steps below have to be performed for each Private Node.
+Before changing the CA certificate, by either rotating or restoring it, you must delete all previously joined private nodes. After the rotation, 
+you must re-join the nodes again to the virtual cluster. Each step must be performed on each private node. 
 
-### Steps before CA rotation
+### Steps before changing the CA certificate
+
+Before changing the CA certificate, by either rotating or restoring it, you need to delete the private nodes in the virtual cluster. 
 
 <Flow>
 <Step>
@@ -192,13 +196,13 @@ Connect to your virtual cluster:
 
 </Step>
 <Step>
-Delete the previously joined Private Node:
+Delete each private node:
 
 :::info
-`vcluster node delete` will try to evict any workload first before deleting the
-Node. In case there's no other Node left the workload will be stopped
-nevertheless. If you forgot to delete a Node before starting the CA rotation
-you have to append `--drain=false` to the below command.
+`vcluster node delete` tries to evict any workload before deleting the
+node from the virtual cluster. If there's no other node for the workload to be re-scheduled to, the 
+workload stops. If you forgot to delete a node before change the CA cert, 
+you must append `--drain=false` to successfully delete the node.  
 :::
 
 <InterpolatedCodeBlock
@@ -209,7 +213,10 @@ you have to append `--drain=false` to the below command.
 </Step>
 </Flow>
 
-### Steps after CA rotation
+### Steps after changing the CA certificate
+
+After changing the CA certificate, by either rotating or restoring it, you need to re-create a token to join the virtual cluster 
+and join the private nodes back to the virtual cluster. 
 
 <Flow>
 <Step>
@@ -231,15 +238,15 @@ vcluster token create
 </Step>
 <Step>
 
+Copy the command and append the `--force-join` flag. Run the updated command on every private node. 
+
 :::warning
-The `--force-join` flag leads to the running containers being killed via the
-container runtime and being restared by the kubelet. In case you have a
+The `--force-join` flag leads to running containers being killed via the
+container runtime and being restarted by the kubelet. If you have a
 stateful application running that requires graceful termination, please ensure
 that you have performed the necessary steps beforehand (vcluster node delete,
 backups etc.).
 :::
-
-Copy the command and adjust it to include the `--force-join` flag like in the example below:
 
 ```bash
 curl -fsSLk "https://example.com:443/node/join?token=d34db33f" | sh -s -- --force-join
@@ -247,8 +254,4 @@ curl -fsSLk "https://example.com:443/node/join?token=d34db33f" | sh -s -- --forc
 
 </Step>
 
-<Step>
-Login into your Private Node and execute the curl command from the step above.
-
-</Step>
 </Flow>


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description


## Preview Link 
https://deploy-preview-882--next-vcluster-docs-site.netlify.app/docs/vcluster/next/manage/certificates


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-808

