### PR TITLE
Add banner informing of the change of rewriteHosts config

### DIFF
--- a/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/README.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/core/pods/README.mdx
@@ -8,6 +8,13 @@ description: Configuration for ...
 import DisableResourceWarning from '../../../../../../_fragments/hints/warning-do-not-disable-resource.mdx'
 import Patches from '../../../../../../_fragments/patches.mdx'
 import SyncPods from '../../../../../../_partials/config/sync/toHost/pods.mdx'
+import Admonition from '@theme/Admonition';
+
+<Admonition type="info" title="Config change">
+  The configuration for the `rewriteHosts.initContainer.image` was changed in vcluster version `0.27.0`.
+  Instead of a string the field now accepts an object that allows more granular control over the registry, repository and tag of the image used.
+  See [config](#pods-rewriteHosts-initContainer) for details.
+</Admonition>
 
 By default, this is enabled.
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
Add info about config change.

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes ENG-7954