### PR TITLE
chore: remove backslash and link in cert rotation docs

### DIFF
--- a/vcluster/manage/certificates.mdx
+++ b/vcluster/manage/certificates.mdx
@@ -15,13 +15,13 @@ By default, vCluster uses a self-signed Certificate Authority (CA) to sign these
 vCluster provides commands that allow you to check and rotate client, server, and CA certificates.
 
 :::info
-Certificate rotation requires vCluster version v0.27.0 or higher. 
+Certificate rotation requires vCluster version v0.27.0 or higher.
 The virtual cluster must run the k8s distribution.
 :::
 
 ## Check certificate information
 
-The `vcluster certs check` command provides the following information for each certificate of the given virtual cluster:\
+The `vcluster certs check` command provides the following information for each certificate of the given virtual cluster:
 
 <br />
 
@@ -80,7 +80,7 @@ The restart does not affect running application workloads because the underlying
   language="bash"
 />
 
-Client and server leaf certificate rotation is less intrusive compared to [CA rotation](#rotating-ca-certificates). 
+Client and server leaf certificate rotation is less intrusive compared to [CA rotation](#rotate-ca-certificates).
 This means that connecting to the virtual cluster with previously issued kubeconfigs continues to work.
 
 ## Rotate CA certificates
@@ -94,7 +94,7 @@ If the rotation fails, you can restore the previous PKI from the automatically c
 The CA rotation command performs these operations:
 
 - **Creates PKI backup**: Backs up the existing certificate directory to enable recovery if needed.
-- **Generates new Certificate Authority**: Creates a new CA certificate and uses it to sign fresh certificates for all cluster components.  
+- **Generates new Certificate Authority**: Creates a new CA certificate and uses it to sign fresh certificates for all cluster components.
 - **Restarts virtual cluster**: Restarts the cluster to load the new certificates.
 
 <br />
@@ -149,7 +149,7 @@ cp -R /data/pki.bak/[[VAR:BACKUP UNIX TIMESTAMP:1752736900]] /data/pki`}
 
 </Step>
 <Step>
-Log out and perform a regular leaf [certificate rotation](#rotating-client-and-server-leaf-certificates):
+Log out and perform a regular leaf [certificate rotation](#rotate-client-and-server-leaf-certificates):
 
 <InterpolatedCodeBlock
   code={`vcluster -n [[VAR:VCLUSTER NAMESPACE:my-vcluster]] certs rotate [[VAR:VCLUSTER NAME:my-vcluster]]`}


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

