### PR TITLE
Add warning for embedded etcd upgrade to 3.6

### DIFF
--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded.mdx
@@ -17,15 +17,16 @@ import Admonition from '@theme/Admonition';
 
 <ProAdmonition/>
 
-<Admonition type="warning" title="Upgrade Notice">
-  There's an [issue](https://etcd.io/blog/2025/upgrade_from_3.5_to_3.6_issue/) with the upgrade path of etcd from `>=3.5.1 <3.5.20` to `3.6` that can lead to a failed upgrade and broken vcluster.
-  A fix was introduced to etcd in patch version `3.5.20` which migrates membership data to the v3 data store and prevents issues when upgrading further.
+:::warning Upgrade Notice
 
-  To circumvent the issue, we upgrade etcd to `3.6` earliest in vcluster version `0.29.0`.
-  Any vcluster with version `<0.24.2` must be upgraded to a version `<0.29.0` prior to the upgrade to `0.29.0`.
+An issue exists when upgrading etcd (from version 3.5.1 or later, but earlier than 3.5.20) to version 3.6. This upgrade path can lead to a failed upgrade and cause the virtual cluster to break. etcd version 3.5.20 includes a fix that migrates membership data to the v3 data store. This migration prevents the issue when upgrading to version 3.6.
 
-  Further information can be found in the [etcd Blog](https://etcd.io/blog/2025/upgrade_from_3.5_to_3.6_issue/).
-</Admonition>
+To avoid this issue, vCluster does not upgrade etcd to version 3.6 until vCluster version 0.29.0.
+
+Any vCluster running a version earlier than 0.24.2, must first be upgraded to a version between 0.24.2 and 0.28.x, before upgrading to version 0.29.0.
+
+For more information, see the [official etcd documentation](https://etcd.io/blog/2025/upgrade_from_3.5_to_3.6_issue/).
+:::
 
 When using this backing store option, etcd is deployed as part of the vCluster control plane pod to reduce the overall footprint.
 

--- a/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded.mdx
+++ b/vcluster/configure/vcluster-yaml/control-plane/components/backing-store/etcd/embedded.mdx
@@ -12,9 +12,20 @@ import InterpolatedCodeBlock from "@site/src/components/InterpolatedCodeBlock";
 import Flow, { Step } from '@site/src/components/Flow';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import Admonition from '@theme/Admonition';
 
 
 <ProAdmonition/>
+
+<Admonition type="warning" title="Upgrade Notice">
+  There's an [issue](https://etcd.io/blog/2025/upgrade_from_3.5_to_3.6_issue/) with the upgrade path of etcd from `>=3.5.1 <3.5.20` to `3.6` that can lead to a failed upgrade and broken vcluster.
+  A fix was introduced to etcd in patch version `3.5.20` which migrates membership data to the v3 data store and prevents issues when upgrading further.
+
+  To circumvent the issue, we upgrade etcd to `3.6` earliest in vcluster version `0.29.0`.
+  Any vcluster with version `<0.24.2` must be upgraded to a version `<0.29.0` prior to the upgrade to `0.29.0`.
+
+  Further information can be found in the [etcd Blog](https://etcd.io/blog/2025/upgrade_from_3.5_to_3.6_issue/).
+</Admonition>
 
 When using this backing store option, etcd is deployed as part of the vCluster control plane pod to reduce the overall footprint.
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Add an upgrade warning for the embedded etcd feature.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENG-6982