### PR TITLE
document agent-values endpoint

### DIFF
--- a/platform/configure/config.mdx
+++ b/platform/configure/config.mdx
@@ -34,7 +34,7 @@ The platform's `values.yaml` file contains multiple configuration sections:
 3. **Agent settings** - Control how the [platform agent](#work-with-the-platform-agent) operates in connected clusters
    - Set through the top-level `agentValues:` section of the `vcluster-platform` chart
    - Located in the platform Helm chart ([loft-sh/loft](https://github.com/loft-sh/loft/tree/master/chart))
-   - You can override these per-cluster with annotations
+   - You can [override](#understanding-agent-values) these per-cluster with annotations
 
 ### Distinguish between values.yaml and config sections {#understanding-the-difference}
 
@@ -314,6 +314,23 @@ The platform agent uses its own set of configuration values, which you can speci
 3. **Cluster-specific values**: The `loft.sh/agent-values` annotation on a Cluster resource overrides global values for that specific cluster.
 
 When the platform upgrades an agent, it uses the values from the `agentValues` section (or from the cluster annotation if present).
+
+### Retrieve agent values {#retrieve-agent-values}
+
+Supposing you have a platform instance on host `nimbus.vcluster.cloud` and a connected cluster called `staging`, the table below
+table show how to retrieve each tier of agent values for a specific cluster.  This can be useful in determining what the
+platform is using currently, or to combine rather than override values. For instance, with a Helm deploy you can specify
+`--values=https://<platform-config-endpoint> --values=https://<cluster-annotation-endpoint>`. Note that an
+[access key](/platform/administer/users-permissions/access-keys#how-access-keys-work) is required.
+<br></br>
+
+<!-- vale off -->
+| Host | Cluster Name | Source | Request | Response |
+|-|-|-|-|-|
+| nimbus.vcluster.cloud | staging | none | https://nimbus.vcluster.cloud/clusters/staging?token=access-key | Current agent values |
+| nimbus.vcluster.cloud | staging | platform-config | https://nimbus.vcluster.cloud/clusters/staging?token=access-key&source=platform-config | Content of `agentValues` section in platform config |
+| nimbus.vcluster.cloud | staging | cluster-annotation | https://nimbus.vcluster.cloud/clusters/staging?token=access-key&source=cluster-annotation | Value of the `loft.sh/agent-values` annotation on the `Cluster Object` |
+<!-- vale on -->
 
 ### Configure the agent through the platform {#configuring-the-agent-through-the-platform}
 

--- a/platform/configure/config.mdx
+++ b/platform/configure/config.mdx
@@ -327,11 +327,11 @@ An [access key](/platform/administer/users-permissions/access-keys#how-access-ke
 <br></br>
 
 <!-- vale off -->
-| Host | Cluster Name | Source | Request | Response |
-|-|-|-|-|-|
-| nimbus.vcluster.cloud | staging | none | https://nimbus.vcluster.cloud/clusters/staging?token=access-key | Current agent values |
-| nimbus.vcluster.cloud | staging | platform-config | https://nimbus.vcluster.cloud/clusters/staging?token=access-key&source=platform-config | Content of `agentValues` section in platform config |
-| nimbus.vcluster.cloud | staging | cluster-annotation | https://nimbus.vcluster.cloud/clusters/staging?token=access-key&source=cluster-annotation | Value of the `loft.sh/agent-values` annotation on the `Cluster Object` |
+| Host                    | Cluster Name | Source            | Request                                                                                     | Response                                            |
+|-------------------------|-----------|----------------------|---------------------------------------------------------------------------------------------|-----------------------------------------------------|
+| `nimbus.vcluster.cloud` | `staging` | none                 | `https://nimbus.vcluster.cloud/clusters/staging?token=access-key`                           | Current agent values                                |
+| `nimbus.vcluster.cloud` | `staging` | `platform-config`    | `https://nimbus.vcluster.cloud/clusters/staging?token=access-key&source=platform-config`    | Content of `agentValues` section in platform config |
+| `nimbus.vcluster.cloud` | `staging` | `cluster-annotation` | `https://nimbus.vcluster.cloud/clusters/staging?token=access-key&source=cluster-annotation` | Value of the `loft.sh/agent-values` annotation on the `Cluster Object` |
 <!-- vale on -->
 
 ### Configure the agent through the platform {#configuring-the-agent-through-the-platform}

--- a/platform/configure/config.mdx
+++ b/platform/configure/config.mdx
@@ -317,11 +317,13 @@ When the platform upgrades an agent, it uses the values from the `agentValues` s
 
 ### Retrieve agent values {#retrieve-agent-values}
 
-Supposing you have a platform instance on host `nimbus.vcluster.cloud` and a connected cluster called `staging`, the table below
-table show how to retrieve each tier of agent values for a specific cluster.  This can be useful in determining what the
-platform is using currently, or to combine rather than override values. For instance, with a Helm deploy you can specify
-`--values=https://<platform-config-endpoint> --values=https://<cluster-annotation-endpoint>`. Note that an
-[access key](/platform/administer/users-permissions/access-keys#how-access-keys-work) is required.
+For a platform instance on host `nimbus.vcluster.cloud` with a connected cluster named `staging`, the following table shows how to retrieve agent values for each tier. Use these endpoints to determine current platform configuration or to layer values instead of overriding them.
+
+For Helm deployments, specify multiple values files:
+```bash
+--values=https://<platform-config-endpoint> --values=https://<cluster-annotation-endpoint>
+```
+An [access key](/platform/administer/users-permissions/access-keys#how-access-keys-work) is required for authentication.
 <br></br>
 
 <!-- vale off -->

--- a/platform/configure/config.mdx
+++ b/platform/configure/config.mdx
@@ -319,7 +319,7 @@ When the platform upgrades an agent, it uses the values from the `agentValues` s
 
 For a platform instance on host `nimbus.vcluster.cloud` with a connected cluster named `staging`, the following table shows how to retrieve agent values for each tier. Use these endpoints to determine current platform configuration or to layer values instead of overriding them.
 
-For Helm deployments, specify multiple values files:
+You can specify multiple values files:
 ```bash
 --values=https://<platform-config-endpoint> --values=https://<cluster-annotation-endpoint>
 ```


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
[Document Preview](https://deploy-preview-887--vcluster-docs-site.netlify.app/docs/platform/next/configure/config#retrieve-agent-values)

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-731

