### PR TITLE
refactor: Rewrite cert-manager docs

### DIFF
--- a/vcluster/_fragments/integrations/cert-manager.mdx
+++ b/vcluster/_fragments/integrations/cert-manager.mdx
@@ -14,22 +14,19 @@ import ProAdmonition from "../../_partials/admonitions/pro-admonition.mdx";
 
 <ProAdmonition />
 
-# Cert manager integration
+# Cert-manager integration
 
-This guide shows how to set up cert-manager integration with your virtual cluster.
+This guide explains how to integrate cert-manager with your virtual cluster to manage TLS certificates seamlessly across host and virtual environments.
 
-### Prerequisites
+## Prerequisites
 
 <BasePrerequisites />
 
-- `cert-manager` operator installed on your host cluster, see [cert-manager installation
-  guide](https://cert-manager.io).
+- cert-manager operator installed on your host cluster. See the [cert-manager installation guide](https://cert-manager.io/docs/installation/) for setup instructions.
 
 ## Enable the integration
 
-<!-- TODO:(piotr1215) add link to cert-manager integration when available -->
-
-Enable the cert-manager integration in your virtual cluster configuration:
+Enable cert-manager integration in your virtual cluster configuration:
 
 ```yaml title="Enable cert-manager integration"
 integrations:
@@ -37,193 +34,493 @@ integrations:
     enabled: true
 ```
 
-This configuration:
+This configuration enables the integration and configures automatic resource sync:
 
-- Enables the integration.
-- Imports cluster-scoped `ClusterIssuers` from your host cluster into the virtual
-  cluster.
-- Exports namespaced Issuers and Certificates from the virtual cluster to the
-  host cluster.
+- **Imports**: Cluster-scoped `ClusterIssuers` from your host cluster into the virtual cluster
+- **Exports**: Namespaced `Issuers` and `Certificates` from the virtual cluster to the host cluster
+- **Syncs**: Generated certificate secrets back to the virtual cluster automatically
 
-:::tip create virtual cluster
-Create or update a `virtual Cluster` following the [vCluster quick start
-guide](/vcluster/#deploy-vcluster).
-:::
 
-### Set up cluster contexts
+## Set up cluster contexts
 
-Setting up the host and virtual cluster contexts makes it easier to switch
-between them.
+Create or update a virtual cluster following the [vCluster quick start guide](/vcluster/#deploy-vcluster).
+Configure cluster contexts to simplify switching between host and virtual clusters:
 
 ```bash
 export HOST_CTX="your-host-context"
 export VCLUSTER_CTX="vcluster-ctx"
 ```
 
-:::tip
-You can find your contexts by running `kubectl config get-contexts`
+:::tip Find your contexts
+Run `kubectl config get-contexts` to list available contexts.
 :::
 
-## Setup the integration
+## Certificate issuer configurations
 
-If you don't have cert-manager configured yet, follow these steps:
+Choose the appropriate certificate issuer based on your security and operational requirements.
 
-<Flow id="cert-manager-integration">
+<details>
+<summary>Self-signed certificates for development</summary>
+
+Self-signed certificates work well for development environments and internal services that don't require public trust.
+
+<Flow id="self-signed-setup">
 <Step>
 
-<Highlight color="green">Virtual Cluster</Highlight> Create the `Issuer`.
+<Highlight color="green">Virtual Cluster</Highlight> Create a self-signed issuer
 
-:::tip
-This should create a corresponding Issuer in the host cluster.
-:::
-
-Create a file named `issuer.yaml`:
-
-```yaml title="Issuer"
-cat <<EOF > issuer.yaml
+```yaml title="self-signed-issuer.yaml"
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
-  name: letsencrypt-staging
+  name: selfsigned-issuer
+  namespace: default
 spec:
-  acme:
-    # highlight-start
-    # Replace this email address with your own
-    # Let's Encrypt will use this to contact you about expiring
-    # certificates, and issues related to your account
-    # highlight-end
-    email: user@example.com
-    server: https://acme-staging-v02.api.letsencrypt.org/directory
-    privateKeySecretRef:
-      name: example-issuer-account-key
-    solvers:
-    - http01:
-        ingress:
-          ingressClassName: nginx
-EOF
+  selfSigned: {}
 ```
 
-Apply to the virtual cluster:
+Apply the issuer:
 
-```bash title="Apply Issuer to virtual cluster"
-kubectl --context=$VCLUSTER_CTX apply -f issuer.yaml
+```bash title="Apply self-signed issuer"
+kubectl --context=$VCLUSTER_CTX apply -f self-signed-issuer.yaml
 ```
 
 </Step>
 
-## Create a certificate
-
-With the `Issuer` configured, create a certificate within the virtual cluster.
-
 <Step>
 
-<Highlight color="green">Virtual Cluster</Highlight> Create the Certificate
+<Highlight color="green">Virtual Cluster</Highlight> Create a certificate
 
-Create a file named `certificate.yaml`:
-
-```yaml title="Create Certificate"
-cat <<EOF > certificate.yaml
+```yaml title="self-signed-certificate.yaml"
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: quickstart-example-tls
+  name: app-tls-cert
   namespace: default
 spec:
+  secretName: app-tls-secret
+  duration: 2160h # 90 days
+  renewBefore: 360h # 15 days
+  commonName: myapp.local
   dnsNames:
-  - example.example.com
+  - myapp.local
+  - api.myapp.local
+  privateKey:
+    algorithm: RSA
+    size: 2048
   issuerRef:
-    group: cert-manager.io
+    name: selfsigned-issuer
     kind: Issuer
-    name: letsencrypt-staging
-  secretName: quickstart-example-tls
-  usages:
-  - digital signature
-  - key encipherment
-EOF
 ```
 
-```bash title="Apply Certificate in virtual cluster"
-kubectl --context=$VCLUSTER_CTX apply -f certificate.yaml
-```
+Apply the certificate:
 
-:::tip
-Once that certificate is created in the virtual cluster, the integration syncs the created secret back to the virtual cluster after the cert-manager operator creates it in the host cluster, and the certificate is ready to use.
-:::
-
-</Step>
-
-## Verify the setup
-
-<Step>
-
-<Highlight>Host Cluster</Highlight> Check the `ClusterIssuer`
-
-```bash title="Check ClusterIssuer in host cluster"
-kubectl --context=$HOST_CTX describe clusterissuer letsencrypt-staging
-```
-
-</Step>
-<Step>
-
-<Highlight color="green">Virtual Cluster</Highlight> Check resources
-
-```bash title="Check Issuer and Certificate in virtual cluster"
-kubectl --context=$VCLUSTER_CTX describe issuer letsencrypt-staging -n default
-
-kubectl --context=$VCLUSTER_CTX describe certificate quickstart-example-tls -n default
-
-kubectl --context=$VCLUSTER_CTX get secret quickstart-example-tls -n default
+```bash title="Apply certificate"
+kubectl --context=$VCLUSTER_CTX apply -f self-signed-certificate.yaml
 ```
 
 </Step>
 </Flow>
 
-## Using the certificate
+**Security note**: Self-signed certificates generate browser warnings and should not be used in production environments accessible to external users.
 
-To use your certificate in an application, reference it in your Ingress resource:
+</details>
 
-```yaml title="ingress.yaml"
+<details>
+<summary>Private PKI for enterprise environments</summary>
+
+Private PKI configurations provide enterprise-grade certificate management with custom certificate authorities.
+
+<Flow id="private-pki-setup">
+<Step>
+
+<Highlight color="green">Virtual Cluster</Highlight> Create a root CA certificate
+
+First, create a self-signed root CA:
+
+```yaml title="root-ca.yaml"
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: cert-manager
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: root-ca-cert
+  namespace: cert-manager
+spec:
+  isCA: true
+  commonName: "Enterprise Root CA"
+  subject:
+    organizations:
+      - "Enterprise Corp"
+    organizationalUnits:
+      - "IT Security"
+    countries:
+      - "US"
+  secretName: root-ca-secret
+  duration: 87600h # 10 years
+  renewBefore: 78840h # 9 years
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+```
+
+</Step>
+
+<Step>
+
+<Highlight color="green">Virtual Cluster</Highlight> Create a CA issuer
+
+```yaml title="ca-issuer.yaml"
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: enterprise-ca-issuer
+spec:
+  ca:
+    secretName: root-ca-secret
+```
+
+</Step>
+
+<Step>
+
+<Highlight color="green">Virtual Cluster</Highlight> Issue certificates from your CA
+
+```yaml title="ca-signed-certificate.yaml"
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: enterprise-app-cert
+  namespace: default
+spec:
+  secretName: enterprise-app-secret
+  duration: 8760h # 1 year
+  renewBefore: 720h # 30 days
+  commonName: myapp.enterprise.local
+  dnsNames:
+  - myapp.enterprise.local
+  - api.myapp.enterprise.local
+  subject:
+    organizations:
+      - "Enterprise Corp"
+    organizationalUnits:
+      - "Application Services"
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+  issuerRef:
+    name: enterprise-ca-issuer
+    kind: ClusterIssuer
+```
+
+</Step>
+</Flow>
+
+**Security considerations**: 
+- Store root CA private keys securely and offline when possible
+- Implement proper certificate lifecycle management
+- Monitor certificate expiration dates
+- Establish clear revocation procedures
+
+</details>
+
+<details>
+<summary>ACME/Let's Encrypt for public-facing services</summary>
+
+ACME issuers like Let's Encrypt provide free, automatically-renewed certificates for public-facing services.
+
+<Flow id="acme-setup">
+<Step>
+
+<Highlight color="green">Virtual Cluster</Highlight> Create an ACME issuer
+
+```yaml title="acme-issuer.yaml"
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt-prod
+  namespace: default
+spec:
+  acme:
+    email: admin@yourdomain.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-prod-account-key
+    solvers:
+    - http01:
+        ingress:
+          ingressClassName: nginx
+    - dns01:
+        cloudflare:
+          email: admin@yourdomain.com
+          apiKeySecretRef:
+            name: cloudflare-api-key-secret
+            key: api-key
+```
+
+</Step>
+
+<Step>
+
+<Highlight color="green">Virtual Cluster</Highlight> Create an ACME certificate
+
+```yaml title="acme-certificate.yaml"
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: public-app-cert
+  namespace: default
+spec:
+  secretName: public-app-secret
+  duration: 2160h # 90 days
+  renewBefore: 720h # 30 days
+  dnsNames:
+  - myapp.example.com
+  - api.myapp.example.com
+  issuerRef:
+    name: letsencrypt-prod
+    kind: Issuer
+```
+
+</Step>
+</Flow>
+
+**Rate limits**: Let's Encrypt enforces rate limits. Use staging environment (`https://acme-staging-v02.api.letsencrypt.org/directory`) for testing.
+
+</details>
+
+<details>
+<summary>PKI for compliance requirements</summary>
+
+PKI configurations require specific certificate formats and validation procedures for compliance with standards.
+
+```yaml title="gov-compliant-certificate.yaml"
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: gov-service-cert
+  namespace: default
+spec:
+  secretName: gov-service-secret
+  duration: 8760h # 1 year maximum
+  renewBefore: 2160h # 90 days
+  commonName: service.application.1234567890
+  subject:
+    organizations:
+      - "Organization"
+    organizationalUnits:
+      - "PKI"
+      - "CONTRACTOR"
+    countries:
+      - "US"
+  usages:
+  - digital signature
+  - key encipherment
+  - server auth
+  privateKey:
+    algorithm: RSA
+    size: 2048  # Federal minimum requirement
+  issuerRef:
+    name: gov-pki-issuer
+    kind: ClusterIssuer
+```
+
+**Compliance requirements**:
+- Use hierarchical 3-tier CA structure
+- Include specific Distinguished Name fields
+- Maintain Certificate Revocation Lists (CRLs)
+- Follow Federal PKI Certificate Policy guidelines
+
+</details>
+
+## Verify certificate creation
+
+Check that your certificates generate correctly:
+
+<Flow id="verification">
+<Step>
+
+<Highlight color="green">Virtual Cluster</Highlight> Check certificate status
+
+```bash title="Verify certificate creation"
+kubectl --context=$VCLUSTER_CTX describe certificate <certificate-name> -n <namespace>
+```
+
+Look for `Ready: True` in the status conditions.
+
+</Step>
+
+<Step>
+
+<Highlight color="green">Virtual Cluster</Highlight> Verify secret creation
+
+```bash title="Check certificate secret"
+kubectl --context=$VCLUSTER_CTX get secret <secret-name> -n <namespace> -o yaml
+```
+
+Confirm the secret contains `tls.crt` and `tls.key` data.
+
+</Step>
+
+<Step>
+
+<Highlight>Host Cluster</Highlight> Confirm synchronization
+
+```bash title="Check host cluster resources"
+kubectl --context=$HOST_CTX get certificate,issuer -A
+```
+
+Verify resources appear in the host cluster namespace.
+
+</Step>
+</Flow>
+
+## Use certificates in applications
+
+Reference your certificates in Ingress resources:
+
+```yaml title="secure-ingress.yaml"
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: example-ingress
+  name: secure-app-ingress
   annotations:
     kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:
   tls:
     - hosts:
-        - example.example.com
-      secretName: quickstart-example-tls
+        - myapp.example.com
+      secretName: app-tls-secret
   rules:
-    - host: example.example.com
+    - host: myapp.example.com
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: example-service
+                name: app-service
                 port:
                   number: 80
 ```
 
 ## Troubleshooting
 
-<Highlight>Host Cluster</Highlight>
-- Verify cert-manager is running
+<details>
+<summary>Certificate creation issues</summary>
 
-```bash title="Verify Cert Manager Installation
-kubectl --context=$HOST_CTX -n cert-manager get pods
+**Check certificate status**:
+```bash
+kubectl --context=$VCLUSTER_CTX describe certificate <name>
 ```
-- Check cert-manager logs for errors - Ensure proper RBAC permissions are configured
+
+**Common problems**:
+- **Pending status**: Check CertificateRequest events
+- **Failed validation**: Verify DNS/HTTP challenge accessibility
+- **Rate limiting**: Switch to staging ACME server for testing
+
+**Examine certificate requests**:
+```bash
+kubectl --context=$VCLUSTER_CTX get certificaterequests
+kubectl --context=$VCLUSTER_CTX describe certificaterequest <name>
+```
+
+</details>
+
+<details>
+<summary>Integration synchronization problems</summary>
+
+**Verify integration status**:
+
+<Highlight>Host Cluster</Highlight>
+```bash title="Check cert-manager installation"
+kubectl --context=$HOST_CTX -n cert-manager get pods
+kubectl --context=$HOST_CTX -n cert-manager logs deployment/cert-manager
+```
 
 <Highlight color="green">Virtual Cluster</Highlight>
-- Verify the integration is enabled in your vcluster configuration
-- Check that secrets are syncing correctly between clusters
-- Ensure your Issuer and Certificate configurations are correct
+```bash title="Verify integration configuration"
+# Check if integration is enabled
+kubectl --context=$VCLUSTER_CTX get configmap vcluster-config -o yaml
 
-For detailed troubleshooting steps, see the [cert-manager troubleshooting guide](https://cert-manager.io/docs/troubleshooting/).
+# Check resource synchronization
+kubectl --context=$VCLUSTER_CTX get events --field-selector reason=Sync
+```
 
-## Config reference
+**Common synchronization issues**:
+- RBAC permissions missing on host cluster
+- Network policies blocking communication
+- Resource naming conflicts between clusters
+
+</details>
+
+<details>
+<summary>ACME challenge failures</summary>
+
+**HTTP-01 challenge issues**:
+```bash
+kubectl --context=$VCLUSTER_CTX describe order <order-name>
+kubectl --context=$VCLUSTER_CTX describe challenge <challenge-name>
+```
+
+**Solutions**:
+- Verify ingress controller configuration
+- Check firewall rules allow HTTP traffic on port 80
+- Ensure domain points to correct load balancer IP
+
+**DNS-01 challenge issues**:
+- Verify DNS provider credentials
+- Check API rate limits
+- Confirm DNS propagation timing
+
+</details>
+
+For comprehensive troubleshooting, consult the [cert-manager troubleshooting guide](https://cert-manager.io/docs/troubleshooting/).
+
+## Advanced configuration
+
+<details>
+<summary>Custom sync configurations</summary>
+
+Fine-tune resource synchronization behavior:
+
+```yaml title="Advanced cert-manager integration"
+integrations:
+  certManager:
+    enabled: true
+    sync:
+      toHost:
+        certificates:
+          enabled: true
+        issuers:
+          enabled: true
+      fromHost:
+        clusterIssuers:
+          enabled: true
+          selector:
+            matchLabels:
+              vcluster.loft.sh/managed: "true"
+    resyncInterval: 30s
+```
+
+**Configuration options**:
+- `resyncInterval`: How often to check for resource changes
+- `selector`: Filter which ClusterIssuers to import
+- Individual resource type controls for granular sync management
+
+</details>
+
+## Configuration reference
 
 <CertManagerPartial />

--- a/vcluster/_fragments/integrations/cert-manager.mdx
+++ b/vcluster/_fragments/integrations/cert-manager.mdx
@@ -136,16 +136,15 @@ Private PKI configurations provide enterprise-grade certificate management with 
 <Flow id="private-pki-setup">
 <Step>
 
-<Highlight color="green">Virtual Cluster</Highlight> Create a root CA certificate
+<Highlight>Host Cluster</Highlight> Create a root CA certificate
 
-Create a self-signed root CA:
+Create a self-signed root CA in the host cluster (ClusterIssuers are imported from host to virtual cluster):
 
 ```yaml title="root-ca.yaml"
 apiVersion: cert-manager.io/v1
-kind: Issuer
+kind: ClusterIssuer
 metadata:
   name: selfsigned-issuer
-  namespace: cert-manager
 spec:
   selfSigned: {}
 ---
@@ -172,14 +171,20 @@ spec:
     size: 256
   issuerRef:
     name: selfsigned-issuer
-    kind: Issuer
+    kind: ClusterIssuer
+```
+
+Apply in the host cluster:
+
+```bash title="Apply root CA in host cluster"
+kubectl --context=$HOST_CTX apply -f root-ca.yaml
 ```
 
 </Step>
 
 <Step>
 
-<Highlight color="green">Virtual Cluster</Highlight> Create a CA issuer
+<Highlight>Host Cluster</Highlight> Create a CA issuer
 
 ```yaml title="ca-issuer.yaml"
 apiVersion: cert-manager.io/v1
@@ -189,6 +194,12 @@ metadata:
 spec:
   ca:
     secretName: root-ca-secret
+```
+
+Apply in the host cluster:
+
+```bash title="Apply CA issuer in host cluster"
+kubectl --context=$HOST_CTX apply -f ca-issuer.yaml
 ```
 
 </Step>
@@ -204,7 +215,7 @@ metadata:
   name: enterprise-app-cert
   namespace: default
 spec:
-  secretName: enterprise-app-secret
+  secretName: enterprise-app-tls
   duration: 8760h # 1 year
   renewBefore: 720h # 30 days
   commonName: myapp.enterprise.local
@@ -223,6 +234,12 @@ spec:
   issuerRef:
     name: enterprise-ca-issuer
     kind: ClusterIssuer
+```
+
+Apply in the virtual cluster:
+
+```bash title="Apply certificate in virtual cluster"
+kubectl --context=$VCLUSTER_CTX apply -f ca-signed-certificate.yaml
 ```
 
 </Step>
@@ -389,7 +406,7 @@ Verify resources appear in the host cluster namespace.
 
 ## Use certificates in applications
 
-Reference your certificates in Ingress resources:
+Reference your certificate secrets in Ingress resources:
 
 ```yaml title="secure-ingress.yaml"
 apiVersion: networking.k8s.io/v1
@@ -403,7 +420,7 @@ spec:
   tls:
     - hosts:
         - myapp.example.com
-      secretName: app-tls-secret
+      secretName: your-tls-secret  # Use the secretName from your Certificate
   rules:
     - host: myapp.example.com
       http:
@@ -416,6 +433,10 @@ spec:
                 port:
                   number: 80
 ```
+
+:::tip
+Replace `your-tls-secret` with the actual `secretName` specified in your Certificate resource (e.g., `app-tls-secret`, `enterprise-app-tls`, or `public-app-secret` from the examples above).
+:::
 
 ## Troubleshooting
 
@@ -470,21 +491,15 @@ kubectl --context=$VCLUSTER_CTX get events --field-selector reason=Sync
 <details>
 <summary>ACME challenge failures</summary>
 
-**HTTP-01 challenge issues**:
+For detailed troubleshooting of ACME challenges:
+
+**Check challenge status**:
 ```bash
 kubectl --context=$VCLUSTER_CTX describe order <order-name>
 kubectl --context=$VCLUSTER_CTX describe challenge <challenge-name>
 ```
 
-**Solutions**:
-- Verify ingress controller configuration
-- Check firewall rules allow HTTP traffic on port 80
-- Ensure domain points to correct load balancer IP
-
-**DNS-01 challenge issues**:
-- Verify DNS provider credentials
-- Check API rate limits
-- Confirm DNS propagation timing
+For comprehensive ACME troubleshooting, including HTTP-01 and DNS-01 challenge issues, see the [cert-manager ACME troubleshooting guide](https://cert-manager.io/docs/troubleshooting/acme/).
 
 </details>
 
@@ -511,7 +526,7 @@ integrations:
         clusterIssuers:
           enabled: true
           selector:
-            matchLabels:
+            labels:
               vcluster.loft.sh/managed: "true"
     resyncInterval: 30s
 ```

--- a/vcluster/_fragments/integrations/cert-manager.mdx
+++ b/vcluster/_fragments/integrations/cert-manager.mdx
@@ -14,15 +14,15 @@ import ProAdmonition from "../../_partials/admonitions/pro-admonition.mdx";
 
 <ProAdmonition />
 
-# Cert-manager integration
-
-This guide explains how to integrate cert-manager with your virtual cluster to manage TLS certificates seamlessly across host and virtual environments.
+You can integrate cert-manager with your virtual cluster to manage TLS certificates across host and virtual environments.
 
 ## Prerequisites
 
 <BasePrerequisites />
 
-- cert-manager operator installed on your host cluster. See the [cert-manager installation guide](https://cert-manager.io/docs/installation/) for setup instructions.
+- cert-manager operator installed on your host cluster. For setup instructions, see the [cert-manager installation guide](https://cert-manager.io/docs/installation/).
+
+<!-- vale off -->
 
 ## Enable the integration
 
@@ -122,7 +122,9 @@ kubectl --context=$VCLUSTER_CTX apply -f self-signed-certificate.yaml
 </Step>
 </Flow>
 
-**Security note**: Self-signed certificates generate browser warnings and should not be used in production environments accessible to external users.
+:::warning
+Self-signed certificates generate browser warnings and should not be used in production environments accessible to external users.
+:::
 
 </details>
 
@@ -136,7 +138,7 @@ Private PKI configurations provide enterprise-grade certificate management with 
 
 <Highlight color="green">Virtual Cluster</Highlight> Create a root CA certificate
 
-First, create a self-signed root CA:
+Create a self-signed root CA:
 
 ```yaml title="root-ca.yaml"
 apiVersion: cert-manager.io/v1
@@ -235,9 +237,9 @@ spec:
 </details>
 
 <details>
-<summary>ACME/Let's Encrypt for public-facing services</summary>
+<summary>ACME for public-facing services</summary>
 
-ACME issuers like Let's Encrypt provide free, automatically-renewed certificates for public-facing services.
+[ACME](https://cert-manager.io/docs/configuration/acme/) (Automatic Certificate Management Environment) issuers like [Let's Encrypt](https://letsencrypt.org) provide free, automatically-renewed certificates for public-facing services.
 
 <Flow id="acme-setup">
 <Step>
@@ -486,7 +488,7 @@ kubectl --context=$VCLUSTER_CTX describe challenge <challenge-name>
 
 </details>
 
-For comprehensive troubleshooting, consult the [cert-manager troubleshooting guide](https://cert-manager.io/docs/troubleshooting/).
+For troubleshooting guidance, see the [cert-manager troubleshooting documentation](https://cert-manager.io/docs/troubleshooting/).
 
 ## Advanced configuration
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/configmaps.mdx
@@ -121,9 +121,9 @@ sync:
       enabled: true
       mappings:
         byName:
-          # syncs "config" ConfigMap from "cert-manager" namespace in the host
+          # syncs "config" ConfigMap from "system" namespace in the host
           # as "my-config" in "my-virtual" namespace in a virtual cluster.
-          "cert-manager/config": "my-virtual/my-config"
+          "system/config": "my-virtual/my-config"
 ```
 
 ## Patches

--- a/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/custom-resources.mdx
@@ -18,7 +18,7 @@ import VersionedCrdSyncing from '../../../../_fragments/sync/versioned-crd-synci
 
 vCluster allows you to sync custom resources from the host cluster to the virtual cluster. This feature creates read-only copies of custom resources inside your virtual cluster, making them available to applications and users without giving them direct access to the host cluster.
 
-When you enable custom resource syncing, vCluster first copies the CustomResourceDefinition (CRD) from the host to the virtual cluster, then begins syncing the actual custom resource instances. This is particularly useful for sharing cluster-wide resources like `ClusterIssuers` from [cert-manager](https://cert-manager.io/) or `ClusterStores` from [external-secrets](https://external-secrets.io/latest/) with your virtual cluster workloads.
+When you enable custom resource syncing, vCluster first copies the CustomResourceDefinition (CRD) from the host to the virtual cluster, then begins syncing the actual custom resource instances. This is particularly useful for sharing cluster-wide resources like cluster-scoped custom resources or `ClusterStores` from [external-secrets](https://external-secrets.io/latest/) with your virtual cluster workloads.
 
 The synced resources are read-only in the virtual cluster. If you modify them in the host cluster, vCluster automatically updates the virtual cluster copies. However, changes made to these resources within the virtual cluster are not persisted.
 
@@ -34,13 +34,13 @@ vCluster automatically adds the required cluster RBAC permissions for retrieving
 
 Cluster-scoped custom resources exist at the cluster level and are not tied to any specific namespace. These are the simplest to sync because they don't require namespace mapping.
 
-To sync `ClusterIssuers` from the host cluster using [cert-manager](https://cert-manager.io/), configure the resource in your `vcluster.yaml` file:
+To sync cluster-scoped custom resources from the host cluster, configure the resource in your `vcluster.yaml` file:
 
 ```yaml title="configure cluster-scoped CRD sync from host"
 sync:
   fromHost:
     customResources:
-      clusterissuers.cert-manager.io:
+      customobjects.example.io:
         enabled: true
         scope: Cluster
 ```
@@ -61,13 +61,13 @@ Enabling this feature allows you to sync namespaced custom resources from specif
 sync:
   fromHost:
     customResources:
-      certificaterequests.cert-manager.io:
+      customobjects.example.io:
         enabled: true
         scope: Namespaced
         mappings:
           byName:
-            # syncs all CertificateRequests from "foo" namespace
-            # to the "bar" namespace in a virtual cluster. CertificateRequests names are unchanged.
+            # syncs all CustomObjects from "foo" namespace
+            # to the "bar" namespace in a virtual cluster. CustomObjects names are unchanged.
             "foo/*": "bar/*"
 ```
 
@@ -100,7 +100,7 @@ vCluster creates namespaces in the virtual cluster automatically during the sync
 
 vCluster cannot sync custom resources that were already synced from virtual to host. It skips these resources.
 
-The following is an example with cert-manager's `CertificateRequest` custom resource.
+The following is an example with a generic custom resource.
 
 To sync all custom resources from a given namespace in the host to a given namespace in the virtual cluster, use the "namespace/*" wildcard:
 
@@ -108,13 +108,13 @@ To sync all custom resources from a given namespace in the host to a given names
 sync:
   fromHost:
     customResources:
-      certificaterequests.cert-manager.io:
+      customobjects.example.io:
         enabled: true
         scope: Namespaced
         mappings:
           byName:
-            # syncs all CertificateRequests from "foo" namespace
-            # to the "bar" namespace in a virtual cluster. CertificateRequests names are unchanged.
+            # syncs all CustomObjects from "foo" namespace
+            # to the "bar" namespace in a virtual cluster. CustomObjects names are unchanged.
             "foo/*": "bar/*"
 ```
 
@@ -124,14 +124,14 @@ To sync only specific custom resources from namespaces, provide `namespace/name`
 sync:
   fromHost:
     customResources:
-      certificaterequests.cert-manager.io:
+      customobjects.example.io:
         enabled: true
         scope: Namespaced
         mappings:
           byName:
-            # syncs CertificateRequest named "cm-name" from "foo" host namespace
+            # syncs CustomObject named "my-object" from "foo" host namespace
             # to the "bar" namespace in virtual.
-            "foo/cm-name": "bar/cm-name"
+            "foo/my-object": "bar/my-object"
 ```
 
 There is also a syntax to sync all custom resources from the virtual cluster's own host namespace to the virtual namespace. Since the virtual cluster's namespace is not always known upfront (for example, when vCluster is created by the platform), `""` (empty string) is treated as "vCluster's own host namespace":
@@ -140,12 +140,12 @@ There is also a syntax to sync all custom resources from the virtual cluster's o
 sync:
   fromHost:
     customResources:
-      certificaterequests.cert-manager.io:
+      customobjects.example.io:
         enabled: true
         scope: Namespaced
         mappings:
           byName:
-            # syncs all CertificateRequests from virtual cluster's host namespace
+            # syncs all CustomObjects from virtual cluster's host namespace
             # to "my-virtual" namespace in a virtual cluster.
             "": "my-virtual"
 ```
@@ -156,14 +156,14 @@ You can also specify only a few custom resources from the virtual cluster's own 
 sync:
   fromHost:
     customResources:
-      certificaterequests.cert-manager.io:
+      customobjects.example.io:
         enabled: true
         scope: Namespaced
         mappings:
           byName:
-            # syncs CertificateRequest named "my-cm" from virtual cluster's host namespace
+            # syncs CustomObject named "my-object" from virtual cluster's host namespace
             # to "my-virtual-namespace" in a virtual cluster.
-            "/my-cm": "my-virtual/my-cm"
+            "/my-object": "my-virtual/my-object"
 ```
 
 It's also possible to modify the custom resource name during the sync:
@@ -172,14 +172,14 @@ It's also possible to modify the custom resource name during the sync:
 sync:
   fromHost:
     customResources:
-      certificaterequests.cert-manager.io:
+      customobjects.example.io:
         enabled: true
         scope: Namespaced
         mappings:
           byName:
-            # syncs "foo" CertificateRequest from "cert-manager" namespace in the host
+            # syncs "foo" CustomObject from "system" namespace in the host
             # as "my-foo" in "my-virtual" namespace in a virtual cluster.
-            "cert-manager/foo": "my-virtual/my-foo"
+            "system/foo": "my-virtual/my-foo"
 ```
 
 ### Patches
@@ -198,12 +198,12 @@ The following `vcluster.yaml` shows how patches are used:
 sync:
   fromHost:
     customResources:
-      certificaterequests.cert-manager.io:
+      customobjects.example.io:
         enabled: true
         scope: Namespaced
         mappings:
           byName:
-            "default/my-cm": "barfoo2/cm-my"
+            "default/my-object": "barfoo2/object-my"
         patches:
           - path: metadata.annotations[*]
             # optional reverseExpression to reverse the change from the host cluster
@@ -212,9 +212,9 @@ sync:
 
 In the example:
 
-- The custom resource in the host namespace `default` named `my-cm` is synced to the namespace `barfoo2` in virtual and named `cm-my`.
+- The custom resource in the host namespace `default` named `my-object` is synced to the namespace `barfoo2` in virtual and named `object-my`.
 
-- If the `default/my-cm` host object has an annotation with a value that starts with `www.` (for example: `my-address: www.loft.sh`), then the synced object in the virtual cluster `barfoo2/cm-my` has the annotation `my-address: loft.sh`.
+- If the `default/my-object` host object has an annotation with a value that starts with `www.` (for example: `my-address: www.loft.sh`), then the synced object in the virtual cluster `barfoo2/object-my` has the annotation `my-address: loft.sh`.
 
 <NamespacedCustomResourcesExample/>
 

--- a/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/from-host/secrets.mdx
@@ -120,9 +120,9 @@ sync:
       enabled: true
       mappings:
         byName:
-          # syncs "config" Secret from "cert-manager" namespace in the host
+          # syncs "config" Secret from "system" namespace in the host
           # as "my-config" in "my-virtual" namespace in a virtual cluster.
-          "cert-manager/config": "my-virtual/my-config"
+          "system/config": "my-virtual/my-config"
 ```
 
 ## Patches

--- a/vcluster/configure/vcluster-yaml/sync/to-host/advanced/custom-resources.mdx
+++ b/vcluster/configure/vcluster-yaml/sync/to-host/advanced/custom-resources.mdx
@@ -7,11 +7,9 @@ sidebar_class_name: pro
 description: Configuration for syncing custom resources to host.
 ---
 
-import CertManagerExample from '../../../../../_fragments/cert-manager-example.mdx'
 import CodeBlock from '@theme/CodeBlock';
 import CustomResourceDefinitions from '../../../../../_partials/config/sync/toHost/customResources.mdx'
 import ProAdmonition from '../../../../../_partials/admonitions/pro-admonition.mdx'
-import CertManagerConfig from '!!raw-loader!@site/vcluster/configure/vcluster-yaml/experimental/_code/cert-manager-config.yaml'
 import VersionedCrdSyncing from '../../../../../_fragments/sync/versioned-crd-syncing.mdx'
 
 <ProAdmonition/>
@@ -20,7 +18,7 @@ vCluster allows you to sync custom resources from the virtual cluster to the hos
 
 This feature only works for resources that have a corresponding CustomResourceDefinition (CRD) installed in the host cluster.
 
-If a synced custom resource creates additional resources in the host cluster, vCluster attempts to detect and sync those resources back to the virtual cluster. For example, a [cert-manager](https://cert-manager.io/) `Certificate` creates a `Secret`, which is automatically synced into the virtual cluster.
+If a synced custom resource creates additional resources in the host cluster, vCluster attempts to detect and sync those resources back to the virtual cluster. For example, a custom resource that creates a `Secret` has that `Secret` automatically synced into the virtual cluster.
 
 vCluster also adds the necessary cluster and namespace-level RBAC permissions to retrieve the CRD and sync the corresponding resources.
 
@@ -46,7 +44,7 @@ By default, you do not need to specify an API version when syncing a custom reso
 sync:
   toHost:
     customResources:
-      certificates.cert-manager.io:
+      customobjects.example.io:
         enabled: true
 ```
 
@@ -64,13 +62,13 @@ You can use `*` in paths to select all entries of an array or object, for exampl
 
 You can use a reference patch to make a specific field in one resource point to another resource that vCluster should rewrite. If the referenced resource exists in the host cluster, vCluster automatically imports it into the virtual cluster.
 
-This is useful when working with resources like `Certificate`, which reference a `Secret` created by cert-manager:
+This is useful when working with resources that reference other resources like `Secrets`:
 
 ```yaml
 sync:
   toHost:
     customResources:
-      certificates.cert-manager.io:
+      customobjects.example.io:
         enabled: true
         patches:
         - path: spec.secretName
@@ -85,20 +83,20 @@ vCluster translates the path `spec.secretName` as it points to a Secret. If the 
 ### JavaScript expression patches {#javascript-expression-patches}
 <!-- vale on -->
 
-These are JavaScript ES6 compatible expression patches that can be used to change a field while syncing. You define how it changes when syncing from the virtual cluster into the host cluster or when syncing from the host cluster into the virtual cluster. To add a suffix to certificate DNS names you can:
+These are JavaScript ES6 compatible expression patches that can be used to change a field while syncing. You define how it changes when syncing from the virtual cluster into the host cluster or when syncing from the host cluster into the virtual cluster. To add a prefix to field values you can:
 
 ```yaml
 sync:
   toHost:
     customResources:
-      certificates.cert-manager.io:
+      customobjects.example.io:
         enabled: true
         patches:
-        - path: spec.dnsNames[*]
+        - path: spec.names[*]
           # specifies the sync direction here again, because you can also react on change for fromHost with an expression
-          expression: '"www."+value'
+          expression: '"prefix-"+value'
           # optional reverseExpression, if omitted patches from host are discarded for that path
-          # reverseExpression: 'value.slice("my-prefix".length)'
+          # reverseExpression: 'value.slice("prefix-".length)'
 ```
 
 There is also a variable called `context` besides `value` that can be used to access vCluster specific data:
@@ -109,68 +107,68 @@ There is also a variable called `context` besides `value` that can be used to ac
 - `context.virtualObject`: Virtual object (can be null if not available)
 - `context.path`: The matched path on the object, useful when using wildcard path selectors (*)
 
-For example, to add `www.` to every DNS name specified in a cert-manager certificate in the path `spec.dnsNames`, you can use the following patch:
+For example, to add a prefix to values in a custom resource field, you can use the following patch:
 
 ```yaml
 sync:
   toHost:
     customResources:
-      certificates.cert-manager.io:
+      customobjects.example.io:
         enabled: true
         patches:
-        - path: spec.dnsNames[*]
+        - path: spec.hosts[*]
           # specifies the sync direction here again, because you can also react on change for fromHost
-          expression: "value.startsWith('www.') ? value : `www.${value}`"
+          expression: "value.startsWith('prod-') ? value : `prod-${value}`"
           # specifies how to sync back changes to the virtual cluster. If omitted does not sync back changes.
-          reverseExpression: "value.startsWith('www.') ? value.slice(4) : value"
+          reverseExpression: "value.startsWith('prod-') ? value.slice(5) : value"
 ```
 
-The patch creates a new certificate within the vCluster:
+The patch creates a new custom object within the vCluster:
 
 ```yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
+apiVersion: example.io/v1
+kind: CustomObject
 metadata:
   name: name-within-vcluster
 spec:
-  dnsNames:
-    - example.com
+  hosts:
+    - server.example.com
 ```
 
-vCluster syncs the host cluster and applies your patch, creating this modified certificate:
+vCluster syncs the host cluster and applies your patch, creating this modified resource:
 
 ```yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
+apiVersion: example.io/v1
+kind: CustomObject
 metadata:
   name: synced-name
 spec:
-  dnsNames:
-    - www.example.com # the patch added www. to this field
+  hosts:
+    - prod-server.example.com # the patch added prod- prefix to this field
 ```
 
-If you directly edit the certificate in the host cluster and change the domain:
+If you directly edit the resource in the host cluster and change the value:
 
 ```yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
+apiVersion: example.io/v1
+kind: CustomObject
 metadata:
   name: synced-name
 spec:
-  dnsNames:
-    - www.other-domain.com # changed from www.example.com
+  hosts:
+    - prod-other-server.example.com # changed from prod-server.example.com
 ```
 
-vCluster detects the change, applies the reverse patch, and updates the certificate in your virtual cluster:
+vCluster detects the change, applies the reverse patch, and updates the resource in your virtual cluster:
 
 ```yaml
-apiVersion: cert-manager.io/v1
-kind: Certificate
+apiVersion: example.io/v1
+kind: CustomObject
 metadata:
   name: name-within-vcluster
 spec:
-  dnsNames:
-    - other-domain.com # the patch removed the www. from www.other-domain.com
+  hosts:
+    - other-server.example.com # the patch removed the prod- prefix
 ```
 
 ## Configure Kubernetes Gateway API sync


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- Rewrite for cert-manager docs  for July improvements

## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-755

