### PR TITLE
feat: remove pro label from right hand side config menu

### DIFF
--- a/configsrc/vcluster/0.26/vcluster.schema.json
+++ b/configsrc/vcluster/0.26/vcluster.schema.json
@@ -385,6 +385,10 @@
           "$ref": "#/$defs/Distro",
           "description": "Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed."
         },
+        "standalone": {
+          "$ref": "#/$defs/Standalone",
+          "description": "Standalone holds configuration for standalone mode. Standalone mode is set automatically when no container is detected and\nalso implies privateNodes.enabled."
+        },
         "backingStore": {
           "$ref": "#/$defs/BackingStore",
           "description": "BackingStore defines which backing store to use for virtual cluster. If not defined will use embedded database as a default backing store."
@@ -446,6 +450,10 @@
         "headlessService": {
           "$ref": "#/$defs/ControlPlaneHeadlessService",
           "description": "HeadlessService specifies options for the headless service used for the vCluster StatefulSet."
+        },
+        "konnectivity": {
+          "$ref": "#/$defs/Konnectivity",
+          "description": "Konnectivity holds dedicated konnectivity configuration. This is only available when privateNodes.enabled is true."
         },
         "registry": {
           "$ref": "#/$defs/Registry",
@@ -2992,6 +3000,14 @@
     },
     "Networking": {
       "properties": {
+        "serviceCIDR": {
+          "type": "string",
+          "description": "ServiceCIDR holds the service cidr for the virtual cluster. This should only be set if privateNodes.enabled is true or vCluster cannot detect the host service cidr."
+        },
+        "podCIDR": {
+          "type": "string",
+          "description": "PodCIDR holds the pod cidr for the virtual cluster. This should only be set if privateNodes.enabled is true."
+        },
         "replicateServices": {
           "$ref": "#/$defs/ReplicateServices",
           "description": "ReplicateServices allows replicating services from the host within the virtual cluster or the other way around."
@@ -3468,6 +3484,33 @@
       },
       "additionalProperties": false,
       "type": "object"
+    },
+    "PrivateNodes": {
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Enabled defines if dedicated nodes should be enabled."
+        },
+        "importNodeBinaries": {
+          "type": "boolean",
+          "description": "ImportNodeBinaries defines to use the loft-sh/kubernetes:VERSION-full image to also copy the node binaries to the control plane. This allows upgrades and\njoining new nodes into the cluster without having to download the binaries from the internet."
+        },
+        "kubelet": {
+          "$ref": "#/$defs/Kubelet",
+          "description": "Kubelet holds kubelet configuration that is used for all nodes."
+        },
+        "autoUpgrade": {
+          "$ref": "#/$defs/AutoUpgrade",
+          "description": "AutoUpgrade holds configuration for auto upgrade."
+        },
+        "joinNode": {
+          "$ref": "#/$defs/JoinConfiguration",
+          "description": "JoinNode holds configuration specifically used during joining the node (see \"kubeadm join\")."
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "description": "PrivateNodes enables private nodes for vCluster."
     },
     "RBAC": {
       "properties": {
@@ -4732,6 +4775,10 @@
     "controlPlane": {
       "$ref": "#/$defs/ControlPlane",
       "description": "Configure vCluster's control plane components and deployment."
+    },
+    "privateNodes": {
+      "$ref": "#/$defs/PrivateNodes",
+      "description": "PrivateNodes holds configuration for vCluster private nodes mode."
     },
     "rbac": {
       "$ref": "#/$defs/RBAC",

--- a/hack/platform/util/schema.go
+++ b/hack/platform/util/schema.go
@@ -573,7 +573,8 @@ func renderField(
 		_, ok = definitions[refSplit[len(refSplit)-1]]
 		if ok {
 			anchorName := anchorPrefix + fieldName
-			fieldContent = fmt.Sprintf(TemplateConfigField, true, "", headlinePrefix, fieldName, required, fieldType, "", "", false, anchorName, description, fieldContent)
+			proLabel := ""
+			fieldContent = fmt.Sprintf(TemplateConfigField, true, "", headlinePrefix, fieldName, required, fieldType, "", "", proLabel, anchorName, description, fieldContent)
 		}
 	} else {
 		if defaults != nil {
@@ -589,7 +590,8 @@ func renderField(
 
 		enumValues := GetEumValues(fieldSchema, required, &fieldDefault)
 		anchorName := anchorPrefix + fieldName
-		fieldContent = fmt.Sprintf(TemplateConfigField, expandable, " open", headlinePrefix, fieldName, required, fieldType, fieldDefault, enumValues, false, anchorName, description, fieldContent)
+		proLabel := ""
+		fieldContent = fmt.Sprintf(TemplateConfigField, expandable, " open", headlinePrefix, fieldName, required, fieldType, fieldDefault, enumValues, proLabel, anchorName, description, fieldContent)
 	}
 
 	return fieldContent

--- a/hack/platform/util/templates.go
+++ b/hack/platform/util/templates.go
@@ -4,7 +4,7 @@ const TemplateConfigField = `
 <details className="config-field" data-expandable="%t"%s>
 <summary>
 
-%s` + "`%s`" + ` <span className="config-field-required" data-required="%t">required</span> <span className="config-field-type">%s</span> <span className="config-field-default">%s</span> <span className="config-field-enum">%s</span> <span data-pro="%t" className="config-field-pro">pro</span> {#%s}
+%s` + "`%s`" + ` <span className="config-field-required" data-required="%t">required</span> <span className="config-field-type">%s</span> <span className="config-field-default">%s</span> <span className="config-field-enum">%s</span>%s {#%s}
 
 %s
 

--- a/platform/api/_partials/resources/config/external.mdx
+++ b/platform/api/_partials/resources/config/external.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external}
+## `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external}
 
 External holds configuration for tools that are external to the vCluster.
 
@@ -14,7 +14,7 @@ External holds configuration for tools that are external to the vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform}
+### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform}
 
 platform holds platform configuration
 
@@ -26,7 +26,7 @@ platform holds platform configuration
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-apiKey}
+#### `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-apiKey}
 
 APIKey defines where to find the platform access key and host. By default, vCluster will search in the following locations in this precedence:
 * environment variable called LICENSE
@@ -41,7 +41,7 @@ APIKey defines where to find the platform access key and host. By default, vClus
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-apiKey-secretName}
+##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-apiKey-secretName}
 
 SecretName is the name of the secret where the platform access key is stored. This defaults to vcluster-platform-api-key if undefined.
 
@@ -56,7 +56,7 @@ SecretName is the name of the secret where the platform access key is stored. Th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-apiKey-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-apiKey-namespace}
 
 Namespace defines the namespace where the access key secret should be retrieved from. If this is not equal to the namespace
 where the vCluster instance is deployed, you need to make sure vCluster has access to this other namespace.
@@ -72,7 +72,7 @@ where the vCluster instance is deployed, you need to make sure vCluster has acce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-apiKey-createRBAC}
+##### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-apiKey-createRBAC}
 
 CreateRBAC will automatically create the necessary RBAC roles and role bindings to allow vCluster to read the secret specified
 in the above namespace, if specified.
@@ -92,7 +92,7 @@ This defaults to true.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoSleep}
+#### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoSleep}
 
 AutoSleep holds configuration for automatic sleep and wakeup
 
@@ -104,7 +104,7 @@ AutoSleep holds configuration for automatic sleep and wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoSleep-afterInactivity}
+##### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoSleep-afterInactivity}
 
 AfterInactivity specifies after how many seconds of inactivity the virtual cluster should sleep
 
@@ -119,7 +119,7 @@ AfterInactivity specifies after how many seconds of inactivity the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoSleep-schedule}
+##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoSleep-schedule}
 
 Schedule specifies scheduled virtual cluster sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. Use ".Timezone" field instead.
@@ -135,7 +135,7 @@ Note: timezone defined in the schedule string will be ignored. Use ".Timezone" f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoSleep-timezone}
+##### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoSleep-timezone}
 
 Timezone specifies time zone used for scheduled virtual cluster operations. Defaults to UTC.
 Accepts the same format as time.LoadLocation() in Go (https://pkg.go.dev/time#LoadLocation).
@@ -152,7 +152,7 @@ The value should be a location name corresponding to a file in the IANA Time Zon
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoSleep-autoWakeup}
+##### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoSleep-autoWakeup}
 
 AutoSleep holds configuration for automatic wakeup
 
@@ -164,7 +164,7 @@ AutoSleep holds configuration for automatic wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoSleep-autoWakeup-schedule}
+##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoSleep-autoWakeup-schedule}
 
 Schedule specifies scheduled wakeup from sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. The timezone for the autoSleep schedule will be
@@ -187,7 +187,7 @@ used
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `autoDelete` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoDelete}
+#### `autoDelete` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoDelete}
 
 AutoDelete holds configuration for automatic delete
 
@@ -199,7 +199,7 @@ AutoDelete holds configuration for automatic delete
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoDelete-afterInactivity}
+##### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoDelete-afterInactivity}
 
 AfterInactivity specifies after how many seconds of inactivity the virtual cluster be deleted
 

--- a/platform/api/_partials/resources/config/external/platform.mdx
+++ b/platform/api/_partials/resources/config/external/platform.mdx
@@ -1,7 +1,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform}
+## `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform}
 
 platform holds platform configuration
 
@@ -13,7 +13,7 @@ platform holds platform configuration
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-apiKey}
+### `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey}
 
 APIKey defines where to find the platform access key and host. By default, vCluster will search in the following locations in this precedence:
 * environment variable called LICENSE
@@ -28,7 +28,7 @@ APIKey defines where to find the platform access key and host. By default, vClus
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-apiKey-secretName}
+#### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-secretName}
 
 SecretName is the name of the secret where the platform access key is stored. This defaults to vcluster-platform-api-key if undefined.
 
@@ -43,7 +43,7 @@ SecretName is the name of the secret where the platform access key is stored. Th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-apiKey-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-namespace}
 
 Namespace defines the namespace where the access key secret should be retrieved from. If this is not equal to the namespace
 where the vCluster instance is deployed, you need to make sure vCluster has access to this other namespace.
@@ -59,7 +59,7 @@ where the vCluster instance is deployed, you need to make sure vCluster has acce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-apiKey-createRBAC}
+#### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-createRBAC}
 
 CreateRBAC will automatically create the necessary RBAC roles and role bindings to allow vCluster to read the secret specified
 in the above namespace, if specified.
@@ -79,7 +79,7 @@ This defaults to true.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoSleep}
+### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoSleep}
 
 AutoSleep holds configuration for automatic sleep and wakeup
 
@@ -91,7 +91,7 @@ AutoSleep holds configuration for automatic sleep and wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoSleep-afterInactivity}
+#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoSleep-afterInactivity}
 
 AfterInactivity specifies after how many seconds of inactivity the virtual cluster should sleep
 
@@ -106,7 +106,7 @@ AfterInactivity specifies after how many seconds of inactivity the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoSleep-schedule}
+#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoSleep-schedule}
 
 Schedule specifies scheduled virtual cluster sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. Use ".Timezone" field instead.
@@ -122,7 +122,7 @@ Note: timezone defined in the schedule string will be ignored. Use ".Timezone" f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoSleep-timezone}
+#### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoSleep-timezone}
 
 Timezone specifies time zone used for scheduled virtual cluster operations. Defaults to UTC.
 Accepts the same format as time.LoadLocation() in Go (https://pkg.go.dev/time#LoadLocation).
@@ -139,7 +139,7 @@ The value should be a location name corresponding to a file in the IANA Time Zon
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoSleep-autoWakeup}
+#### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoSleep-autoWakeup}
 
 AutoSleep holds configuration for automatic wakeup
 
@@ -151,7 +151,7 @@ AutoSleep holds configuration for automatic wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoSleep-autoWakeup-schedule}
+##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoSleep-autoWakeup-schedule}
 
 Schedule specifies scheduled wakeup from sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. The timezone for the autoSleep schedule will be
@@ -174,7 +174,7 @@ used
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoDelete` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoDelete}
+### `autoDelete` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoDelete}
 
 AutoDelete holds configuration for automatic delete
 
@@ -186,7 +186,7 @@ AutoDelete holds configuration for automatic delete
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoDelete-afterInactivity}
+#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoDelete-afterInactivity}
 
 AfterInactivity specifies after how many seconds of inactivity the virtual cluster be deleted
 
@@ -204,7 +204,7 @@ AfterInactivity specifies after how many seconds of inactivity the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-project}
+### `project` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-project}
 
 Project specifies which platform project the vcluster should be imported to.
 

--- a/platform/api/_partials/resources/config/external/platform/apiKey.mdx
+++ b/platform/api/_partials/resources/config/external/platform/apiKey.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#apiKey}
+## `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apiKey}
 
 APIKey defines where to find the platform access key and host. By default, vCluster will search in the following locations in this precedence:
 * environment variable called LICENSE
@@ -17,7 +17,7 @@ APIKey defines where to find the platform access key and host. By default, vClus
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#apiKey-secretName}
+### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apiKey-secretName}
 
 SecretName is the name of the secret where the platform access key is stored. This defaults to vcluster-platform-api-key if undefined.
 
@@ -32,7 +32,7 @@ SecretName is the name of the secret where the platform access key is stored. Th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#apiKey-namespace}
+### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apiKey-namespace}
 
 Namespace defines the namespace where the access key secret should be retrieved from. If this is not equal to the namespace
 where the vCluster instance is deployed, you need to make sure vCluster has access to this other namespace.
@@ -48,7 +48,7 @@ where the vCluster instance is deployed, you need to make sure vCluster has acce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#apiKey-createRBAC}
+### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apiKey-createRBAC}
 
 CreateRBAC will automatically create the necessary RBAC roles and role bindings to allow vCluster to read the secret specified
 in the above namespace, if specified.

--- a/platform/api/_partials/resources/config/external/platform/autoDelete.mdx
+++ b/platform/api/_partials/resources/config/external/platform/autoDelete.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `autoDelete` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoDelete}
+## `autoDelete` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoDelete}
 
 AutoDelete holds configuration for automatic delete
 
@@ -14,7 +14,7 @@ AutoDelete holds configuration for automatic delete
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoDelete-afterInactivity}
+### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoDelete-afterInactivity}
 
 AfterInactivity specifies after how many seconds of inactivity the virtual cluster be deleted
 

--- a/platform/api/_partials/resources/config/external/platform/autoSleep.mdx
+++ b/platform/api/_partials/resources/config/external/platform/autoSleep.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoSleep}
+## `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoSleep}
 
 AutoSleep holds configuration for automatic sleep and wakeup
 
@@ -14,7 +14,7 @@ AutoSleep holds configuration for automatic sleep and wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoSleep-afterInactivity}
+### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoSleep-afterInactivity}
 
 AfterInactivity specifies after how many seconds of inactivity the virtual cluster should sleep
 
@@ -29,7 +29,7 @@ AfterInactivity specifies after how many seconds of inactivity the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoSleep-schedule}
+### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoSleep-schedule}
 
 Schedule specifies scheduled virtual cluster sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. Use ".Timezone" field instead.
@@ -45,7 +45,7 @@ Note: timezone defined in the schedule string will be ignored. Use ".Timezone" f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoSleep-timezone}
+### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoSleep-timezone}
 
 Timezone specifies time zone used for scheduled virtual cluster operations. Defaults to UTC.
 Accepts the same format as time.LoadLocation() in Go (https://pkg.go.dev/time#LoadLocation).
@@ -62,7 +62,7 @@ The value should be a location name corresponding to a file in the IANA Time Zon
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoSleep-autoWakeup}
+### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoSleep-autoWakeup}
 
 AutoSleep holds configuration for automatic wakeup
 
@@ -74,7 +74,7 @@ AutoSleep holds configuration for automatic wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoSleep-autoWakeup-schedule}
+#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoSleep-autoWakeup-schedule}
 
 Schedule specifies scheduled wakeup from sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. The timezone for the autoSleep schedule will be

--- a/platform/api/_partials/resources/config/external/platform/autoSleep/autoWakeup.mdx
+++ b/platform/api/_partials/resources/config/external/platform/autoSleep/autoWakeup.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoWakeup}
+## `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoWakeup}
 
 AutoSleep holds configuration for automatic wakeup
 
@@ -14,7 +14,7 @@ AutoSleep holds configuration for automatic wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoWakeup-schedule}
+### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoWakeup-schedule}
 
 Schedule specifies scheduled wakeup from sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. The timezone for the autoSleep schedule will be

--- a/platform_versioned_docs/version-4.2.0/api/_partials/resources/config/external.mdx
+++ b/platform_versioned_docs/version-4.2.0/api/_partials/resources/config/external.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external}
+## `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external}
 
 External holds configuration for tools that are external to the vCluster.
 
@@ -14,7 +14,7 @@ External holds configuration for tools that are external to the vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform}
+### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform}
 
 platform holds platform configuration
 
@@ -26,7 +26,7 @@ platform holds platform configuration
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-apiKey}
+#### `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-apiKey}
 
 APIKey defines where to find the platform access key and host. By default, vCluster will search in the following locations in this precedence:
 * environment variable called LICENSE
@@ -41,7 +41,7 @@ APIKey defines where to find the platform access key and host. By default, vClus
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-apiKey-secretName}
+##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-apiKey-secretName}
 
 SecretName is the name of the secret where the platform access key is stored. This defaults to vcluster-platform-api-key if undefined.
 
@@ -56,7 +56,7 @@ SecretName is the name of the secret where the platform access key is stored. Th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-apiKey-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-apiKey-namespace}
 
 Namespace defines the namespace where the access key secret should be retrieved from. If this is not equal to the namespace
 where the vCluster instance is deployed, you need to make sure vCluster has access to this other namespace.
@@ -72,7 +72,7 @@ where the vCluster instance is deployed, you need to make sure vCluster has acce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-apiKey-createRBAC}
+##### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-apiKey-createRBAC}
 
 CreateRBAC will automatically create the necessary RBAC roles and role bindings to allow vCluster to read the secret specified
 in the above namespace, if specified.
@@ -92,7 +92,7 @@ This defaults to true.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoSleep}
+#### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoSleep}
 
 AutoSleep holds configuration for automatic sleep and wakeup
 
@@ -104,7 +104,7 @@ AutoSleep holds configuration for automatic sleep and wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoSleep-afterInactivity}
+##### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoSleep-afterInactivity}
 
 AfterInactivity specifies after how many seconds of inactivity the virtual cluster should sleep
 
@@ -119,7 +119,7 @@ AfterInactivity specifies after how many seconds of inactivity the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoSleep-schedule}
+##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoSleep-schedule}
 
 Schedule specifies scheduled virtual cluster sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. Use ".Timezone" field instead.
@@ -135,7 +135,7 @@ Note: timezone defined in the schedule string will be ignored. Use ".Timezone" f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoSleep-timezone}
+##### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoSleep-timezone}
 
 Timezone specifies time zone used for scheduled virtual cluster operations. Defaults to UTC.
 Accepts the same format as time.LoadLocation() in Go (https://pkg.go.dev/time#LoadLocation).
@@ -152,7 +152,7 @@ The value should be a location name corresponding to a file in the IANA Time Zon
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoSleep-autoWakeup}
+##### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoSleep-autoWakeup}
 
 AutoSleep holds configuration for automatic wakeup
 
@@ -164,7 +164,7 @@ AutoSleep holds configuration for automatic wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoSleep-autoWakeup-schedule}
+##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoSleep-autoWakeup-schedule}
 
 Schedule specifies scheduled wakeup from sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. The timezone for the autoSleep schedule will be
@@ -187,7 +187,7 @@ used
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `autoDelete` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoDelete}
+#### `autoDelete` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoDelete}
 
 AutoDelete holds configuration for automatic delete
 
@@ -199,7 +199,7 @@ AutoDelete holds configuration for automatic delete
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoDelete-afterInactivity}
+##### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoDelete-afterInactivity}
 
 AfterInactivity specifies after how many seconds of inactivity the virtual cluster be deleted
 

--- a/platform_versioned_docs/version-4.2.0/api/_partials/resources/config/external/platform.mdx
+++ b/platform_versioned_docs/version-4.2.0/api/_partials/resources/config/external/platform.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform}
+## `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform}
 
 platform holds platform configuration
 
@@ -14,7 +14,7 @@ platform holds platform configuration
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-apiKey}
+### `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey}
 
 APIKey defines where to find the platform access key and host. By default, vCluster will search in the following locations in this precedence:
 * environment variable called LICENSE
@@ -29,7 +29,7 @@ APIKey defines where to find the platform access key and host. By default, vClus
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-apiKey-secretName}
+#### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-secretName}
 
 SecretName is the name of the secret where the platform access key is stored. This defaults to vcluster-platform-api-key if undefined.
 
@@ -44,7 +44,7 @@ SecretName is the name of the secret where the platform access key is stored. Th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-apiKey-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-namespace}
 
 Namespace defines the namespace where the access key secret should be retrieved from. If this is not equal to the namespace
 where the vCluster instance is deployed, you need to make sure vCluster has access to this other namespace.
@@ -60,7 +60,7 @@ where the vCluster instance is deployed, you need to make sure vCluster has acce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-apiKey-createRBAC}
+#### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-createRBAC}
 
 CreateRBAC will automatically create the necessary RBAC roles and role bindings to allow vCluster to read the secret specified
 in the above namespace, if specified.
@@ -80,7 +80,7 @@ This defaults to true.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoSleep}
+### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoSleep}
 
 AutoSleep holds configuration for automatic sleep and wakeup
 
@@ -92,7 +92,7 @@ AutoSleep holds configuration for automatic sleep and wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoSleep-afterInactivity}
+#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoSleep-afterInactivity}
 
 AfterInactivity specifies after how many seconds of inactivity the virtual cluster should sleep
 
@@ -107,7 +107,7 @@ AfterInactivity specifies after how many seconds of inactivity the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoSleep-schedule}
+#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoSleep-schedule}
 
 Schedule specifies scheduled virtual cluster sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. Use ".Timezone" field instead.
@@ -123,7 +123,7 @@ Note: timezone defined in the schedule string will be ignored. Use ".Timezone" f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoSleep-timezone}
+#### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoSleep-timezone}
 
 Timezone specifies time zone used for scheduled virtual cluster operations. Defaults to UTC.
 Accepts the same format as time.LoadLocation() in Go (https://pkg.go.dev/time#LoadLocation).
@@ -140,7 +140,7 @@ The value should be a location name corresponding to a file in the IANA Time Zon
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoSleep-autoWakeup}
+#### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoSleep-autoWakeup}
 
 AutoSleep holds configuration for automatic wakeup
 
@@ -152,7 +152,7 @@ AutoSleep holds configuration for automatic wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoSleep-autoWakeup-schedule}
+##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoSleep-autoWakeup-schedule}
 
 Schedule specifies scheduled wakeup from sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. The timezone for the autoSleep schedule will be
@@ -175,7 +175,7 @@ used
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoDelete` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoDelete}
+### `autoDelete` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoDelete}
 
 AutoDelete holds configuration for automatic delete
 
@@ -187,7 +187,7 @@ AutoDelete holds configuration for automatic delete
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoDelete-afterInactivity}
+#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoDelete-afterInactivity}
 
 AfterInactivity specifies after how many seconds of inactivity the virtual cluster be deleted
 

--- a/platform_versioned_docs/version-4.2.0/api/_partials/resources/config/external/platform/apiKey.mdx
+++ b/platform_versioned_docs/version-4.2.0/api/_partials/resources/config/external/platform/apiKey.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#apiKey}
+## `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apiKey}
 
 APIKey defines where to find the platform access key and host. By default, vCluster will search in the following locations in this precedence:
 * environment variable called LICENSE
@@ -17,7 +17,7 @@ APIKey defines where to find the platform access key and host. By default, vClus
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#apiKey-secretName}
+### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apiKey-secretName}
 
 SecretName is the name of the secret where the platform access key is stored. This defaults to vcluster-platform-api-key if undefined.
 
@@ -32,7 +32,7 @@ SecretName is the name of the secret where the platform access key is stored. Th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#apiKey-namespace}
+### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apiKey-namespace}
 
 Namespace defines the namespace where the access key secret should be retrieved from. If this is not equal to the namespace
 where the vCluster instance is deployed, you need to make sure vCluster has access to this other namespace.
@@ -48,7 +48,7 @@ where the vCluster instance is deployed, you need to make sure vCluster has acce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#apiKey-createRBAC}
+### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apiKey-createRBAC}
 
 CreateRBAC will automatically create the necessary RBAC roles and role bindings to allow vCluster to read the secret specified
 in the above namespace, if specified.

--- a/platform_versioned_docs/version-4.2.0/api/_partials/resources/config/external/platform/autoDelete.mdx
+++ b/platform_versioned_docs/version-4.2.0/api/_partials/resources/config/external/platform/autoDelete.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `autoDelete` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoDelete}
+## `autoDelete` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoDelete}
 
 AutoDelete holds configuration for automatic delete
 
@@ -14,7 +14,7 @@ AutoDelete holds configuration for automatic delete
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoDelete-afterInactivity}
+### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoDelete-afterInactivity}
 
 AfterInactivity specifies after how many seconds of inactivity the virtual cluster be deleted
 

--- a/platform_versioned_docs/version-4.2.0/api/_partials/resources/config/external/platform/autoSleep.mdx
+++ b/platform_versioned_docs/version-4.2.0/api/_partials/resources/config/external/platform/autoSleep.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoSleep}
+## `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoSleep}
 
 AutoSleep holds configuration for automatic sleep and wakeup
 
@@ -14,7 +14,7 @@ AutoSleep holds configuration for automatic sleep and wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoSleep-afterInactivity}
+### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoSleep-afterInactivity}
 
 AfterInactivity specifies after how many seconds of inactivity the virtual cluster should sleep
 
@@ -29,7 +29,7 @@ AfterInactivity specifies after how many seconds of inactivity the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoSleep-schedule}
+### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoSleep-schedule}
 
 Schedule specifies scheduled virtual cluster sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. Use ".Timezone" field instead.
@@ -45,7 +45,7 @@ Note: timezone defined in the schedule string will be ignored. Use ".Timezone" f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoSleep-timezone}
+### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoSleep-timezone}
 
 Timezone specifies time zone used for scheduled virtual cluster operations. Defaults to UTC.
 Accepts the same format as time.LoadLocation() in Go (https://pkg.go.dev/time#LoadLocation).
@@ -62,7 +62,7 @@ The value should be a location name corresponding to a file in the IANA Time Zon
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoSleep-autoWakeup}
+### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoSleep-autoWakeup}
 
 AutoSleep holds configuration for automatic wakeup
 
@@ -74,7 +74,7 @@ AutoSleep holds configuration for automatic wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoSleep-autoWakeup-schedule}
+#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoSleep-autoWakeup-schedule}
 
 Schedule specifies scheduled wakeup from sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. The timezone for the autoSleep schedule will be

--- a/platform_versioned_docs/version-4.2.0/api/_partials/resources/config/external/platform/autoSleep/autoWakeup.mdx
+++ b/platform_versioned_docs/version-4.2.0/api/_partials/resources/config/external/platform/autoSleep/autoWakeup.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoWakeup}
+## `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoWakeup}
 
 AutoSleep holds configuration for automatic wakeup
 
@@ -14,7 +14,7 @@ AutoSleep holds configuration for automatic wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoWakeup-schedule}
+### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoWakeup-schedule}
 
 Schedule specifies scheduled wakeup from sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. The timezone for the autoSleep schedule will be

--- a/platform_versioned_docs/version-4.3.0/api/_partials/resources/config/external.mdx
+++ b/platform_versioned_docs/version-4.3.0/api/_partials/resources/config/external.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external}
+## `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external}
 
 External holds configuration for tools that are external to the vCluster.
 
@@ -14,7 +14,7 @@ External holds configuration for tools that are external to the vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform}
+### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform}
 
 platform holds platform configuration
 
@@ -26,7 +26,7 @@ platform holds platform configuration
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-apiKey}
+#### `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-apiKey}
 
 APIKey defines where to find the platform access key and host. By default, vCluster will search in the following locations in this precedence:
 * environment variable called LICENSE
@@ -41,7 +41,7 @@ APIKey defines where to find the platform access key and host. By default, vClus
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-apiKey-secretName}
+##### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-apiKey-secretName}
 
 SecretName is the name of the secret where the platform access key is stored. This defaults to vcluster-platform-api-key if undefined.
 
@@ -56,7 +56,7 @@ SecretName is the name of the secret where the platform access key is stored. Th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-apiKey-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-apiKey-namespace}
 
 Namespace defines the namespace where the access key secret should be retrieved from. If this is not equal to the namespace
 where the vCluster instance is deployed, you need to make sure vCluster has access to this other namespace.
@@ -72,7 +72,7 @@ where the vCluster instance is deployed, you need to make sure vCluster has acce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-apiKey-createRBAC}
+##### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-apiKey-createRBAC}
 
 CreateRBAC will automatically create the necessary RBAC roles and role bindings to allow vCluster to read the secret specified
 in the above namespace, if specified.
@@ -92,7 +92,7 @@ This defaults to true.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoSleep}
+#### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoSleep}
 
 AutoSleep holds configuration for automatic sleep and wakeup
 
@@ -104,7 +104,7 @@ AutoSleep holds configuration for automatic sleep and wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoSleep-afterInactivity}
+##### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoSleep-afterInactivity}
 
 AfterInactivity specifies after how many seconds of inactivity the virtual cluster should sleep
 
@@ -119,7 +119,7 @@ AfterInactivity specifies after how many seconds of inactivity the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoSleep-schedule}
+##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoSleep-schedule}
 
 Schedule specifies scheduled virtual cluster sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. Use ".Timezone" field instead.
@@ -135,7 +135,7 @@ Note: timezone defined in the schedule string will be ignored. Use ".Timezone" f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoSleep-timezone}
+##### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoSleep-timezone}
 
 Timezone specifies time zone used for scheduled virtual cluster operations. Defaults to UTC.
 Accepts the same format as time.LoadLocation() in Go (https://pkg.go.dev/time#LoadLocation).
@@ -152,7 +152,7 @@ The value should be a location name corresponding to a file in the IANA Time Zon
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoSleep-autoWakeup}
+##### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoSleep-autoWakeup}
 
 AutoSleep holds configuration for automatic wakeup
 
@@ -164,7 +164,7 @@ AutoSleep holds configuration for automatic wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoSleep-autoWakeup-schedule}
+##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoSleep-autoWakeup-schedule}
 
 Schedule specifies scheduled wakeup from sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. The timezone for the autoSleep schedule will be
@@ -187,7 +187,7 @@ used
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `autoDelete` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoDelete}
+#### `autoDelete` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoDelete}
 
 AutoDelete holds configuration for automatic delete
 
@@ -199,7 +199,7 @@ AutoDelete holds configuration for automatic delete
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-platform-autoDelete-afterInactivity}
+##### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-platform-autoDelete-afterInactivity}
 
 AfterInactivity specifies after how many seconds of inactivity the virtual cluster be deleted
 

--- a/platform_versioned_docs/version-4.3.0/api/_partials/resources/config/external/platform.mdx
+++ b/platform_versioned_docs/version-4.3.0/api/_partials/resources/config/external/platform.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform}
+## `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform}
 
 platform holds platform configuration
 
@@ -14,7 +14,7 @@ platform holds platform configuration
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-apiKey}
+### `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey}
 
 APIKey defines where to find the platform access key and host. By default, vCluster will search in the following locations in this precedence:
 * environment variable called LICENSE
@@ -29,7 +29,7 @@ APIKey defines where to find the platform access key and host. By default, vClus
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-apiKey-secretName}
+#### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-secretName}
 
 SecretName is the name of the secret where the platform access key is stored. This defaults to vcluster-platform-api-key if undefined.
 
@@ -44,7 +44,7 @@ SecretName is the name of the secret where the platform access key is stored. Th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-apiKey-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-namespace}
 
 Namespace defines the namespace where the access key secret should be retrieved from. If this is not equal to the namespace
 where the vCluster instance is deployed, you need to make sure vCluster has access to this other namespace.
@@ -60,7 +60,7 @@ where the vCluster instance is deployed, you need to make sure vCluster has acce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-apiKey-createRBAC}
+#### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-apiKey-createRBAC}
 
 CreateRBAC will automatically create the necessary RBAC roles and role bindings to allow vCluster to read the secret specified
 in the above namespace, if specified.
@@ -80,7 +80,7 @@ This defaults to true.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoSleep}
+### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoSleep}
 
 AutoSleep holds configuration for automatic sleep and wakeup
 
@@ -92,7 +92,7 @@ AutoSleep holds configuration for automatic sleep and wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoSleep-afterInactivity}
+#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoSleep-afterInactivity}
 
 AfterInactivity specifies after how many seconds of inactivity the virtual cluster should sleep
 
@@ -107,7 +107,7 @@ AfterInactivity specifies after how many seconds of inactivity the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoSleep-schedule}
+#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoSleep-schedule}
 
 Schedule specifies scheduled virtual cluster sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. Use ".Timezone" field instead.
@@ -123,7 +123,7 @@ Note: timezone defined in the schedule string will be ignored. Use ".Timezone" f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoSleep-timezone}
+#### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoSleep-timezone}
 
 Timezone specifies time zone used for scheduled virtual cluster operations. Defaults to UTC.
 Accepts the same format as time.LoadLocation() in Go (https://pkg.go.dev/time#LoadLocation).
@@ -140,7 +140,7 @@ The value should be a location name corresponding to a file in the IANA Time Zon
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoSleep-autoWakeup}
+#### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoSleep-autoWakeup}
 
 AutoSleep holds configuration for automatic wakeup
 
@@ -152,7 +152,7 @@ AutoSleep holds configuration for automatic wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoSleep-autoWakeup-schedule}
+##### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoSleep-autoWakeup-schedule}
 
 Schedule specifies scheduled wakeup from sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. The timezone for the autoSleep schedule will be
@@ -175,7 +175,7 @@ used
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoDelete` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoDelete}
+### `autoDelete` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoDelete}
 
 AutoDelete holds configuration for automatic delete
 
@@ -187,7 +187,7 @@ AutoDelete holds configuration for automatic delete
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#platform-autoDelete-afterInactivity}
+#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#platform-autoDelete-afterInactivity}
 
 AfterInactivity specifies after how many seconds of inactivity the virtual cluster be deleted
 

--- a/platform_versioned_docs/version-4.3.0/api/_partials/resources/config/external/platform/apiKey.mdx
+++ b/platform_versioned_docs/version-4.3.0/api/_partials/resources/config/external/platform/apiKey.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#apiKey}
+## `apiKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apiKey}
 
 APIKey defines where to find the platform access key and host. By default, vCluster will search in the following locations in this precedence:
 * environment variable called LICENSE
@@ -17,7 +17,7 @@ APIKey defines where to find the platform access key and host. By default, vClus
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#apiKey-secretName}
+### `secretName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apiKey-secretName}
 
 SecretName is the name of the secret where the platform access key is stored. This defaults to vcluster-platform-api-key if undefined.
 
@@ -32,7 +32,7 @@ SecretName is the name of the secret where the platform access key is stored. Th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#apiKey-namespace}
+### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apiKey-namespace}
 
 Namespace defines the namespace where the access key secret should be retrieved from. If this is not equal to the namespace
 where the vCluster instance is deployed, you need to make sure vCluster has access to this other namespace.
@@ -48,7 +48,7 @@ where the vCluster instance is deployed, you need to make sure vCluster has acce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#apiKey-createRBAC}
+### `createRBAC` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#apiKey-createRBAC}
 
 CreateRBAC will automatically create the necessary RBAC roles and role bindings to allow vCluster to read the secret specified
 in the above namespace, if specified.

--- a/platform_versioned_docs/version-4.3.0/api/_partials/resources/config/external/platform/autoDelete.mdx
+++ b/platform_versioned_docs/version-4.3.0/api/_partials/resources/config/external/platform/autoDelete.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `autoDelete` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoDelete}
+## `autoDelete` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoDelete}
 
 AutoDelete holds configuration for automatic delete
 
@@ -14,7 +14,7 @@ AutoDelete holds configuration for automatic delete
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoDelete-afterInactivity}
+### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoDelete-afterInactivity}
 
 AfterInactivity specifies after how many seconds of inactivity the virtual cluster be deleted
 

--- a/platform_versioned_docs/version-4.3.0/api/_partials/resources/config/external/platform/autoSleep.mdx
+++ b/platform_versioned_docs/version-4.3.0/api/_partials/resources/config/external/platform/autoSleep.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoSleep}
+## `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoSleep}
 
 AutoSleep holds configuration for automatic sleep and wakeup
 
@@ -14,7 +14,7 @@ AutoSleep holds configuration for automatic sleep and wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoSleep-afterInactivity}
+### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoSleep-afterInactivity}
 
 AfterInactivity specifies after how many seconds of inactivity the virtual cluster should sleep
 
@@ -29,7 +29,7 @@ AfterInactivity specifies after how many seconds of inactivity the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoSleep-schedule}
+### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoSleep-schedule}
 
 Schedule specifies scheduled virtual cluster sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. Use ".Timezone" field instead.
@@ -45,7 +45,7 @@ Note: timezone defined in the schedule string will be ignored. Use ".Timezone" f
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoSleep-timezone}
+### `timezone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoSleep-timezone}
 
 Timezone specifies time zone used for scheduled virtual cluster operations. Defaults to UTC.
 Accepts the same format as time.LoadLocation() in Go (https://pkg.go.dev/time#LoadLocation).
@@ -62,7 +62,7 @@ The value should be a location name corresponding to a file in the IANA Time Zon
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoSleep-autoWakeup}
+### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoSleep-autoWakeup}
 
 AutoSleep holds configuration for automatic wakeup
 
@@ -74,7 +74,7 @@ AutoSleep holds configuration for automatic wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoSleep-autoWakeup-schedule}
+#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoSleep-autoWakeup-schedule}
 
 Schedule specifies scheduled wakeup from sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. The timezone for the autoSleep schedule will be

--- a/platform_versioned_docs/version-4.3.0/api/_partials/resources/config/external/platform/autoSleep/autoWakeup.mdx
+++ b/platform_versioned_docs/version-4.3.0/api/_partials/resources/config/external/platform/autoSleep/autoWakeup.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoWakeup}
+## `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoWakeup}
 
 AutoSleep holds configuration for automatic wakeup
 
@@ -14,7 +14,7 @@ AutoSleep holds configuration for automatic wakeup
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoWakeup-schedule}
+### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoWakeup-schedule}
 
 Schedule specifies scheduled wakeup from sleep in Cron format, see https://en.wikipedia.org/wiki/Cron.
 Note: timezone defined in the schedule string will be ignored. The timezone for the autoSleep schedule will be

--- a/vcluster/_partials/config/controlPlane.mdx
+++ b/vcluster/_partials/config/controlPlane.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `controlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane}
+## `controlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane}
 
 Configure vCluster's control plane components and deployment.
 
@@ -14,7 +14,7 @@ Configure vCluster's control plane components and deployment.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-endpoint}
+### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-endpoint}
 
 Endpoint is the endpoint of the virtual cluster. This is used to connect to the virtual cluster.
 
@@ -29,7 +29,7 @@ Endpoint is the endpoint of the virtual cluster. This is used to connect to the 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro}
+### `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro}
 
 Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed.
 
@@ -41,7 +41,7 @@ Distro holds virtual cluster related distro options. A distro cannot be changed 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s}
+#### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s}
 
 K8S holds K8s relevant configuration.
 
@@ -53,7 +53,7 @@ K8S holds K8s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-enabled}
 
 Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -68,7 +68,7 @@ Enabled specifies if the K8s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-version}
+##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-version}
 
 [Deprecated] Version field is deprecated.
 Use controlPlane.distro.k8s.image.tag to specify the Kubernetes version instead.
@@ -84,7 +84,7 @@ Use controlPlane.distro.k8s.image.tag to specify the Kubernetes version instead.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer}
+##### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer}
 
 APIServer holds configuration specific to starting the api server.
 
@@ -96,7 +96,7 @@ APIServer holds configuration specific to starting the api server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -111,7 +111,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -126,7 +126,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -144,7 +144,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager}
+##### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager}
 
 ControllerManager holds configuration specific to starting the controller manager.
 
@@ -156,7 +156,7 @@ ControllerManager holds configuration specific to starting the controller manage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -171,7 +171,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -186,7 +186,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -204,7 +204,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-scheduler}
+##### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler}
 
 Scheduler holds configuration specific to starting the scheduler. Enable this via controlPlane.advanced.virtualScheduler.enabled
 
@@ -216,7 +216,7 @@ Scheduler holds configuration specific to starting the scheduler. Enable this vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-scheduler-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -231,7 +231,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-scheduler-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -246,7 +246,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-scheduler-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -264,7 +264,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image}
 
 Image is the distro image
 
@@ -276,7 +276,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -292,7 +292,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -307,7 +307,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.33.1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.33.1</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -325,7 +325,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -340,7 +340,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-env}
+##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -355,7 +355,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-resources}
 
 Resources for the distro init container
 
@@ -370,7 +370,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-securityContext}
+##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -388,7 +388,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s}
+#### `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s}
 
 [Deprecated] K3S holds K3s relevant configuration.
 
@@ -400,7 +400,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-enabled}
 
 Enabled specifies if the K3s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -415,7 +415,7 @@ Enabled specifies if the K3s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-token}
+##### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-token}
 
 Token is the K3s token to use. If empty, vCluster will choose one.
 
@@ -430,7 +430,7 @@ Token is the K3s token to use. If empty, vCluster will choose one.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-image}
 
 Image is the distro image
 
@@ -442,7 +442,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -458,7 +458,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -473,7 +473,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.33.1-k3s1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.33.1-k3s1</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -491,7 +491,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -506,7 +506,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-env}
+##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -521,7 +521,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-resources}
 
 Resources for the distro init container
 
@@ -536,7 +536,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-securityContext}
+##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -551,7 +551,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -566,7 +566,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -587,7 +587,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `standalone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone}
+### `standalone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone}
 
 Standalone holds configuration for standalone mode. Standalone mode is set automatically when no container is detected and
 also implies privateNodes.enabled.
@@ -600,7 +600,7 @@ also implies privateNodes.enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-enabled}
 
 Enabled defines if standalone mode should be enabled.
 
@@ -615,7 +615,7 @@ Enabled defines if standalone mode should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `syncConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-syncConfig}
+#### `syncConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-syncConfig}
 
 SyncConfig allows controlling the vCluster config through a secret "vcluster-config" in the namespace "kube-system". vCluster will watch for changes in this secret and
 update the local config accordingly and restart vCluster if needed.
@@ -628,7 +628,7 @@ update the local config accordingly and restart vCluster if needed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-syncConfig-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-standalone-syncConfig-enabled}
 
 Enabled defines if config syncing should be enabled.
 
@@ -646,7 +646,7 @@ Enabled defines if config syncing should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dataDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">/var/lib/vcluster</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-dataDir}
+#### `dataDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">/var/lib/vcluster</span> <span className="config-field-enum"></span> {#controlPlane-standalone-dataDir}
 
 DataDir defines the data directory for the standalone mode.
 
@@ -661,7 +661,7 @@ DataDir defines the data directory for the standalone mode.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `bundleRepository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">https://github.com/loft-sh/kubernetes/releases/download</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-bundleRepository}
+#### `bundleRepository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">https://github.com/loft-sh/kubernetes/releases/download</span> <span className="config-field-enum"></span> {#controlPlane-standalone-bundleRepository}
 
 BundleRepository is the repository to use for downloading the Kubernetes bundle. Defaults to https://github.com/loft-sh/kubernetes/releases/download
 
@@ -676,7 +676,7 @@ BundleRepository is the repository to use for downloading the Kubernetes bundle.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-bundle}
+#### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-bundle}
 
 Bundle is a path to a Kubernetes bundle to use for the standalone mode. If empty, will use the bundleRepository to download the bundle.
 
@@ -691,7 +691,7 @@ Bundle is a path to a Kubernetes bundle to use for the standalone mode. If empty
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `joinNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode}
+#### `joinNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode}
 
 JoinNode holds configuration for the standalone control plane node.
 
@@ -703,7 +703,7 @@ JoinNode holds configuration for the standalone control plane node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-enabled}
 
 Enabled defines if the standalone node should be joined into the cluster. If false, only the control plane binaries will be executed and no node will show up in the actual cluster.
 
@@ -718,7 +718,7 @@ Enabled defines if the standalone node should be joined into the cluster. If fal
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `preJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-preJoinCommands}
+##### `preJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-preJoinCommands}
 
 PreJoinCommands are commands that will be executed before the join process starts.
 
@@ -733,7 +733,7 @@ PreJoinCommands are commands that will be executed before the join process start
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `postJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-postJoinCommands}
+##### `postJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-postJoinCommands}
 
 PostJoinCommands are commands that will be executed after the join process starts.
 
@@ -748,7 +748,7 @@ PostJoinCommands are commands that will be executed after the join process start
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `containerd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-containerd}
+##### `containerd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd}
 
 Containerd holds configuration for the containerd join process.
 
@@ -760,7 +760,7 @@ Containerd holds configuration for the containerd join process.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-containerd-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-enabled}
 
 Enabled defines if containerd should be installed and configured by vCluster.
 
@@ -775,7 +775,7 @@ Enabled defines if containerd should be installed and configured by vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-containerd-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry}
 
 Registry holds configuration for how containerd should be configured to use a registries.
 
@@ -787,7 +787,7 @@ Registry holds configuration for how containerd should be configured to use a re
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-containerd-registry-configPath}
+##### `configPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-configPath}
 
 ConfigPath is the path to the containerd registry config.
 
@@ -802,7 +802,7 @@ ConfigPath is the path to the containerd registry config.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mirrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors}
+##### `mirrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors}
 
 Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry.io:5000 or docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -814,7 +814,7 @@ Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-server}
+##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-server}
 
 Server is the fallback server to use for the containerd registry mirror. E.g. https://registry-1.docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -829,7 +829,7 @@ Server is the fallback server to use for the containerd registry mirror. E.g. ht
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-caCert}
+##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror.
 
@@ -844,7 +844,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -859,7 +859,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -874,7 +874,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `hosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts}
+##### `hosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts}
 
 Hosts holds configuration for the containerd registry mirror hosts. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -886,7 +886,7 @@ Hosts holds configuration for the containerd registry mirror hosts. See https://
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-server}
+##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-server}
 
 Server is the server to use for the containerd registry mirror host. E.g. http://192.168.31.250:5000.
 
@@ -901,7 +901,7 @@ Server is the server to use for the containerd registry mirror host. E.g. http:/
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-caCert}
+##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror host.
 
@@ -916,7 +916,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror ho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -931,7 +931,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -955,7 +955,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `importImages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-containerd-importImages}
+##### `importImages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-importImages}
 
 ImportImages is a list of images to import into the containerd registry from local files. If the path is a folder, all files that end with .tar or .tar.gz in the folder will be imported.
 
@@ -970,7 +970,7 @@ ImportImages is a list of images to import into the containerd registry from loc
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `pauseImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-containerd-pauseImage}
+##### `pauseImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-pauseImage}
 
 PauseImage is the image for the pause container.
 
@@ -988,7 +988,7 @@ PauseImage is the image for the pause container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCertPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-caCertPath}
+##### `caCertPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-caCertPath}
 
 CACertPath is the path to the SSL certificate authority used to
 secure communications between node and control-plane.
@@ -1005,7 +1005,7 @@ Defaults to "/etc/kubernetes/pki/ca.crt".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipPhases` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-skipPhases}
+##### `skipPhases` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-skipPhases}
 
 SkipPhases is a list of phases to skip during command execution.
 The list of phases can be obtained with the "kubeadm join --help" command.
@@ -1021,7 +1021,7 @@ The list of phases can be obtained with the "kubeadm join --help" command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `nodeRegistration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-nodeRegistration}
+##### `nodeRegistration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration}
 
 NodeRegistration holds configuration for the node registration similar to the kubeadm node registration.
 
@@ -1033,7 +1033,7 @@ NodeRegistration holds configuration for the node registration similar to the ku
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `criSocket` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-nodeRegistration-criSocket}
+##### `criSocket` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-criSocket}
 
 CRI socket is the socket for the CRI.
 
@@ -1048,7 +1048,7 @@ CRI socket is the socket for the CRI.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubeletExtraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs}
+##### `kubeletExtraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs}
 
 KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
 kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config ConfigMap
@@ -1064,7 +1064,7 @@ Extra arguments will override existing default arguments. Duplicate extra argume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs-name}
 
 Name is the name of the argument.
 
@@ -1079,7 +1079,7 @@ Name is the name of the argument.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs-value}
 
 Value is the value of the argument.
 
@@ -1097,7 +1097,7 @@ Value is the value of the argument.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-nodeRegistration-taints}
+##### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints}
 
 Taints are additional taints to set for the kubelet.
 
@@ -1109,7 +1109,7 @@ Taints are additional taints to set for the kubelet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-key}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-key}
 
 Required. The taint key to be applied to a node.
 
@@ -1124,7 +1124,7 @@ Required. The taint key to be applied to a node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-value}
 
 The taint value corresponding to the taint key.
 
@@ -1139,7 +1139,7 @@ The taint value corresponding to the taint key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-effect}
+##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-effect}
 
 Required. The effect of the taint on pods
 that do not tolerate the taint.
@@ -1159,7 +1159,7 @@ Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignorePreflightErrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-nodeRegistration-ignorePreflightErrors}
+##### `ignorePreflightErrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-ignorePreflightErrors}
 
 IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered, e.g. 'IsPrivilegedUser,Swap'.
 Value 'all' ignores errors from all checks.
@@ -1175,7 +1175,7 @@ Value 'all' ignores errors from all checks.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-standalone-joinNode-nodeRegistration-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-imagePullPolicy}
 
 ImagePullPolicy specifies the policy for image pulling during kubeadm "init" and "join" operations.
 The value of this field must be one of "Always", "IfNotPresent" or "Never".
@@ -1201,7 +1201,7 @@ If this field is unset kubeadm will default it to "IfNotPresent", or pull the re
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `backingStore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore}
+### `backingStore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore}
 
 BackingStore defines which backing store to use for virtual cluster. If not defined will use embedded database as a default backing store.
 
@@ -1213,7 +1213,7 @@ BackingStore defines which backing store to use for virtual cluster. If not defi
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `etcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd}
+#### `etcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd}
 
 Etcd defines that etcd should be used as the backend for the virtual cluster
 
@@ -1225,7 +1225,7 @@ Etcd defines that etcd should be used as the backend for the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-embedded}
+##### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded}
 
 Embedded defines to use embedded etcd as a storage backend for the virtual cluster
 
@@ -1237,7 +1237,7 @@ Embedded defines to use embedded etcd as a storage backend for the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-enabled}
 
 Enabled defines if the embedded etcd should be used.
 
@@ -1252,7 +1252,7 @@ Enabled defines if the embedded etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-embedded-migrateFromDeployedEtcd}
+##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-migrateFromDeployedEtcd}
 
 MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd.
 
@@ -1267,7 +1267,7 @@ MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-embedded-snapshotCount}
+##### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-snapshotCount}
 
 SnapshotCount defines the number of snapshots to keep for the embedded etcd. Defaults to 10000 if less than 1.
 
@@ -1282,7 +1282,7 @@ SnapshotCount defines the number of snapshots to keep for the embedded etcd. Def
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-embedded-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to the embedded etcd.
 
@@ -1300,7 +1300,7 @@ ExtraArgs are additional arguments to pass to the embedded etcd.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy}
+##### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy}
 
 Deploy defines to use an external etcd that is deployed by the helm chart
 
@@ -1312,7 +1312,7 @@ Deploy defines to use an external etcd that is deployed by the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-enabled}
 
 Enabled defines that an external etcd should be deployed.
 
@@ -1327,7 +1327,7 @@ Enabled defines that an external etcd should be deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet}
+##### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet}
 
 StatefulSet holds options for the external etcd statefulSet.
 
@@ -1339,7 +1339,7 @@ StatefulSet holds options for the external etcd statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enabled}
 
 Enabled defines if the statefulSet should be deployed
 
@@ -1354,7 +1354,7 @@ Enabled defines if the statefulSet should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enableServiceLinks}
+##### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -1369,7 +1369,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image}
 
 Image is the image to use for the external etcd statefulSet
 
@@ -1381,7 +1381,7 @@ Image is the image to use for the external etcd statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -1397,7 +1397,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -1412,7 +1412,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.21-0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.21-0</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -1430,7 +1430,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the external etcd image
 
@@ -1445,7 +1445,7 @@ ImagePullPolicy is the pull policy for the external etcd image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-env}
+##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-env}
 
 Env are extra environment variables
 
@@ -1460,7 +1460,7 @@ Env are extra environment variables
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-extraArgs}
 
 ExtraArgs are appended to the etcd command.
 
@@ -1475,7 +1475,7 @@ ExtraArgs are appended to the etcd command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources}
 
 Resources the etcd can consume
 
@@ -1487,7 +1487,7 @@ Resources the etcd can consume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -1502,7 +1502,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -1520,7 +1520,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods}
+##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods}
 
 Pods defines extra metadata for the etcd pods.
 
@@ -1532,7 +1532,7 @@ Pods defines extra metadata for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -1547,7 +1547,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -1565,7 +1565,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability}
+##### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability}
 
 HighAvailability are high availability options
 
@@ -1577,7 +1577,7 @@ HighAvailability are high availability options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
 
 Replicas are the amount of pods to use.
 
@@ -1595,7 +1595,7 @@ Replicas are the amount of pods to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling}
+##### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling}
 
 Scheduling options for the etcd pods.
 
@@ -1607,7 +1607,7 @@ Scheduling options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -1622,7 +1622,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -1637,7 +1637,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -1652,7 +1652,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -1667,7 +1667,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -1682,7 +1682,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -1700,7 +1700,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security}
+##### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security}
 
 Security options for the etcd pods.
 
@@ -1712,7 +1712,7 @@ Security options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -1727,7 +1727,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -1745,7 +1745,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence}
+##### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence}
 
 Persistence options for the etcd pods.
 
@@ -1757,7 +1757,7 @@ Persistence options for the etcd pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -1769,7 +1769,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim.
 
@@ -1784,7 +1784,7 @@ Enabled enables deploying a persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -1799,7 +1799,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -1814,7 +1814,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -1829,7 +1829,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -1847,7 +1847,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -1862,7 +1862,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -1877,7 +1877,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -1889,7 +1889,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -1904,7 +1904,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -1920,7 +1920,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -1936,7 +1936,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -1952,7 +1952,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -1970,7 +1970,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -1994,7 +1994,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2009,7 +2009,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-statefulSet-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -2027,7 +2027,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service}
 
 Service holds options for the external etcd service.
 
@@ -2039,7 +2039,7 @@ Service holds options for the external etcd service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-service-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service-enabled}
 
 Enabled defines if the etcd service should be deployed
 
@@ -2054,7 +2054,7 @@ Enabled defines if the etcd service should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-service-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service-annotations}
 
 Annotations are extra annotations for the external etcd service
 
@@ -2072,7 +2072,7 @@ Annotations are extra annotations for the external etcd service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-headlessService}
+##### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-headlessService}
 
 HeadlessService holds options for the external etcd headless service.
 
@@ -2084,7 +2084,7 @@ HeadlessService holds options for the external etcd headless service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-deploy-headlessService-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-headlessService-annotations}
 
 Annotations are extra annotations for the external etcd headless service
 
@@ -2105,7 +2105,7 @@ Annotations are extra annotations for the external etcd headless service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-external}
+##### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external}
 
 External defines to use a self-hosted external etcd that is not deployed by the helm chart
 
@@ -2117,7 +2117,7 @@ External defines to use a self-hosted external etcd that is not deployed by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-enabled}
 
 Enabled defines if the external etcd should be used.
 
@@ -2132,7 +2132,7 @@ Enabled defines if the external etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-external-endpoint}
+##### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-endpoint}
 
 Endpoint holds the endpoint of the external etcd server, e.g. my-example-service:2379
 
@@ -2147,7 +2147,7 @@ Endpoint holds the endpoint of the external etcd server, e.g. my-example-service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `tls` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-external-tls}
+##### `tls` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls}
 
 TLS defines the tls configuration for the external etcd server
 
@@ -2159,7 +2159,7 @@ TLS defines the tls configuration for the external etcd server
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-external-tls-caFile}
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-caFile}
 
 CaFile is the path to the ca file
 
@@ -2174,7 +2174,7 @@ CaFile is the path to the ca file
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-external-tls-certFile}
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-certFile}
 
 CertFile is the path to the cert file
 
@@ -2189,7 +2189,7 @@ CertFile is the path to the cert file
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-etcd-external-tls-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-keyFile}
 
 KeyFile is the path to the key file
 
@@ -2213,7 +2213,7 @@ KeyFile is the path to the key file
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database}
+#### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database}
 
 Database defines that a database backend should be used as the backend for the virtual cluster. This uses a project called kine under the hood which is a shim for bridging Kubernetes and relational databases.
 
@@ -2225,7 +2225,7 @@ Database defines that a database backend should be used as the backend for the v
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-embedded}
+##### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded}
 
 Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster
 
@@ -2237,7 +2237,7 @@ Embedded defines that an embedded database (sqlite) should be used as the backen
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-enabled}
 
 Enabled defines if the database should be used.
 
@@ -2252,7 +2252,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-embedded-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -2270,7 +2270,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-embedded-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -2285,7 +2285,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-embedded-certFile}
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -2300,7 +2300,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-embedded-caFile}
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -2315,7 +2315,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-embedded-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 
@@ -2333,7 +2333,7 @@ ExtraArgs are additional arguments to pass to Kine.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external}
+##### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external}
 
 External defines that an external database should be used as the backend for the virtual cluster
 
@@ -2345,7 +2345,7 @@ External defines that an external database should be used as the backend for the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-enabled}
 
 Enabled defines if the database should be used.
 
@@ -2360,7 +2360,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -2378,7 +2378,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -2393,7 +2393,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external-certFile}
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -2408,7 +2408,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external-caFile}
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -2423,7 +2423,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 
@@ -2438,7 +2438,7 @@ ExtraArgs are additional arguments to pass to Kine.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-backingStore-database-external-connector}
+##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-connector}
 
 Connector specifies a secret located in a connected vCluster Platform that contains database server connection information
 to be used by Platform to create a database and database user for the vCluster.
@@ -2465,7 +2465,7 @@ This is optional.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `coredns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns}
+### `coredns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns}
 
 CoreDNS defines everything related to the coredns that is deployed and used within the vCluster.
 
@@ -2477,7 +2477,7 @@ CoreDNS defines everything related to the coredns that is deployed and used with
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-coredns-enabled}
 
 Enabled defines if coredns is enabled
 
@@ -2492,7 +2492,7 @@ Enabled defines if coredns is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-embedded}
+#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-coredns-embedded}
 
 Embedded defines if vCluster will start the embedded coredns service within the control-plane and not as a separate deployment. This is a PRO feature.
 
@@ -2507,7 +2507,7 @@ Embedded defines if vCluster will start the embedded coredns service within the 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-security}
+#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-security}
 
 Security defines pod or container security context.
 
@@ -2519,7 +2519,7 @@ Security defines pod or container security context.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -2534,7 +2534,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -2552,7 +2552,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-service}
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-service}
 
 Service holds extra options for the coredns service deployed within the virtual cluster
 
@@ -2564,7 +2564,7 @@ Service holds extra options for the coredns service deployed within the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-service-spec}
+##### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-spec}
 
 Spec holds extra options for the coredns service
 
@@ -2579,7 +2579,7 @@ Spec holds extra options for the coredns service
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-service-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2594,7 +2594,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-service-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-labels}
 
 Labels are extra labels for this resource.
 
@@ -2612,7 +2612,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deployment` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment}
+#### `deployment` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment}
 
 Deployment holds extra options for the coredns deployment deployed within the virtual cluster
 
@@ -2624,7 +2624,7 @@ Deployment holds extra options for the coredns deployment deployed within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-image}
 
 Image is the coredns image to use
 
@@ -2639,7 +2639,7 @@ Image is the coredns image to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-replicas}
 
 Replicas is the amount of coredns pods to run.
 
@@ -2654,7 +2654,7 @@ Replicas is the amount of coredns pods to run.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-nodeSelector}
 
 NodeSelector is the node selector to use for coredns.
 
@@ -2669,7 +2669,7 @@ NodeSelector is the node selector to use for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-affinity}
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -2684,7 +2684,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -2699,7 +2699,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources}
 
 Resources are the desired resources for coredns.
 
@@ -2711,7 +2711,7 @@ Resources are the desired resources for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources-limits}
 
 Limits are resource limits for the container
 
@@ -2726,7 +2726,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -2744,7 +2744,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-pods}
+##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods}
 
 Pods is additional metadata for the coredns pods.
 
@@ -2756,7 +2756,7 @@ Pods is additional metadata for the coredns pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2771,7 +2771,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -2789,7 +2789,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -2804,7 +2804,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-labels}
 
 Labels are extra labels for this resource.
 
@@ -2819,7 +2819,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-deployment-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the CoreDNS pod.
 
@@ -2837,7 +2837,7 @@ TopologySpreadConstraints are the topology spread constraints for the CoreDNS po
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-overwriteConfig}
+#### `overwriteConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-overwriteConfig}
 
 OverwriteConfig can be used to overwrite the coredns config
 
@@ -2852,7 +2852,7 @@ OverwriteConfig can be used to overwrite the coredns config
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteManifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-overwriteManifests}
+#### `overwriteManifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-overwriteManifests}
 
 OverwriteManifests can be used to overwrite the coredns manifests used to deploy coredns
 
@@ -2867,7 +2867,7 @@ OverwriteManifests can be used to overwrite the coredns manifests used to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-coredns-priorityClassName}
+#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-priorityClassName}
 
 PriorityClassName specifies the priority class name for the CoreDNS pods.
 
@@ -2885,7 +2885,7 @@ PriorityClassName specifies the priority class name for the CoreDNS pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-proxy}
+### `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-proxy}
 
 Proxy defines options for the virtual cluster control plane proxy that is used to do authentication and intercept requests.
 
@@ -2897,7 +2897,7 @@ Proxy defines options for the virtual cluster control plane proxy that is used t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `bindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-proxy-bindAddress}
+#### `bindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> {#controlPlane-proxy-bindAddress}
 
 BindAddress under which vCluster will expose the proxy.
 
@@ -2912,7 +2912,7 @@ BindAddress under which vCluster will expose the proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-proxy-port}
+#### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> {#controlPlane-proxy-port}
 
 Port under which vCluster will expose the proxy. Changing port is currently not supported.
 
@@ -2927,7 +2927,7 @@ Port under which vCluster will expose the proxy. Changing port is currently not 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraSANs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-proxy-extraSANs}
+#### `extraSANs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-proxy-extraSANs}
 
 ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
 
@@ -2945,7 +2945,7 @@ ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `hostPathMapper` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-hostPathMapper}
+### `hostPathMapper` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper}
 
 HostPathMapper defines if vCluster should rewrite host paths.
 
@@ -2957,7 +2957,7 @@ HostPathMapper defines if vCluster should rewrite host paths.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-hostPathMapper-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper-enabled}
 
 Enabled specifies if the host path mapper will be used
 
@@ -2972,7 +2972,7 @@ Enabled specifies if the host path mapper will be used
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `central` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-hostPathMapper-central}
+#### `central` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper-central}
 
 Central specifies if the central host path mapper will be used
 
@@ -2990,7 +2990,7 @@ Central specifies if the central host path mapper will be used
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress}
+### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-ingress}
 
 Ingress defines options for vCluster ingress deployed by Helm.
 
@@ -3002,7 +3002,7 @@ Ingress defines options for vCluster ingress deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-ingress-enabled}
 
 Enabled defines if the control plane ingress should be enabled
 
@@ -3017,7 +3017,7 @@ Enabled defines if the control plane ingress should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress-host}
+#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#controlPlane-ingress-host}
 
 Host is the host where vCluster will be reachable
 
@@ -3032,7 +3032,7 @@ Host is the host where vCluster will be reachable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `pathType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress-pathType}
+#### `pathType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> {#controlPlane-ingress-pathType}
 
 PathType is the path type of the ingress
 
@@ -3047,7 +3047,7 @@ PathType is the path type of the ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress-spec}
+#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-spec}
 
 Spec allows you to configure extra ingress options.
 
@@ -3062,7 +3062,7 @@ Spec allows you to configure extra ingress options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -3077,7 +3077,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-ingress-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-labels}
 
 Labels are extra labels for this resource.
 
@@ -3095,7 +3095,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service}
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-service}
 
 Service defines options for vCluster service deployed by Helm.
 
@@ -3107,7 +3107,7 @@ Service defines options for vCluster service deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-service-enabled}
 
 Enabled defines if the control plane service should be enabled
 
@@ -3122,7 +3122,7 @@ Enabled defines if the control plane service should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service-spec}
+#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#controlPlane-service-spec}
 
 Spec allows you to configure extra service options.
 
@@ -3137,7 +3137,7 @@ Spec allows you to configure extra service options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kubeletNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service-kubeletNodePort}
+#### `kubeletNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#controlPlane-service-kubeletNodePort}
 
 KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 0.
 
@@ -3152,7 +3152,7 @@ KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `httpsNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service-httpsNodePort}
+#### `httpsNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#controlPlane-service-httpsNodePort}
 
 HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 
@@ -3167,7 +3167,7 @@ HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -3182,7 +3182,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-service-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-service-labels}
 
 Labels are extra labels for this resource.
 
@@ -3200,7 +3200,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet}
+### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet}
 
 StatefulSet defines options for vCluster statefulSet deployed by Helm.
 
@@ -3212,7 +3212,7 @@ StatefulSet defines options for vCluster statefulSet deployed by Helm.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-highAvailability}
+#### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability}
 
 HighAvailability holds options related to high availability.
 
@@ -3224,7 +3224,7 @@ HighAvailability holds options related to high availability.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-replicas}
 
 Replicas is the amount of replicas to use for the statefulSet.
 
@@ -3239,7 +3239,7 @@ Replicas is the amount of replicas to use for the statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `leaseDuration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-highAvailability-leaseDuration}
+##### `leaseDuration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-leaseDuration}
 
 LeaseDuration is the time to lease for the leader.
 
@@ -3254,7 +3254,7 @@ LeaseDuration is the time to lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `renewDeadline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-highAvailability-renewDeadline}
+##### `renewDeadline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-renewDeadline}
 
 RenewDeadline is the deadline to renew a lease for the leader.
 
@@ -3269,7 +3269,7 @@ RenewDeadline is the deadline to renew a lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retryPeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-highAvailability-retryPeriod}
+##### `retryPeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-retryPeriod}
 
 RetryPeriod is the time until a replica will retry to get a lease.
 
@@ -3287,7 +3287,7 @@ RetryPeriod is the time until a replica will retry to get a lease.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources}
 
 Resources are the resource requests and limits for the statefulSet container.
 
@@ -3299,7 +3299,7 @@ Resources are the resource requests and limits for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:8Gi memory:2Gi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:8Gi memory:2Gi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -3314,7 +3314,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:400Mi memory:256Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:400Mi memory:256Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -3332,7 +3332,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling}
+#### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling}
 
 Scheduling holds options related to scheduling.
 
@@ -3344,7 +3344,7 @@ Scheduling holds options related to scheduling.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -3359,7 +3359,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -3374,7 +3374,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -3389,7 +3389,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -3404,7 +3404,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -3419,7 +3419,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -3437,7 +3437,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-security}
+#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security}
 
 Security defines pod or container security context.
 
@@ -3449,7 +3449,7 @@ Security defines pod or container security context.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -3464,7 +3464,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -3482,7 +3482,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `probes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes}
+#### `probes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes}
 
 Probes enables or disables the main container probes.
 
@@ -3494,7 +3494,7 @@ Probes enables or disables the main container probes.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `livenessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-livenessProbe}
+##### `livenessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe}
 
 LivenessProbe specifies if the liveness probe for the container should be enabled
 
@@ -3506,7 +3506,7 @@ LivenessProbe specifies if the liveness probe for the container should be enable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-livenessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3521,7 +3521,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-livenessProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-failureThreshold}
 
 Number of consecutive failures for the probe to be considered failed
 
@@ -3536,7 +3536,7 @@ Number of consecutive failures for the probe to be considered failed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `initialDelaySeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-livenessProbe-initialDelaySeconds}
+##### `initialDelaySeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-initialDelaySeconds}
 
 Time (in seconds) to wait before starting the liveness probe
 
@@ -3551,7 +3551,7 @@ Time (in seconds) to wait before starting the liveness probe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-livenessProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -3566,7 +3566,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-livenessProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -3584,7 +3584,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `readinessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-readinessProbe}
+##### `readinessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe}
 
 ReadinessProbe specifies if the readiness probe for the container should be enabled
 
@@ -3596,7 +3596,7 @@ ReadinessProbe specifies if the readiness probe for the container should be enab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-readinessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3611,7 +3611,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-readinessProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-failureThreshold}
 
 Number of consecutive failures for the probe to be considered failed
 
@@ -3626,7 +3626,7 @@ Number of consecutive failures for the probe to be considered failed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-readinessProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -3641,7 +3641,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-readinessProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -3659,7 +3659,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `startupProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-startupProbe}
+##### `startupProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe}
 
 StartupProbe specifies if the startup probe for the container should be enabled
 
@@ -3671,7 +3671,7 @@ StartupProbe specifies if the startup probe for the container should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-startupProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3686,7 +3686,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">300</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-startupProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">300</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-failureThreshold}
 
 Number of consecutive failures allowed before failing the pod
 
@@ -3701,7 +3701,7 @@ Number of consecutive failures allowed before failing the pod
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-startupProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -3716,7 +3716,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">6</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-probes-startupProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">6</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -3737,7 +3737,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence}
+#### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence}
 
 Persistence defines options around persistence for the statefulSet.
 
@@ -3749,7 +3749,7 @@ Persistence defines options around persistence for the statefulSet.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -3761,7 +3761,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim. If auto, vCluster will automatically determine
 based on the chosen distro and other options if this is required.
@@ -3777,7 +3777,7 @@ based on the chosen distro and other options if this is required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -3792,7 +3792,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -3807,7 +3807,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -3822,7 +3822,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -3840,7 +3840,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -3855,7 +3855,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-dataVolume}
+##### `dataVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-dataVolume}
 
 Allows you to override the dataVolume. Only works correctly if volumeClaim.enabled=false.
 
@@ -3870,7 +3870,7 @@ Allows you to override the dataVolume. Only works correctly if volumeClaim.enabl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `binariesVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-binariesVolume}
+##### `binariesVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-binariesVolume}
 
 BinariesVolume defines a binaries volume that is used to retrieve
 distro specific executables to be run by the syncer controller.
@@ -3887,7 +3887,7 @@ This volume doesn't need to be persistent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -3902,7 +3902,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -3914,7 +3914,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -3929,7 +3929,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -3945,7 +3945,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -3961,7 +3961,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -3977,7 +3977,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -3995,7 +3995,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -4019,7 +4019,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-enableServiceLinks}
+#### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -4034,7 +4034,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -4049,7 +4049,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -4064,7 +4064,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-pods}
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods}
 
 Additional labels or annotations for the statefulSet pods.
 
@@ -4076,7 +4076,7 @@ Additional labels or annotations for the statefulSet pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -4091,7 +4091,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -4109,7 +4109,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image}
 
 Image is the image for the controlPlane statefulSet container
 It defaults to the vCluster pro repository that includes the optional pro modules that are turned off by default.
@@ -4123,7 +4123,7 @@ If you still want to use the pure OSS build, set the repository to 'loft-sh/vclu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -4139,7 +4139,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -4154,7 +4154,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -4172,7 +4172,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -4187,7 +4187,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `workingDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-workingDir}
+#### `workingDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-workingDir}
 
 WorkingDir specifies in what folder the main process should get started.
 
@@ -4202,7 +4202,7 @@ WorkingDir specifies in what folder the main process should get started.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-command}
 
 Command allows you to override the main command.
 
@@ -4217,7 +4217,7 @@ Command allows you to override the main command.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-args}
+#### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-args}
 
 Args allows you to override the main arguments.
 
@@ -4232,7 +4232,7 @@ Args allows you to override the main arguments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-env}
+#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-env}
 
 Env are additional environment variables for the statefulSet container.
 
@@ -4247,7 +4247,7 @@ Env are additional environment variables for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dnsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsPolicy}
+#### `dnsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsPolicy}
 
 Set DNS policy for the pod.
 
@@ -4262,7 +4262,7 @@ Set DNS policy for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `dnsConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsConfig}
+#### `dnsConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig}
 
 Specifies the DNS parameters of a pod.
 
@@ -4274,7 +4274,7 @@ Specifies the DNS parameters of a pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nameservers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsConfig-nameservers}
+##### `nameservers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-nameservers}
 
 A list of DNS name server IP addresses.
 This will be appended to the base nameservers generated from DNSPolicy.
@@ -4291,7 +4291,7 @@ Duplicated nameservers will be removed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `searches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsConfig-searches}
+##### `searches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-searches}
 
 A list of DNS search domains for host-name lookup.
 This will be appended to the base search paths generated from DNSPolicy.
@@ -4308,7 +4308,7 @@ Duplicated search paths will be removed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsConfig-options}
+##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options}
 
 A list of DNS resolver options.
 This will be merged with the base options generated from DNSPolicy.
@@ -4323,7 +4323,7 @@ will override those that appear in the base DNSPolicy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsConfig-options-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options-name}
 
 Required.
 
@@ -4338,7 +4338,7 @@ Required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-statefulSet-dnsConfig-options-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options-value}
 
 
 
@@ -4362,7 +4362,7 @@ Required.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceMonitor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-serviceMonitor}
+### `serviceMonitor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor}
 
 ServiceMonitor can be used to automatically create a service monitor for vCluster deployment itself.
 
@@ -4374,7 +4374,7 @@ ServiceMonitor can be used to automatically create a service monitor for vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-serviceMonitor-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-enabled}
 
 Enabled configures if Helm should create the service monitor.
 
@@ -4389,7 +4389,7 @@ Enabled configures if Helm should create the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-serviceMonitor-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-labels}
 
 Labels are the extra labels to add to the service monitor.
 
@@ -4404,7 +4404,7 @@ Labels are the extra labels to add to the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-serviceMonitor-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-annotations}
 
 Annotations are the extra annotations to add to the service monitor.
 
@@ -4422,7 +4422,7 @@ Annotations are the extra annotations to add to the service monitor.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced}
+### `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced}
 
 Advanced holds additional configuration for the vCluster control plane.
 
@@ -4434,7 +4434,7 @@ Advanced holds additional configuration for the vCluster control plane.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-defaultImageRegistry}
+#### `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-defaultImageRegistry}
 
 DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
 upload all required vCluster images to a single private repository and set this value. Workload images are not affected by this.
@@ -4450,7 +4450,7 @@ upload all required vCluster images to a single private repository and set this 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-virtualScheduler}
+#### `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-virtualScheduler}
 
 VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.
 Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
@@ -4463,7 +4463,7 @@ Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-virtualScheduler-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-virtualScheduler-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4481,7 +4481,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount}
+#### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount}
 
 ServiceAccount specifies options for the vCluster control plane service account.
 
@@ -4493,7 +4493,7 @@ ServiceAccount specifies options for the vCluster control plane service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-enabled}
 
 Enabled specifies if the service account should get deployed.
 
@@ -4508,7 +4508,7 @@ Enabled specifies if the service account should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-name}
 
 Name specifies what name to use for the service account.
 
@@ -4523,7 +4523,7 @@ Name specifies what name to use for the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount-imagePullSecrets}
+##### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the service account.
 
@@ -4535,7 +4535,7 @@ ImagePullSecrets defines extra image pull secrets for the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -4553,7 +4553,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -4568,7 +4568,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-serviceAccount-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -4586,7 +4586,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount}
+#### `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount}
 
 WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster.
 
@@ -4598,7 +4598,7 @@ WorkloadServiceAccount specifies options for the service account that will be us
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-enabled}
 
 Enabled specifies if the service account for the workloads should get deployed.
 
@@ -4613,7 +4613,7 @@ Enabled specifies if the service account for the workloads should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-name}
 
 Name specifies what name to use for the service account for the virtual cluster workloads.
 
@@ -4628,7 +4628,7 @@ Name specifies what name to use for the service account for the virtual cluster 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets}
+##### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the workload service account.
 
@@ -4640,7 +4640,7 @@ ImagePullSecrets defines extra image pull secrets for the workload service accou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -4658,7 +4658,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -4673,7 +4673,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-workloadServiceAccount-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -4691,7 +4691,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-headlessService}
+#### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService}
 
 HeadlessService specifies options for the headless service used for the vCluster StatefulSet.
 
@@ -4703,7 +4703,7 @@ HeadlessService specifies options for the headless service used for the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-headlessService-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -4718,7 +4718,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-headlessService-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService-labels}
 
 Labels are extra labels for this resource.
 
@@ -4736,7 +4736,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `konnectivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-konnectivity}
+#### `konnectivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity}
 
 Konnectivity holds dedicated konnectivity configuration. This is only available when privateNodes.enabled is true.
 
@@ -4748,7 +4748,7 @@ Konnectivity holds dedicated konnectivity configuration. This is only available 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-konnectivity-server}
+##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-server}
 
 Server holds configuration for the konnectivity server.
 
@@ -4760,7 +4760,7 @@ Server holds configuration for the konnectivity server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-konnectivity-server-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-server-enabled}
 
 Enabled defines if the konnectivity server should be enabled.
 
@@ -4775,7 +4775,7 @@ Enabled defines if the konnectivity server should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-konnectivity-server-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-server-extraArgs}
 
 ExtraArgs are additional arguments to pass to the konnectivity server.
 
@@ -4793,7 +4793,7 @@ ExtraArgs are additional arguments to pass to the konnectivity server.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `agent` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-konnectivity-agent}
+##### `agent` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent}
 
 Agent holds configuration for the konnectivity agent.
 
@@ -4805,7 +4805,7 @@ Agent holds configuration for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-konnectivity-agent-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-enabled}
 
 Enabled defines if the konnectivity agent should be enabled.
 
@@ -4820,7 +4820,7 @@ Enabled defines if the konnectivity agent should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-konnectivity-agent-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-replicas}
 
 Replicas is the number of replicas for the konnectivity agent.
 
@@ -4835,7 +4835,7 @@ Replicas is the number of replicas for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-konnectivity-agent-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-image}
 
 Image is the image for the konnectivity agent.
 
@@ -4850,7 +4850,7 @@ Image is the image for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-konnectivity-agent-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -4865,7 +4865,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-konnectivity-agent-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-nodeSelector}
 
 NodeSelector is the node selector for the konnectivity agent.
 
@@ -4880,7 +4880,7 @@ NodeSelector is the node selector for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-konnectivity-agent-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-priorityClassName}
 
 PriorityClassName is the priority class name for the konnectivity agent.
 
@@ -4895,7 +4895,7 @@ PriorityClassName is the priority class name for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-konnectivity-agent-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-tolerations}
 
 Tolerations is the tolerations for the konnectivity agent.
 
@@ -4910,7 +4910,7 @@ Tolerations is the tolerations for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-konnectivity-agent-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-extraEnv}
 
 ExtraEnv is the extra environment variables for the konnectivity agent.
 
@@ -4925,7 +4925,7 @@ ExtraEnv is the extra environment variables for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-konnectivity-agent-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-extraArgs}
 
 ExtraArgs are additional arguments to pass to the konnectivity agent.
 
@@ -4946,7 +4946,7 @@ ExtraArgs are additional arguments to pass to the konnectivity agent.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-registry}
+#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry}
 
 Registry allows enabling an embedded docker image registry in vCluster. This is useful for air-gapped environments or when you don't have a public registry available to distribute images.
 
@@ -4958,7 +4958,7 @@ Registry allows enabling an embedded docker image registry in vCluster. This is 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-registry-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry-enabled}
 
 Enabled defines if the embedded registry should be enabled.
 
@@ -4973,7 +4973,7 @@ Enabled defines if the embedded registry should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `anonymousPull` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-registry-anonymousPull}
+##### `anonymousPull` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry-anonymousPull}
 
 AnonymousPull allows enabling anonymous pull for the embedded registry. This allows anybody to pull images from the registry without authentication.
 
@@ -4988,7 +4988,7 @@ AnonymousPull allows enabling anonymous pull for the embedded registry. This all
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-registry-config}
+##### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry-config}
 
 Config is the regular docker registry config. See https://distribution.github.io/distribution/about/configuration/ for more details.
 
@@ -5006,7 +5006,7 @@ Config is the regular docker registry config. See https://distribution.github.io
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-globalMetadata}
+#### `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-globalMetadata}
 
 GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 
@@ -5018,7 +5018,7 @@ GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-advanced-globalMetadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-globalMetadata-annotations}
 
 Annotations are extra annotations for this resource.
 

--- a/vcluster/_partials/config/controlPlane/advanced.mdx
+++ b/vcluster/_partials/config/controlPlane/advanced.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced}
+## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced}
 
 Advanced holds additional configuration for the vCluster control plane.
 
@@ -14,7 +14,7 @@ Advanced holds additional configuration for the vCluster control plane.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-defaultImageRegistry}
+### `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-defaultImageRegistry}
 
 DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
 upload all required vCluster images to a single private repository and set this value. Workload images are not affected by this.
@@ -30,7 +30,7 @@ upload all required vCluster images to a single private repository and set this 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-virtualScheduler}
+### `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-virtualScheduler}
 
 VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.
 Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
@@ -43,7 +43,7 @@ Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-virtualScheduler-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-virtualScheduler-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -61,7 +61,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount}
+### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount}
 
 ServiceAccount specifies options for the vCluster control plane service account.
 
@@ -73,7 +73,7 @@ ServiceAccount specifies options for the vCluster control plane service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-enabled}
 
 Enabled specifies if the service account should get deployed.
 
@@ -88,7 +88,7 @@ Enabled specifies if the service account should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-name}
 
 Name specifies what name to use for the service account.
 
@@ -103,7 +103,7 @@ Name specifies what name to use for the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-imagePullSecrets}
+#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the service account.
 
@@ -115,7 +115,7 @@ ImagePullSecrets defines extra image pull secrets for the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -133,7 +133,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -148,7 +148,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -166,7 +166,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount}
+### `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount}
 
 WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster.
 
@@ -178,7 +178,7 @@ WorkloadServiceAccount specifies options for the service account that will be us
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-enabled}
 
 Enabled specifies if the service account for the workloads should get deployed.
 
@@ -193,7 +193,7 @@ Enabled specifies if the service account for the workloads should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-name}
 
 Name specifies what name to use for the service account for the virtual cluster workloads.
 
@@ -208,7 +208,7 @@ Name specifies what name to use for the service account for the virtual cluster 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-imagePullSecrets}
+#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the workload service account.
 
@@ -220,7 +220,7 @@ ImagePullSecrets defines extra image pull secrets for the workload service accou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -238,7 +238,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -253,7 +253,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -271,7 +271,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-headlessService}
+### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-headlessService}
 
 HeadlessService specifies options for the headless service used for the vCluster StatefulSet.
 
@@ -283,7 +283,7 @@ HeadlessService specifies options for the headless service used for the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-headlessService-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-headlessService-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -298,7 +298,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-headlessService-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-headlessService-labels}
 
 Labels are extra labels for this resource.
 
@@ -316,7 +316,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `konnectivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-konnectivity}
+### `konnectivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity}
 
 Konnectivity holds dedicated konnectivity configuration. This is only available when privateNodes.enabled is true.
 
@@ -328,7 +328,7 @@ Konnectivity holds dedicated konnectivity configuration. This is only available 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-konnectivity-server}
+#### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-server}
 
 Server holds configuration for the konnectivity server.
 
@@ -340,7 +340,7 @@ Server holds configuration for the konnectivity server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-konnectivity-server-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-konnectivity-server-enabled}
 
 Enabled defines if the konnectivity server should be enabled.
 
@@ -355,7 +355,7 @@ Enabled defines if the konnectivity server should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-konnectivity-server-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-server-extraArgs}
 
 ExtraArgs are additional arguments to pass to the konnectivity server.
 
@@ -373,7 +373,7 @@ ExtraArgs are additional arguments to pass to the konnectivity server.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `agent` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-konnectivity-agent}
+#### `agent` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent}
 
 Agent holds configuration for the konnectivity agent.
 
@@ -385,7 +385,7 @@ Agent holds configuration for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-konnectivity-agent-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-enabled}
 
 Enabled defines if the konnectivity agent should be enabled.
 
@@ -400,7 +400,7 @@ Enabled defines if the konnectivity agent should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-konnectivity-agent-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-replicas}
 
 Replicas is the number of replicas for the konnectivity agent.
 
@@ -415,7 +415,7 @@ Replicas is the number of replicas for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-konnectivity-agent-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-image}
 
 Image is the image for the konnectivity agent.
 
@@ -430,7 +430,7 @@ Image is the image for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-konnectivity-agent-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -445,7 +445,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-konnectivity-agent-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-nodeSelector}
 
 NodeSelector is the node selector for the konnectivity agent.
 
@@ -460,7 +460,7 @@ NodeSelector is the node selector for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-konnectivity-agent-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-priorityClassName}
 
 PriorityClassName is the priority class name for the konnectivity agent.
 
@@ -475,7 +475,7 @@ PriorityClassName is the priority class name for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-konnectivity-agent-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-tolerations}
 
 Tolerations is the tolerations for the konnectivity agent.
 
@@ -490,7 +490,7 @@ Tolerations is the tolerations for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-konnectivity-agent-extraEnv}
+##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-extraEnv}
 
 ExtraEnv is the extra environment variables for the konnectivity agent.
 
@@ -505,7 +505,7 @@ ExtraEnv is the extra environment variables for the konnectivity agent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-konnectivity-agent-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-extraArgs}
 
 ExtraArgs are additional arguments to pass to the konnectivity agent.
 
@@ -526,7 +526,7 @@ ExtraArgs are additional arguments to pass to the konnectivity agent.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-registry}
+### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-registry}
 
 Registry allows enabling an embedded docker image registry in vCluster. This is useful for air-gapped environments or when you don't have a public registry available to distribute images.
 
@@ -538,7 +538,7 @@ Registry allows enabling an embedded docker image registry in vCluster. This is 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-registry-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-registry-enabled}
 
 Enabled defines if the embedded registry should be enabled.
 
@@ -553,7 +553,7 @@ Enabled defines if the embedded registry should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `anonymousPull` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-registry-anonymousPull}
+#### `anonymousPull` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-registry-anonymousPull}
 
 AnonymousPull allows enabling anonymous pull for the embedded registry. This allows anybody to pull images from the registry without authentication.
 
@@ -568,7 +568,7 @@ AnonymousPull allows enabling anonymous pull for the embedded registry. This all
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-registry-config}
+#### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-registry-config}
 
 Config is the regular docker registry config. See https://distribution.github.io/distribution/about/configuration/ for more details.
 
@@ -586,7 +586,7 @@ Config is the regular docker registry config. See https://distribution.github.io
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-globalMetadata}
+### `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-globalMetadata}
 
 GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 
@@ -598,7 +598,7 @@ GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-globalMetadata-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-globalMetadata-annotations}
 
 Annotations are extra annotations for this resource.
 

--- a/vcluster/_partials/config/controlPlane/advanced/defaultImageRegistry.mdx
+++ b/vcluster/_partials/config/controlPlane/advanced/defaultImageRegistry.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#defaultImageRegistry}
+## `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultImageRegistry}
 
 DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
 upload all required vCluster images to a single private repository and set this value. Workload images are not affected by this.

--- a/vcluster/_partials/config/controlPlane/advanced/globalMetadata.mdx
+++ b/vcluster/_partials/config/controlPlane/advanced/globalMetadata.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#globalMetadata}
+## `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#globalMetadata}
 
 GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 
@@ -14,7 +14,7 @@ GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#globalMetadata-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#globalMetadata-annotations}
 
 Annotations are extra annotations for this resource.
 

--- a/vcluster/_partials/config/controlPlane/advanced/headlessService.mdx
+++ b/vcluster/_partials/config/controlPlane/advanced/headlessService.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#headlessService}
+## `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#headlessService}
 
 HeadlessService specifies options for the headless service used for the vCluster StatefulSet.
 
@@ -14,7 +14,7 @@ HeadlessService specifies options for the headless service used for the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#headlessService-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#headlessService-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -29,7 +29,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#headlessService-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#headlessService-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster/_partials/config/controlPlane/advanced/serviceAccount.mdx
+++ b/vcluster/_partials/config/controlPlane/advanced/serviceAccount.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount}
+## `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount}
 
 ServiceAccount specifies options for the vCluster control plane service account.
 
@@ -14,7 +14,7 @@ ServiceAccount specifies options for the vCluster control plane service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#serviceAccount-enabled}
 
 Enabled specifies if the service account should get deployed.
 
@@ -29,7 +29,7 @@ Enabled specifies if the service account should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-name}
 
 Name specifies what name to use for the service account.
 
@@ -44,7 +44,7 @@ Name specifies what name to use for the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-imagePullSecrets}
+### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the service account.
 
@@ -56,7 +56,7 @@ ImagePullSecrets defines extra image pull secrets for the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-imagePullSecrets-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -74,7 +74,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceAccount-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster/_partials/config/controlPlane/advanced/virtualScheduler.mdx
+++ b/vcluster/_partials/config/controlPlane/advanced/virtualScheduler.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualScheduler}
+## `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualScheduler}
 
 VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.
 Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
@@ -15,7 +15,7 @@ Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualScheduler-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#virtualScheduler-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster/_partials/config/controlPlane/advanced/workloadServiceAccount.mdx
+++ b/vcluster/_partials/config/controlPlane/advanced/workloadServiceAccount.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount}
+## `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount}
 
 WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster.
 
@@ -14,7 +14,7 @@ WorkloadServiceAccount specifies options for the service account that will be us
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#workloadServiceAccount-enabled}
 
 Enabled specifies if the service account for the workloads should get deployed.
 
@@ -29,7 +29,7 @@ Enabled specifies if the service account for the workloads should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-name}
 
 Name specifies what name to use for the service account for the virtual cluster workloads.
 
@@ -44,7 +44,7 @@ Name specifies what name to use for the service account for the virtual cluster 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-imagePullSecrets}
+### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the workload service account.
 
@@ -56,7 +56,7 @@ ImagePullSecrets defines extra image pull secrets for the workload service accou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-imagePullSecrets-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -74,7 +74,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#workloadServiceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#workloadServiceAccount-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster/_partials/config/controlPlane/backingStore.mdx
+++ b/vcluster/_partials/config/controlPlane/backingStore.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `backingStore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore}
+## `backingStore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore}
 
 BackingStore defines which backing store to use for virtual cluster. If not defined will use embedded database as a default backing store.
 
@@ -14,7 +14,7 @@ BackingStore defines which backing store to use for virtual cluster. If not defi
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `etcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd}
+### `etcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd}
 
 Etcd defines that etcd should be used as the backend for the virtual cluster
 
@@ -26,7 +26,7 @@ Etcd defines that etcd should be used as the backend for the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-embedded}
+#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded}
 
 Embedded defines to use embedded etcd as a storage backend for the virtual cluster
 
@@ -38,7 +38,7 @@ Embedded defines to use embedded etcd as a storage backend for the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-enabled}
 
 Enabled defines if the embedded etcd should be used.
 
@@ -53,7 +53,7 @@ Enabled defines if the embedded etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-embedded-migrateFromDeployedEtcd}
+##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-migrateFromDeployedEtcd}
 
 MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd.
 
@@ -68,7 +68,7 @@ MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-embedded-snapshotCount}
+##### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-snapshotCount}
 
 SnapshotCount defines the number of snapshots to keep for the embedded etcd. Defaults to 10000 if less than 1.
 
@@ -83,7 +83,7 @@ SnapshotCount defines the number of snapshots to keep for the embedded etcd. Def
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-embedded-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to the embedded etcd.
 
@@ -101,7 +101,7 @@ ExtraArgs are additional arguments to pass to the embedded etcd.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy}
+#### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy}
 
 Deploy defines to use an external etcd that is deployed by the helm chart
 
@@ -113,7 +113,7 @@ Deploy defines to use an external etcd that is deployed by the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-enabled}
 
 Enabled defines that an external etcd should be deployed.
 
@@ -128,7 +128,7 @@ Enabled defines that an external etcd should be deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet}
+##### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet}
 
 StatefulSet holds options for the external etcd statefulSet.
 
@@ -140,7 +140,7 @@ StatefulSet holds options for the external etcd statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-enabled}
 
 Enabled defines if the statefulSet should be deployed
 
@@ -155,7 +155,7 @@ Enabled defines if the statefulSet should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-enableServiceLinks}
+##### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -170,7 +170,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image}
 
 Image is the image to use for the external etcd statefulSet
 
@@ -182,7 +182,7 @@ Image is the image to use for the external etcd statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -198,7 +198,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -213,7 +213,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.21-0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.21-0</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -231,7 +231,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the external etcd image
 
@@ -246,7 +246,7 @@ ImagePullPolicy is the pull policy for the external etcd image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-env}
+##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-env}
 
 Env are extra environment variables
 
@@ -261,7 +261,7 @@ Env are extra environment variables
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-extraArgs}
 
 ExtraArgs are appended to the etcd command.
 
@@ -276,7 +276,7 @@ ExtraArgs are appended to the etcd command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources}
 
 Resources the etcd can consume
 
@@ -288,7 +288,7 @@ Resources the etcd can consume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -303,7 +303,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -321,7 +321,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-pods}
+##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods}
 
 Pods defines extra metadata for the etcd pods.
 
@@ -333,7 +333,7 @@ Pods defines extra metadata for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -348,7 +348,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -366,7 +366,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-highAvailability}
+##### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-highAvailability}
 
 HighAvailability are high availability options
 
@@ -378,7 +378,7 @@ HighAvailability are high availability options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
 
 Replicas are the amount of pods to use.
 
@@ -396,7 +396,7 @@ Replicas are the amount of pods to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling}
+##### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling}
 
 Scheduling options for the etcd pods.
 
@@ -408,7 +408,7 @@ Scheduling options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -423,7 +423,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -438,7 +438,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -453,7 +453,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -468,7 +468,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -483,7 +483,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -501,7 +501,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-security}
+##### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security}
 
 Security options for the etcd pods.
 
@@ -513,7 +513,7 @@ Security options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -528,7 +528,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -546,7 +546,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence}
+##### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence}
 
 Persistence options for the etcd pods.
 
@@ -558,7 +558,7 @@ Persistence options for the etcd pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -570,7 +570,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim.
 
@@ -585,7 +585,7 @@ Enabled enables deploying a persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -600,7 +600,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -615,7 +615,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -630,7 +630,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -648,7 +648,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -663,7 +663,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -678,7 +678,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -690,7 +690,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -705,7 +705,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -721,7 +721,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -737,7 +737,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -753,7 +753,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -771,7 +771,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -795,7 +795,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -810,7 +810,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -828,7 +828,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service}
 
 Service holds options for the external etcd service.
 
@@ -840,7 +840,7 @@ Service holds options for the external etcd service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-service-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service-enabled}
 
 Enabled defines if the etcd service should be deployed
 
@@ -855,7 +855,7 @@ Enabled defines if the etcd service should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-service-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service-annotations}
 
 Annotations are extra annotations for the external etcd service
 
@@ -873,7 +873,7 @@ Annotations are extra annotations for the external etcd service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-headlessService}
+##### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-headlessService}
 
 HeadlessService holds options for the external etcd headless service.
 
@@ -885,7 +885,7 @@ HeadlessService holds options for the external etcd headless service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-headlessService-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-headlessService-annotations}
 
 Annotations are extra annotations for the external etcd headless service
 
@@ -906,7 +906,7 @@ Annotations are extra annotations for the external etcd headless service
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external}
+#### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external}
 
 External defines to use a self-hosted external etcd that is not deployed by the helm chart
 
@@ -918,7 +918,7 @@ External defines to use a self-hosted external etcd that is not deployed by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-external-enabled}
 
 Enabled defines if the external etcd should be used.
 
@@ -933,7 +933,7 @@ Enabled defines if the external etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external-endpoint}
+##### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-endpoint}
 
 Endpoint holds the endpoint of the external etcd server, e.g. my-example-service:2379
 
@@ -948,7 +948,7 @@ Endpoint holds the endpoint of the external etcd server, e.g. my-example-service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `tls` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external-tls}
+##### `tls` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls}
 
 TLS defines the tls configuration for the external etcd server
 
@@ -960,7 +960,7 @@ TLS defines the tls configuration for the external etcd server
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external-tls-caFile}
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-caFile}
 
 CaFile is the path to the ca file
 
@@ -975,7 +975,7 @@ CaFile is the path to the ca file
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external-tls-certFile}
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-certFile}
 
 CertFile is the path to the cert file
 
@@ -990,7 +990,7 @@ CertFile is the path to the cert file
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external-tls-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-keyFile}
 
 KeyFile is the path to the key file
 
@@ -1014,7 +1014,7 @@ KeyFile is the path to the key file
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database}
+### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database}
 
 Database defines that a database backend should be used as the backend for the virtual cluster. This uses a project called kine under the hood which is a shim for bridging Kubernetes and relational databases.
 
@@ -1026,7 +1026,7 @@ Database defines that a database backend should be used as the backend for the v
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded}
+#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded}
 
 Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster
 
@@ -1038,7 +1038,7 @@ Embedded defines that an embedded database (sqlite) should be used as the backen
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-database-embedded-enabled}
 
 Enabled defines if the database should be used.
 
@@ -1053,7 +1053,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -1071,7 +1071,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -1086,7 +1086,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-certFile}
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -1101,7 +1101,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-caFile}
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -1116,7 +1116,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-database-embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 
@@ -1134,7 +1134,7 @@ ExtraArgs are additional arguments to pass to Kine.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external}
+#### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external}
 
 External defines that an external database should be used as the backend for the virtual cluster
 
@@ -1146,7 +1146,7 @@ External defines that an external database should be used as the backend for the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-database-external-enabled}
 
 Enabled defines if the database should be used.
 
@@ -1161,7 +1161,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -1179,7 +1179,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -1194,7 +1194,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-certFile}
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -1209,7 +1209,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-caFile}
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -1224,7 +1224,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-database-external-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 
@@ -1239,7 +1239,7 @@ ExtraArgs are additional arguments to pass to Kine.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-connector}
+##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-connector}
 
 Connector specifies a secret located in a connected vCluster Platform that contains database server connection information
 to be used by Platform to create a database and database user for the vCluster.

--- a/vcluster/_partials/config/controlPlane/backingStore/database/embedded.mdx
+++ b/vcluster/_partials/config/controlPlane/backingStore/database/embedded.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded}
+## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded}
 
 Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster
 
@@ -14,7 +14,7 @@ Embedded defines that an embedded database (sqlite) should be used as the backen
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-enabled}
 
 Enabled defines if the database should be used.
 
@@ -29,7 +29,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-dataSource}
+### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -47,7 +47,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-keyFile}
+### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -62,7 +62,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-certFile}
+### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -77,7 +77,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-caFile}
+### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -92,7 +92,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 

--- a/vcluster/_partials/config/controlPlane/backingStore/database/external.mdx
+++ b/vcluster/_partials/config/controlPlane/backingStore/database/external.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external}
+## `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external}
 
 External defines that an external database should be used as the backend for the virtual cluster
 
@@ -14,7 +14,7 @@ External defines that an external database should be used as the backend for the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#external-enabled}
 
 Enabled defines if the database should be used.
 
@@ -29,7 +29,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-dataSource}
+### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -47,7 +47,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-keyFile}
+### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -62,7 +62,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-certFile}
+### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -77,7 +77,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-caFile}
+### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -92,7 +92,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#external-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 
@@ -107,7 +107,7 @@ ExtraArgs are additional arguments to pass to Kine.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-connector}
+### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-connector}
 
 Connector specifies a secret located in a connected vCluster Platform that contains database server connection information
 to be used by Platform to create a database and database user for the vCluster.

--- a/vcluster/_partials/config/controlPlane/backingStore/etcd/deploy.mdx
+++ b/vcluster/_partials/config/controlPlane/backingStore/etcd/deploy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy}
+## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
 
 Deploy defines to use an external etcd that is deployed by the helm chart
 
@@ -14,7 +14,7 @@ Deploy defines to use an external etcd that is deployed by the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-enabled}
 
 Enabled defines that an external etcd should be deployed.
 
@@ -29,7 +29,7 @@ Enabled defines that an external etcd should be deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet}
+### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet}
 
 StatefulSet holds options for the external etcd statefulSet.
 
@@ -41,7 +41,7 @@ StatefulSet holds options for the external etcd statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-enabled}
 
 Enabled defines if the statefulSet should be deployed
 
@@ -56,7 +56,7 @@ Enabled defines if the statefulSet should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-enableServiceLinks}
+#### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -71,7 +71,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-image}
 
 Image is the image to use for the external etcd statefulSet
 
@@ -83,7 +83,7 @@ Image is the image to use for the external etcd statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -99,7 +99,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -114,7 +114,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.21-0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.21-0</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -132,7 +132,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the external etcd image
 
@@ -147,7 +147,7 @@ ImagePullPolicy is the pull policy for the external etcd image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-env}
+#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-env}
 
 Env are extra environment variables
 
@@ -162,7 +162,7 @@ Env are extra environment variables
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-extraArgs}
 
 ExtraArgs are appended to the etcd command.
 
@@ -177,7 +177,7 @@ ExtraArgs are appended to the etcd command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources}
 
 Resources the etcd can consume
 
@@ -189,7 +189,7 @@ Resources the etcd can consume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -204,7 +204,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -222,7 +222,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-pods}
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods}
 
 Pods defines extra metadata for the etcd pods.
 
@@ -234,7 +234,7 @@ Pods defines extra metadata for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -249,7 +249,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -267,7 +267,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-highAvailability}
+#### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-highAvailability}
 
 HighAvailability are high availability options
 
@@ -279,7 +279,7 @@ HighAvailability are high availability options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#deploy-statefulSet-highAvailability-replicas}
 
 Replicas are the amount of pods to use.
 
@@ -297,7 +297,7 @@ Replicas are the amount of pods to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling}
+#### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling}
 
 Scheduling options for the etcd pods.
 
@@ -309,7 +309,7 @@ Scheduling options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -324,7 +324,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -339,7 +339,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -354,7 +354,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -369,7 +369,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -384,7 +384,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -402,7 +402,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-security}
+#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-security}
 
 Security options for the etcd pods.
 
@@ -414,7 +414,7 @@ Security options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -429,7 +429,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -447,7 +447,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence}
+#### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence}
 
 Persistence options for the etcd pods.
 
@@ -459,7 +459,7 @@ Persistence options for the etcd pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -471,7 +471,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim.
 
@@ -486,7 +486,7 @@ Enabled enables deploying a persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -501,7 +501,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -516,7 +516,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -531,7 +531,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -549,7 +549,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -564,7 +564,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -579,7 +579,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -591,7 +591,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -606,7 +606,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -622,7 +622,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -638,7 +638,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -654,7 +654,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -672,7 +672,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -696,7 +696,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -711,7 +711,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -729,7 +729,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-service}
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-service}
 
 Service holds options for the external etcd service.
 
@@ -741,7 +741,7 @@ Service holds options for the external etcd service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-service-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-service-enabled}
 
 Enabled defines if the etcd service should be deployed
 
@@ -756,7 +756,7 @@ Enabled defines if the etcd service should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-service-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-service-annotations}
 
 Annotations are extra annotations for the external etcd service
 
@@ -774,7 +774,7 @@ Annotations are extra annotations for the external etcd service
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-headlessService}
+### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-headlessService}
 
 HeadlessService holds options for the external etcd headless service.
 
@@ -786,7 +786,7 @@ HeadlessService holds options for the external etcd headless service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-headlessService-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-headlessService-annotations}
 
 Annotations are extra annotations for the external etcd headless service
 

--- a/vcluster/_partials/config/controlPlane/backingStore/etcd/embedded.mdx
+++ b/vcluster/_partials/config/controlPlane/backingStore/etcd/embedded.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded}
+## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded}
 
 Embedded defines to use embedded etcd as a storage backend for the virtual cluster
 
@@ -14,7 +14,7 @@ Embedded defines to use embedded etcd as a storage backend for the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-enabled}
 
 Enabled defines if the embedded etcd should be used.
 
@@ -29,7 +29,7 @@ Enabled defines if the embedded etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-migrateFromDeployedEtcd}
+### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-migrateFromDeployedEtcd}
 
 MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd.
 
@@ -44,7 +44,7 @@ MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-snapshotCount}
+### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-snapshotCount}
 
 SnapshotCount defines the number of snapshots to keep for the embedded etcd. Defaults to 10000 if less than 1.
 
@@ -59,7 +59,7 @@ SnapshotCount defines the number of snapshots to keep for the embedded etcd. Def
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to the embedded etcd.
 

--- a/vcluster/_partials/config/controlPlane/coredns.mdx
+++ b/vcluster/_partials/config/controlPlane/coredns.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `coredns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns}
+## `coredns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns}
 
 CoreDNS defines everything related to the coredns that is deployed and used within the vCluster.
 
@@ -14,7 +14,7 @@ CoreDNS defines everything related to the coredns that is deployed and used with
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#coredns-enabled}
 
 Enabled defines if coredns is enabled
 
@@ -29,7 +29,7 @@ Enabled defines if coredns is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-embedded}
+### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#coredns-embedded}
 
 Embedded defines if vCluster will start the embedded coredns service within the control-plane and not as a separate deployment. This is a PRO feature.
 
@@ -44,7 +44,7 @@ Embedded defines if vCluster will start the embedded coredns service within the 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-security}
+### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-security}
 
 Security defines pod or container security context.
 
@@ -56,7 +56,7 @@ Security defines pod or container security context.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-security-podSecurityContext}
+#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -71,7 +71,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-security-containerSecurityContext}
+#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -89,7 +89,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-service}
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-service}
 
 Service holds extra options for the coredns service deployed within the virtual cluster
 
@@ -101,7 +101,7 @@ Service holds extra options for the coredns service deployed within the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-service-spec}
+#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#coredns-service-spec}
 
 Spec holds extra options for the coredns service
 
@@ -116,7 +116,7 @@ Spec holds extra options for the coredns service
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-service-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -131,7 +131,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-service-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-service-labels}
 
 Labels are extra labels for this resource.
 
@@ -149,7 +149,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `deployment` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment}
+### `deployment` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment}
 
 Deployment holds extra options for the coredns deployment deployed within the virtual cluster
 
@@ -161,7 +161,7 @@ Deployment holds extra options for the coredns deployment deployed within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-image}
 
 Image is the coredns image to use
 
@@ -176,7 +176,7 @@ Image is the coredns image to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-replicas}
+#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#coredns-deployment-replicas}
 
 Replicas is the amount of coredns pods to run.
 
@@ -191,7 +191,7 @@ Replicas is the amount of coredns pods to run.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-nodeSelector}
+#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-nodeSelector}
 
 NodeSelector is the node selector to use for coredns.
 
@@ -206,7 +206,7 @@ NodeSelector is the node selector to use for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-affinity}
+#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -221,7 +221,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-tolerations}
+#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -236,7 +236,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-resources}
 
 Resources are the desired resources for coredns.
 
@@ -248,7 +248,7 @@ Resources are the desired resources for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-resources-limits}
 
 Limits are resource limits for the container
 
@@ -263,7 +263,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -281,7 +281,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-pods}
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-pods}
 
 Pods is additional metadata for the coredns pods.
 
@@ -293,7 +293,7 @@ Pods is additional metadata for the coredns pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -308,7 +308,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -326,7 +326,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -341,7 +341,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-labels}
 
 Labels are extra labels for this resource.
 
@@ -356,7 +356,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-topologySpreadConstraints}
+#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the CoreDNS pod.
 
@@ -374,7 +374,7 @@ TopologySpreadConstraints are the topology spread constraints for the CoreDNS po
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `overwriteConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-overwriteConfig}
+### `overwriteConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-overwriteConfig}
 
 OverwriteConfig can be used to overwrite the coredns config
 
@@ -389,7 +389,7 @@ OverwriteConfig can be used to overwrite the coredns config
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `overwriteManifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-overwriteManifests}
+### `overwriteManifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-overwriteManifests}
 
 OverwriteManifests can be used to overwrite the coredns manifests used to deploy coredns
 
@@ -404,7 +404,7 @@ OverwriteManifests can be used to overwrite the coredns manifests used to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-priorityClassName}
+### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-priorityClassName}
 
 PriorityClassName specifies the priority class name for the CoreDNS pods.
 

--- a/vcluster/_partials/config/controlPlane/distro.mdx
+++ b/vcluster/_partials/config/controlPlane/distro.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro}
+## `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro}
 
 Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed.
 
@@ -14,7 +14,7 @@ Distro holds virtual cluster related distro options. A distro cannot be changed 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s}
+### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s}
 
 K8S holds K8s relevant configuration.
 
@@ -26,7 +26,7 @@ K8S holds K8s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k8s-enabled}
 
 Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -41,7 +41,7 @@ Enabled specifies if the K8s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-version}
+#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-version}
 
 [Deprecated] Version field is deprecated.
 Use controlPlane.distro.k8s.image.tag to specify the Kubernetes version instead.
@@ -57,7 +57,7 @@ Use controlPlane.distro.k8s.image.tag to specify the Kubernetes version instead.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer}
+#### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-apiServer}
 
 APIServer holds configuration specific to starting the api server.
 
@@ -69,7 +69,7 @@ APIServer holds configuration specific to starting the api server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -84,7 +84,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -99,7 +99,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -117,7 +117,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager}
+#### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager}
 
 ControllerManager holds configuration specific to starting the controller manager.
 
@@ -129,7 +129,7 @@ ControllerManager holds configuration specific to starting the controller manage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -144,7 +144,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -159,7 +159,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -177,7 +177,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-scheduler}
+#### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-scheduler}
 
 Scheduler holds configuration specific to starting the scheduler. Enable this via controlPlane.advanced.virtualScheduler.enabled
 
@@ -189,7 +189,7 @@ Scheduler holds configuration specific to starting the scheduler. Enable this vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-scheduler-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -204,7 +204,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-scheduler-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -219,7 +219,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-scheduler-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -237,7 +237,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-image}
 
 Image is the distro image
 
@@ -249,7 +249,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#distro-k8s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -265,7 +265,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#distro-k8s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -280,7 +280,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.33.1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.33.1</span> <span className="config-field-enum"></span> {#distro-k8s-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -298,7 +298,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -313,7 +313,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-env}
+#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -328,7 +328,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-resources}
 
 Resources for the distro init container
 
@@ -343,7 +343,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-securityContext}
+#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#distro-k8s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -361,7 +361,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s}
+### `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s}
 
 [Deprecated] K3S holds K3s relevant configuration.
 
@@ -373,7 +373,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k3s-enabled}
 
 Enabled specifies if the K3s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -388,7 +388,7 @@ Enabled specifies if the K3s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-token}
+#### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-token}
 
 Token is the K3s token to use. If empty, vCluster will choose one.
 
@@ -403,7 +403,7 @@ Token is the K3s token to use. If empty, vCluster will choose one.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-image}
 
 Image is the distro image
 
@@ -415,7 +415,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -431,7 +431,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> {#distro-k3s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -446,7 +446,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.33.1-k3s1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.33.1-k3s1</span> <span className="config-field-enum"></span> {#distro-k3s-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -464,7 +464,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -479,7 +479,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-env}
+#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -494,7 +494,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#distro-k3s-resources}
 
 Resources for the distro init container
 
@@ -509,7 +509,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-securityContext}
+#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#distro-k3s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -524,7 +524,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k3s-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -539,7 +539,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k3s-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 

--- a/vcluster/_partials/config/controlPlane/distro/k3s.mdx
+++ b/vcluster/_partials/config/controlPlane/distro/k3s.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s}
+## `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s}
 
 [Deprecated] K3S holds K3s relevant configuration.
 
@@ -14,7 +14,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k3s-enabled}
 
 Enabled specifies if the K3s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -29,7 +29,7 @@ Enabled specifies if the K3s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-token}
+### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-token}
 
 Token is the K3s token to use. If empty, vCluster will choose one.
 
@@ -44,7 +44,7 @@ Token is the K3s token to use. If empty, vCluster will choose one.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-image}
+### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-image}
 
 Image is the distro image
 
@@ -56,7 +56,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-image-registry}
+#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -72,7 +72,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-image-repository}
+#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> {#k3s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -87,7 +87,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.33.1-k3s1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-image-tag}
+#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.33.1-k3s1</span> <span className="config-field-enum"></span> {#k3s-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -105,7 +105,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -120,7 +120,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-env}
+### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -135,7 +135,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#k3s-resources}
 
 Resources for the distro init container
 
@@ -150,7 +150,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-securityContext}
+### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#k3s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -165,7 +165,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-command}
+### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k3s-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -180,7 +180,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k3s-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 

--- a/vcluster/_partials/config/controlPlane/distro/k8s.mdx
+++ b/vcluster/_partials/config/controlPlane/distro/k8s.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s}
+## `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s}
 
 K8S holds K8s relevant configuration.
 
@@ -14,7 +14,7 @@ K8S holds K8s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k8s-enabled}
 
 Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -29,7 +29,7 @@ Enabled specifies if the K8s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-version}
+### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-version}
 
 [Deprecated] Version field is deprecated.
 Use controlPlane.distro.k8s.image.tag to specify the Kubernetes version instead.
@@ -45,7 +45,7 @@ Use controlPlane.distro.k8s.image.tag to specify the Kubernetes version instead.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer}
+### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-apiServer}
 
 APIServer holds configuration specific to starting the api server.
 
@@ -57,7 +57,7 @@ APIServer holds configuration specific to starting the api server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#k8s-apiServer-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -72,7 +72,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-apiServer-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -87,7 +87,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-apiServer-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -105,7 +105,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager}
+### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-controllerManager}
 
 ControllerManager holds configuration specific to starting the controller manager.
 
@@ -117,7 +117,7 @@ ControllerManager holds configuration specific to starting the controller manage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#k8s-controllerManager-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -132,7 +132,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-controllerManager-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -147,7 +147,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-controllerManager-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -165,7 +165,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-scheduler}
+### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-scheduler}
 
 Scheduler holds configuration specific to starting the scheduler. Enable this via controlPlane.advanced.virtualScheduler.enabled
 
@@ -177,7 +177,7 @@ Scheduler holds configuration specific to starting the scheduler. Enable this vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-scheduler-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k8s-scheduler-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -192,7 +192,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-scheduler-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-scheduler-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -207,7 +207,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-scheduler-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-scheduler-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -225,7 +225,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-image}
+### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-image}
 
 Image is the distro image
 
@@ -237,7 +237,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-image-registry}
+#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#k8s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -253,7 +253,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-image-repository}
+#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#k8s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -268,7 +268,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.33.1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-image-tag}
+#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.33.1</span> <span className="config-field-enum"></span> {#k8s-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -286,7 +286,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -301,7 +301,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-env}
+### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -316,7 +316,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#k8s-resources}
 
 Resources for the distro init container
 
@@ -331,7 +331,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-securityContext}
+### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#k8s-securityContext}
 
 Security options can be used for the distro init container
 

--- a/vcluster/_partials/config/controlPlane/hostPathMapper.mdx
+++ b/vcluster/_partials/config/controlPlane/hostPathMapper.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `hostPathMapper` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#hostPathMapper}
+## `hostPathMapper` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper}
 
 HostPathMapper defines if vCluster should rewrite host paths.
 
@@ -14,7 +14,7 @@ HostPathMapper defines if vCluster should rewrite host paths.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#hostPathMapper-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper-enabled}
 
 Enabled specifies if the host path mapper will be used
 
@@ -29,7 +29,7 @@ Enabled specifies if the host path mapper will be used
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `central` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#hostPathMapper-central}
+### `central` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper-central}
 
 Central specifies if the central host path mapper will be used
 

--- a/vcluster/_partials/config/controlPlane/ingress.mdx
+++ b/vcluster/_partials/config/controlPlane/ingress.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress}
+## `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingress}
 
 Ingress defines options for vCluster ingress deployed by Helm.
 
@@ -14,7 +14,7 @@ Ingress defines options for vCluster ingress deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingress-enabled}
 
 Enabled defines if the control plane ingress should be enabled
 
@@ -29,7 +29,7 @@ Enabled defines if the control plane ingress should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-host}
+### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#ingress-host}
 
 Host is the host where vCluster will be reachable
 
@@ -44,7 +44,7 @@ Host is the host where vCluster will be reachable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `pathType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-pathType}
+### `pathType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> {#ingress-pathType}
 
 PathType is the path type of the ingress
 
@@ -59,7 +59,7 @@ PathType is the path type of the ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-spec}
+### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#ingress-spec}
 
 Spec allows you to configure extra ingress options.
 
@@ -74,7 +74,7 @@ Spec allows you to configure extra ingress options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> {#ingress-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#ingress-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster/_partials/config/controlPlane/proxy.mdx
+++ b/vcluster/_partials/config/controlPlane/proxy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#proxy}
+## `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy}
 
 Proxy defines options for the virtual cluster control plane proxy that is used to do authentication and intercept requests.
 
@@ -14,7 +14,7 @@ Proxy defines options for the virtual cluster control plane proxy that is used t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `bindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#proxy-bindAddress}
+### `bindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> {#proxy-bindAddress}
 
 BindAddress under which vCluster will expose the proxy.
 
@@ -29,7 +29,7 @@ BindAddress under which vCluster will expose the proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#proxy-port}
+### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> {#proxy-port}
 
 Port under which vCluster will expose the proxy. Changing port is currently not supported.
 
@@ -44,7 +44,7 @@ Port under which vCluster will expose the proxy. Changing port is currently not 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraSANs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#proxy-extraSANs}
+### `extraSANs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#proxy-extraSANs}
 
 ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
 

--- a/vcluster/_partials/config/controlPlane/service.mdx
+++ b/vcluster/_partials/config/controlPlane/service.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service}
+## `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#service}
 
 Service defines options for vCluster service deployed by Helm.
 
@@ -14,7 +14,7 @@ Service defines options for vCluster service deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#service-enabled}
 
 Enabled defines if the control plane service should be enabled
 
@@ -29,7 +29,7 @@ Enabled defines if the control plane service should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-spec}
+### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#service-spec}
 
 Spec allows you to configure extra service options.
 
@@ -44,7 +44,7 @@ Spec allows you to configure extra service options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeletNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-kubeletNodePort}
+### `kubeletNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#service-kubeletNodePort}
 
 KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 0.
 
@@ -59,7 +59,7 @@ KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `httpsNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-httpsNodePort}
+### `httpsNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#service-httpsNodePort}
 
 HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 
@@ -74,7 +74,7 @@ HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#service-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster/_partials/config/controlPlane/serviceMonitor.mdx
+++ b/vcluster/_partials/config/controlPlane/serviceMonitor.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `serviceMonitor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceMonitor}
+## `serviceMonitor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceMonitor}
 
 ServiceMonitor can be used to automatically create a service monitor for vCluster deployment itself.
 
@@ -14,7 +14,7 @@ ServiceMonitor can be used to automatically create a service monitor for vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceMonitor-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#serviceMonitor-enabled}
 
 Enabled configures if Helm should create the service monitor.
 
@@ -29,7 +29,7 @@ Enabled configures if Helm should create the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceMonitor-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceMonitor-labels}
 
 Labels are the extra labels to add to the service monitor.
 
@@ -44,7 +44,7 @@ Labels are the extra labels to add to the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceMonitor-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceMonitor-annotations}
 
 Annotations are the extra annotations to add to the service monitor.
 

--- a/vcluster/_partials/config/controlPlane/statefulSet.mdx
+++ b/vcluster/_partials/config/controlPlane/statefulSet.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet}
+## `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet}
 
 StatefulSet defines options for vCluster statefulSet deployed by Helm.
 
@@ -14,7 +14,7 @@ StatefulSet defines options for vCluster statefulSet deployed by Helm.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability}
+### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-highAvailability}
 
 HighAvailability holds options related to high availability.
 
@@ -26,7 +26,7 @@ HighAvailability holds options related to high availability.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability-replicas}
+#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-replicas}
 
 Replicas is the amount of replicas to use for the statefulSet.
 
@@ -41,7 +41,7 @@ Replicas is the amount of replicas to use for the statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `leaseDuration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability-leaseDuration}
+#### `leaseDuration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-leaseDuration}
 
 LeaseDuration is the time to lease for the leader.
 
@@ -56,7 +56,7 @@ LeaseDuration is the time to lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `renewDeadline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability-renewDeadline}
+#### `renewDeadline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-renewDeadline}
 
 RenewDeadline is the deadline to renew a lease for the leader.
 
@@ -71,7 +71,7 @@ RenewDeadline is the deadline to renew a lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `retryPeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability-retryPeriod}
+#### `retryPeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-retryPeriod}
 
 RetryPeriod is the time until a replica will retry to get a lease.
 
@@ -89,7 +89,7 @@ RetryPeriod is the time until a replica will retry to get a lease.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-resources}
 
 Resources are the resource requests and limits for the statefulSet container.
 
@@ -101,7 +101,7 @@ Resources are the resource requests and limits for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:8Gi memory:2Gi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-resources-limits}
+#### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:8Gi memory:2Gi&#93;</span> <span className="config-field-enum"></span> {#statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -116,7 +116,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:400Mi memory:256Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-resources-requests}
+#### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:400Mi memory:256Mi&#93;</span> <span className="config-field-enum"></span> {#statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -134,7 +134,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling}
+### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-scheduling}
 
 Scheduling holds options related to scheduling.
 
@@ -146,7 +146,7 @@ Scheduling holds options related to scheduling.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-nodeSelector}
+#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -161,7 +161,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-affinity}
+#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -176,7 +176,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-tolerations}
+#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -191,7 +191,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-priorityClassName}
+#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -206,7 +206,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-podManagementPolicy}
+#### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -221,7 +221,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-topologySpreadConstraints}
+#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -239,7 +239,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-security}
+### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-security}
 
 Security defines pod or container security context.
 
@@ -251,7 +251,7 @@ Security defines pod or container security context.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-security-podSecurityContext}
+#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -266,7 +266,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-security-containerSecurityContext}
+#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> {#statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -284,7 +284,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `probes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes}
+### `probes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes}
 
 Probes enables or disables the main container probes.
 
@@ -296,7 +296,7 @@ Probes enables or disables the main container probes.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `livenessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-livenessProbe}
+#### `livenessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe}
 
 LivenessProbe specifies if the liveness probe for the container should be enabled
 
@@ -308,7 +308,7 @@ LivenessProbe specifies if the liveness probe for the container should be enable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-livenessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -323,7 +323,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-livenessProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-failureThreshold}
 
 Number of consecutive failures for the probe to be considered failed
 
@@ -338,7 +338,7 @@ Number of consecutive failures for the probe to be considered failed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `initialDelaySeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-livenessProbe-initialDelaySeconds}
+##### `initialDelaySeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-initialDelaySeconds}
 
 Time (in seconds) to wait before starting the liveness probe
 
@@ -353,7 +353,7 @@ Time (in seconds) to wait before starting the liveness probe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-livenessProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -368,7 +368,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-livenessProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -386,7 +386,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `readinessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-readinessProbe}
+#### `readinessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe}
 
 ReadinessProbe specifies if the readiness probe for the container should be enabled
 
@@ -398,7 +398,7 @@ ReadinessProbe specifies if the readiness probe for the container should be enab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-readinessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -413,7 +413,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-readinessProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-failureThreshold}
 
 Number of consecutive failures for the probe to be considered failed
 
@@ -428,7 +428,7 @@ Number of consecutive failures for the probe to be considered failed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-readinessProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -443,7 +443,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-readinessProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -461,7 +461,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `startupProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-startupProbe}
+#### `startupProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe}
 
 StartupProbe specifies if the startup probe for the container should be enabled
 
@@ -473,7 +473,7 @@ StartupProbe specifies if the startup probe for the container should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-startupProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -488,7 +488,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">300</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-startupProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">300</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-failureThreshold}
 
 Number of consecutive failures allowed before failing the pod
 
@@ -503,7 +503,7 @@ Number of consecutive failures allowed before failing the pod
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-startupProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -518,7 +518,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">6</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-startupProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">6</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -539,7 +539,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence}
+### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence}
 
 Persistence defines options around persistence for the statefulSet.
 
@@ -551,7 +551,7 @@ Persistence defines options around persistence for the statefulSet.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim}
+#### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -563,7 +563,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim. If auto, vCluster will automatically determine
 based on the chosen distro and other options if this is required.
@@ -579,7 +579,7 @@ based on the chosen distro and other options if this is required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -594,7 +594,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -609,7 +609,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -624,7 +624,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -642,7 +642,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaimTemplates}
+#### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -657,7 +657,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dataVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-dataVolume}
+#### `dataVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-dataVolume}
 
 Allows you to override the dataVolume. Only works correctly if volumeClaim.enabled=false.
 
@@ -672,7 +672,7 @@ Allows you to override the dataVolume. Only works correctly if volumeClaim.enabl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `binariesVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-binariesVolume}
+#### `binariesVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-binariesVolume}
 
 BinariesVolume defines a binaries volume that is used to retrieve
 distro specific executables to be run by the syncer controller.
@@ -689,7 +689,7 @@ This volume doesn't need to be persistent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumes}
+#### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -704,7 +704,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts}
+#### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -716,7 +716,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -731,7 +731,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -747,7 +747,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -763,7 +763,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -779,7 +779,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -797,7 +797,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -821,7 +821,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-enableServiceLinks}
+### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -836,7 +836,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -851,7 +851,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -866,7 +866,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-pods}
+### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-pods}
 
 Additional labels or annotations for the statefulSet pods.
 
@@ -878,7 +878,7 @@ Additional labels or annotations for the statefulSet pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-pods-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -893,7 +893,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-pods-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -911,7 +911,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-image}
+### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-image}
 
 Image is the image for the controlPlane statefulSet container
 It defaults to the vCluster pro repository that includes the optional pro modules that are turned off by default.
@@ -925,7 +925,7 @@ If you still want to use the pure OSS build, set the repository to 'loft-sh/vclu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-image-registry}
+#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -941,7 +941,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-image-repository}
+#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> {#statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -956,7 +956,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-image-tag}
+#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -974,7 +974,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -989,7 +989,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `workingDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-workingDir}
+### `workingDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-workingDir}
 
 WorkingDir specifies in what folder the main process should get started.
 
@@ -1004,7 +1004,7 @@ WorkingDir specifies in what folder the main process should get started.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-command}
+### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-command}
 
 Command allows you to override the main command.
 
@@ -1019,7 +1019,7 @@ Command allows you to override the main command.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-args}
+### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-args}
 
 Args allows you to override the main arguments.
 
@@ -1034,7 +1034,7 @@ Args allows you to override the main arguments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-env}
+### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-env}
 
 Env are additional environment variables for the statefulSet container.
 
@@ -1049,7 +1049,7 @@ Env are additional environment variables for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dnsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsPolicy}
+### `dnsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsPolicy}
 
 Set DNS policy for the pod.
 
@@ -1064,7 +1064,7 @@ Set DNS policy for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `dnsConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig}
+### `dnsConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig}
 
 Specifies the DNS parameters of a pod.
 
@@ -1076,7 +1076,7 @@ Specifies the DNS parameters of a pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nameservers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-nameservers}
+#### `nameservers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-nameservers}
 
 A list of DNS name server IP addresses.
 This will be appended to the base nameservers generated from DNSPolicy.
@@ -1093,7 +1093,7 @@ Duplicated nameservers will be removed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `searches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-searches}
+#### `searches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-searches}
 
 A list of DNS search domains for host-name lookup.
 This will be appended to the base search paths generated from DNSPolicy.
@@ -1110,7 +1110,7 @@ Duplicated search paths will be removed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-options}
+#### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options}
 
 A list of DNS resolver options.
 This will be merged with the base options generated from DNSPolicy.
@@ -1125,7 +1125,7 @@ will override those that appear in the base DNSPolicy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-options-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options-name}
 
 Required.
 
@@ -1140,7 +1140,7 @@ Required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-options-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options-value}
 
 
 

--- a/vcluster/_partials/config/experimental.mdx
+++ b/vcluster/_partials/config/experimental.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `experimental` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental}
+## `experimental` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental}
 
 Experimental features for vCluster. Configuration here might change, so be careful with this.
 
@@ -14,7 +14,7 @@ Experimental features for vCluster. Configuration here might change, so be caref
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy}
+### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy}
 
 Deploy allows you to configure manifests and Helm charts to deploy within the host or virtual cluster.
 
@@ -26,7 +26,7 @@ Deploy allows you to configure manifests and Helm charts to deploy within the ho
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-host}
+#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host}
 
 Host defines what manifests to deploy into the host cluster
 
@@ -38,7 +38,7 @@ Host defines what manifests to deploy into the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-host-manifests}
+##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the host cluster.
 
@@ -53,7 +53,7 @@ Manifests are raw Kubernetes manifests that should get applied within the host c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-host-manifestsTemplate}
+##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the host cluster.
 
@@ -71,7 +71,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster}
+#### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster}
 
 VCluster defines what manifests and charts to deploy into the vCluster
 
@@ -83,7 +83,7 @@ VCluster defines what manifests and charts to deploy into the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-manifests}
+##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the virtual cluster.
 
@@ -98,7 +98,7 @@ Manifests are raw Kubernetes manifests that should get applied within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-manifestsTemplate}
+##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the virtual cluster.
 
@@ -113,7 +113,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm}
+##### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm}
 
 Helm are Helm charts that should get deployed into the virtual cluster
 
@@ -125,7 +125,7 @@ Helm are Helm charts that should get deployed into the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart}
+##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart}
 
 Chart defines what chart should get deployed.
 
@@ -137,7 +137,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-name}
 
 
 
@@ -152,7 +152,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-repo}
 
 
 
@@ -167,7 +167,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-insecure}
+##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-insecure}
 
 
 
@@ -182,7 +182,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-version}
+##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-version}
 
 
 
@@ -197,7 +197,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-username}
+##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-username}
 
 
 
@@ -212,7 +212,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-password}
+##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-password}
 
 
 
@@ -230,7 +230,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-release}
+##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release}
 
 Release defines what release should get deployed.
 
@@ -242,7 +242,7 @@ Release defines what release should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-release-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release-name}
 
 Name of the release
 
@@ -257,7 +257,7 @@ Name of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-release-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release-namespace}
 
 Namespace of the release
 
@@ -275,7 +275,7 @@ Namespace of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-values}
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-values}
 
 Values defines what values should get used.
 
@@ -290,7 +290,7 @@ Values defines what values should get used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-timeout}
+##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-timeout}
 
 Timeout defines the timeout for Helm
 
@@ -305,7 +305,7 @@ Timeout defines the timeout for Helm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-bundle}
+##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-bundle}
 
 Bundle allows to compress the Helm chart and specify this instead of an online chart
 
@@ -329,7 +329,7 @@ Bundle allows to compress the Helm chart and specify this instead of an online c
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings}
+### `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings}
 
 SyncSettings are advanced settings for the syncer controller.
 
@@ -341,7 +341,7 @@ SyncSettings are advanced settings for the syncer controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `targetNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-targetNamespace}
+#### `targetNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-targetNamespace}
 
 TargetNamespace is the namespace where the workloads should get synced to.
 
@@ -356,7 +356,7 @@ TargetNamespace is the namespace where the workloads should get synced to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-setOwner}
+#### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-syncSettings-setOwner}
 
 SetOwner specifies if vCluster should set an owner reference on the synced objects to the vCluster service. This allows for easy garbage collection.
 
@@ -371,7 +371,7 @@ SetOwner specifies if vCluster should set an owner reference on the synced objec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-hostMetricsBindAddress}
+#### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-hostMetricsBindAddress}
 
 HostMetricsBindAddress is the bind address for the local manager
 
@@ -386,7 +386,7 @@ HostMetricsBindAddress is the bind address for the local manager
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-virtualMetricsBindAddress}
+#### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-virtualMetricsBindAddress}
 
 VirtualMetricsBindAddress is the bind address for the virtual manager
 
@@ -404,7 +404,7 @@ VirtualMetricsBindAddress is the bind address for the virtual manager
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `genericSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync}
+### `genericSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync}
 
 GenericSync holds options to generically sync resources from virtual cluster to host.
 
@@ -416,7 +416,7 @@ GenericSync holds options to generically sync resources from virtual cluster to 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-version}
+#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-version}
 
 Version is the config version
 
@@ -431,7 +431,7 @@ Version is the config version
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `export` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export}
+#### `export` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export}
 
 Exports syncs a resource from the virtual cluster to the host
 
@@ -443,7 +443,7 @@ Exports syncs a resource from the virtual cluster to the host
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-apiVersion}
 
 APIVersion of the object to sync
 
@@ -458,7 +458,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-kind}
 
 Kind of the object to sync
 
@@ -473,7 +473,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-optional}
+##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-optional}
 
 
 
@@ -488,7 +488,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-replaceOnConflict}
+##### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-replaceOnConflict}
 
 ReplaceWhenInvalid determines if the controller should try to recreate the object
 if there is a problem applying
@@ -504,7 +504,7 @@ if there is a problem applying
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches}
 
 Patches are the patches to apply on the virtual cluster objects
 when syncing them from the host cluster
@@ -517,7 +517,7 @@ when syncing them from the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-op}
 
 Operation is the type of the patch
 
@@ -532,7 +532,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -547,7 +547,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-path}
 
 Path is the path of the patch
 
@@ -562,7 +562,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -577,7 +577,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -592,7 +592,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-value}
 
 Value is the new value to be set to the path
 
@@ -607,7 +607,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -624,7 +624,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -637,7 +637,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -652,7 +652,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -667,7 +667,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -682,7 +682,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -697,7 +697,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -715,7 +715,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -730,7 +730,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -743,7 +743,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-sync-secret}
 
 
 
@@ -758,7 +758,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-sync-configmap}
 
 
 
@@ -779,7 +779,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches}
+##### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches}
 
 ReversePatches are the patches to apply to host cluster objects
 after it has been synced to the virtual cluster
@@ -792,7 +792,7 @@ after it has been synced to the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-op}
 
 Operation is the type of the patch
 
@@ -807,7 +807,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-fromPath}
 
 FromPath is the path from the other object
 
@@ -822,7 +822,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-path}
 
 Path is the path of the patch
 
@@ -837,7 +837,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -852,7 +852,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -867,7 +867,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-value}
 
 Value is the new value to be set to the path
 
@@ -882,7 +882,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -899,7 +899,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -912,7 +912,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-path}
 
 Path is the path within the object to select
 
@@ -927,7 +927,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -942,7 +942,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -957,7 +957,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -972,7 +972,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -990,7 +990,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1005,7 +1005,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1018,7 +1018,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-sync-secret}
 
 
 
@@ -1033,7 +1033,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-sync-configmap}
 
 
 
@@ -1054,7 +1054,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-selector}
 
 Selector is a label selector to select the synced objects in the virtual cluster.
 If empty, all objects will be synced.
@@ -1067,7 +1067,7 @@ If empty, all objects will be synced.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labelSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-selector-labelSelector}
+##### `labelSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-selector-labelSelector}
 
 LabelSelector are the labels to select the object from
 
@@ -1088,7 +1088,7 @@ LabelSelector are the labels to select the object from
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `import` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import}
+#### `import` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import}
 
 Imports syncs a resource from the host cluster to virtual cluster
 
@@ -1100,7 +1100,7 @@ Imports syncs a resource from the host cluster to virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-apiVersion}
 
 APIVersion of the object to sync
 
@@ -1115,7 +1115,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-kind}
 
 Kind of the object to sync
 
@@ -1130,7 +1130,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-optional}
+##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-optional}
 
 
 
@@ -1145,7 +1145,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-replaceOnConflict}
+##### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-replaceOnConflict}
 
 ReplaceWhenInvalid determines if the controller should try to recreate the object
 if there is a problem applying
@@ -1161,7 +1161,7 @@ if there is a problem applying
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches}
 
 Patches are the patches to apply on the virtual cluster objects
 when syncing them from the host cluster
@@ -1174,7 +1174,7 @@ when syncing them from the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-op}
 
 Operation is the type of the patch
 
@@ -1189,7 +1189,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1204,7 +1204,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-path}
 
 Path is the path of the patch
 
@@ -1219,7 +1219,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1234,7 +1234,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1249,7 +1249,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-value}
 
 Value is the new value to be set to the path
 
@@ -1264,7 +1264,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1281,7 +1281,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1294,7 +1294,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1309,7 +1309,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1324,7 +1324,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1339,7 +1339,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1354,7 +1354,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1372,7 +1372,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1387,7 +1387,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1400,7 +1400,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-sync-secret}
 
 
 
@@ -1415,7 +1415,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-sync-configmap}
 
 
 
@@ -1436,7 +1436,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches}
+##### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches}
 
 ReversePatches are the patches to apply to host cluster objects
 after it has been synced to the virtual cluster
@@ -1449,7 +1449,7 @@ after it has been synced to the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-op}
 
 Operation is the type of the patch
 
@@ -1464,7 +1464,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1479,7 +1479,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-path}
 
 Path is the path of the patch
 
@@ -1494,7 +1494,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1509,7 +1509,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1524,7 +1524,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-value}
 
 Value is the new value to be set to the path
 
@@ -1539,7 +1539,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1556,7 +1556,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1569,7 +1569,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1584,7 +1584,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1599,7 +1599,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1614,7 +1614,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1629,7 +1629,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1647,7 +1647,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1662,7 +1662,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1675,7 +1675,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-sync-secret}
 
 
 
@@ -1690,7 +1690,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-sync-configmap}
 
 
 
@@ -1714,7 +1714,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `hooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks}
+#### `hooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks}
 
 Hooks are hooks that can be used to inject custom patches before syncing
 
@@ -1726,7 +1726,7 @@ Hooks are hooks that can be used to inject custom patches before syncing
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `hostToVirtual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual}
+##### `hostToVirtual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual}
 
 HostToVirtual is a hook that is executed before syncing from the host to the virtual cluster
 
@@ -1738,7 +1738,7 @@ HostToVirtual is a hook that is executed before syncing from the host to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-apiVersion}
 
 APIVersion of the object to sync
 
@@ -1753,7 +1753,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-kind}
 
 Kind of the object to sync
 
@@ -1768,7 +1768,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-verbs}
 
 Verbs are the verbs that the hook should mutate
 
@@ -1783,7 +1783,7 @@ Verbs are the verbs that the hook should mutate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches}
 
 Patches are the patches to apply on the object to be synced
 
@@ -1795,7 +1795,7 @@ Patches are the patches to apply on the object to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-op}
 
 Operation is the type of the patch
 
@@ -1810,7 +1810,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1825,7 +1825,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-path}
 
 Path is the path of the patch
 
@@ -1840,7 +1840,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1855,7 +1855,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1870,7 +1870,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-value}
 
 Value is the new value to be set to the path
 
@@ -1885,7 +1885,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1902,7 +1902,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1915,7 +1915,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1930,7 +1930,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1945,7 +1945,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1960,7 +1960,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1975,7 +1975,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1993,7 +1993,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -2008,7 +2008,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -2021,7 +2021,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync-secret}
 
 
 
@@ -2036,7 +2036,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync-configmap}
 
 
 
@@ -2060,7 +2060,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualToHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost}
+##### `virtualToHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost}
 
 VirtualToHost is a hook that is executed before syncing from the virtual to the host cluster
 
@@ -2072,7 +2072,7 @@ VirtualToHost is a hook that is executed before syncing from the virtual to the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-apiVersion}
 
 APIVersion of the object to sync
 
@@ -2087,7 +2087,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-kind}
 
 Kind of the object to sync
 
@@ -2102,7 +2102,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-verbs}
 
 Verbs are the verbs that the hook should mutate
 
@@ -2117,7 +2117,7 @@ Verbs are the verbs that the hook should mutate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches}
 
 Patches are the patches to apply on the object to be synced
 
@@ -2129,7 +2129,7 @@ Patches are the patches to apply on the object to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-op}
 
 Operation is the type of the patch
 
@@ -2144,7 +2144,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -2159,7 +2159,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-path}
 
 Path is the path of the patch
 
@@ -2174,7 +2174,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -2189,7 +2189,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -2204,7 +2204,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-value}
 
 Value is the new value to be set to the path
 
@@ -2219,7 +2219,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -2236,7 +2236,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -2249,7 +2249,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -2264,7 +2264,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -2279,7 +2279,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -2294,7 +2294,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -2309,7 +2309,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -2327,7 +2327,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -2342,7 +2342,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -2355,7 +2355,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-sync-secret}
 
 
 
@@ -2370,7 +2370,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-sync-configmap}
 
 
 
@@ -2397,7 +2397,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-clusterRole}
 
 
 
@@ -2409,7 +2409,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-clusterRole-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#experimental-genericSync-clusterRole-extraRules}
 
 
 
@@ -2427,7 +2427,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-role}
+#### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-role}
 
 
 
@@ -2439,7 +2439,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-role-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#experimental-genericSync-role-extraRules}
 
 
 
@@ -2460,7 +2460,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `isolatedControlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane}
+### `isolatedControlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane}
 
 IsolatedControlPlane is a feature to run the vCluster control plane in a different Kubernetes cluster than the workloads themselves.
 
@@ -2472,7 +2472,7 @@ IsolatedControlPlane is a feature to run the vCluster control plane in a differe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-enabled}
 
 Enabled specifies if the isolated control plane feature should be enabled.
 
@@ -2487,7 +2487,7 @@ Enabled specifies if the isolated control plane feature should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `headless` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-headless}
+#### `headless` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-headless}
 
 Headless states that Helm should deploy the vCluster in headless mode for the isolated control plane.
 
@@ -2502,7 +2502,7 @@ Headless states that Helm should deploy the vCluster in headless mode for the is
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-kubeConfig}
+#### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-kubeConfig}
 
 KubeConfig is the path where to find the remote workload cluster kubeconfig.
 
@@ -2517,7 +2517,7 @@ KubeConfig is the path where to find the remote workload cluster kubeconfig.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-namespace}
 
 Namespace is the namespace where to sync the workloads into.
 
@@ -2532,7 +2532,7 @@ Namespace is the namespace where to sync the workloads into.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-service}
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-service}
 
 Service is the vCluster service in the remote cluster.
 
@@ -2550,7 +2550,7 @@ Service is the vCluster service in the remote cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig}
+### `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig}
 
 VirtualClusterKubeConfig allows you to override distro specifics and specify where vCluster will find the required certificates and vCluster config.
 
@@ -2562,7 +2562,7 @@ VirtualClusterKubeConfig allows you to override distro specifics and specify whe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-kubeConfig}
+#### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-kubeConfig}
 
 KubeConfig is the virtual cluster kubeconfig path.
 
@@ -2577,7 +2577,7 @@ KubeConfig is the virtual cluster kubeconfig path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-serverCAKey}
+#### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-serverCAKey}
 
 ServerCAKey is the server ca key path.
 
@@ -2592,7 +2592,7 @@ ServerCAKey is the server ca key path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-serverCACert}
+#### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-serverCACert}
 
 ServerCAKey is the server ca cert path.
 
@@ -2607,7 +2607,7 @@ ServerCAKey is the server ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-clientCACert}
+#### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-clientCACert}
 
 ServerCAKey is the client ca cert path.
 
@@ -2622,7 +2622,7 @@ ServerCAKey is the client ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-requestHeaderCACert}
+#### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-requestHeaderCACert}
 
 RequestHeaderCACert is the request header ca cert path.
 
@@ -2640,7 +2640,7 @@ RequestHeaderCACert is the request header ca cert path.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests}
+### `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests}
 
 DenyProxyRequests denies certain requests in the vCluster proxy.
 
@@ -2652,7 +2652,7 @@ DenyProxyRequests denies certain requests in the vCluster proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-name}
 
 The name of the check.
 
@@ -2667,7 +2667,7 @@ The name of the check.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-namespaces}
+#### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-namespaces}
 
 Namespace describe a list of namespaces that will be affected by the check.
 An empty list means that all namespaces will be affected.
@@ -2684,7 +2684,7 @@ In case of ClusterScoped rules, only the Namespace resource is affected.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules}
+#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules}
 
 Rules describes on which verbs and on what resources/subresources the webhook is enforced.
 The webhook is enforced if it matches any Rule.
@@ -2698,7 +2698,7 @@ The version of the request must match the rule version exactly. Equivalent match
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-apiGroups}
 
 APIGroups is the API groups the resources belong to. '*' is all groups.
 
@@ -2713,7 +2713,7 @@ APIGroups is the API groups the resources belong to. '*' is all groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-apiVersions}
+##### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-apiVersions}
 
 APIVersions is the API versions the resources belong to. '*' is all versions.
 
@@ -2728,7 +2728,7 @@ APIVersions is the API versions the resources belong to. '*' is all versions.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -2743,7 +2743,7 @@ Resources is a list of resources this rule applies to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-scope}
+##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-scope}
 
 Scope specifies the scope of this rule.
 
@@ -2758,7 +2758,7 @@ Scope specifies the scope of this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-operations}
+##### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-operations}
 
 Verb is the kube verb associated with the request for API requests, not the http verb. This includes things like list and watch.
 For non-resource requests, this is the lowercase http verb.
@@ -2778,7 +2778,7 @@ If '*' is present, the length of the slice must be one.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-excludedUsers}
+#### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-excludedUsers}
 
 ExcludedUsers describe a list of users for which the checks will be skipped.
 Impersonation attempts on these users will still be subjected to the checks.

--- a/vcluster/_partials/config/experimental/denyProxyRequests.mdx
+++ b/vcluster/_partials/config/experimental/denyProxyRequests.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests}
+## `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests}
 
 DenyProxyRequests denies certain requests in the vCluster proxy.
 
@@ -14,7 +14,7 @@ DenyProxyRequests denies certain requests in the vCluster proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-name}
 
 The name of the check.
 
@@ -29,7 +29,7 @@ The name of the check.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-namespaces}
+### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-namespaces}
 
 Namespace describe a list of namespaces that will be affected by the check.
 An empty list means that all namespaces will be affected.
@@ -46,7 +46,7 @@ In case of ClusterScoped rules, only the Namespace resource is affected.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules}
+### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules}
 
 Rules describes on which verbs and on what resources/subresources the webhook is enforced.
 The webhook is enforced if it matches any Rule.
@@ -60,7 +60,7 @@ The version of the request must match the rule version exactly. Equivalent match
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-apiGroups}
+#### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-apiGroups}
 
 APIGroups is the API groups the resources belong to. '*' is all groups.
 
@@ -75,7 +75,7 @@ APIGroups is the API groups the resources belong to. '*' is all groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-apiVersions}
+#### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-apiVersions}
 
 APIVersions is the API versions the resources belong to. '*' is all versions.
 
@@ -90,7 +90,7 @@ APIVersions is the API versions the resources belong to. '*' is all versions.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -105,7 +105,7 @@ Resources is a list of resources this rule applies to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-scope}
+#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-scope}
 
 Scope specifies the scope of this rule.
 
@@ -120,7 +120,7 @@ Scope specifies the scope of this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-operations}
+#### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-operations}
 
 Verb is the kube verb associated with the request for API requests, not the http verb. This includes things like list and watch.
 For non-resource requests, this is the lowercase http verb.
@@ -140,7 +140,7 @@ If '*' is present, the length of the slice must be one.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-excludedUsers}
+### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-excludedUsers}
 
 ExcludedUsers describe a list of users for which the checks will be skipped.
 Impersonation attempts on these users will still be subjected to the checks.

--- a/vcluster/_partials/config/experimental/deploy.mdx
+++ b/vcluster/_partials/config/experimental/deploy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy}
+## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
 
 Deploy allows you to configure manifests and Helm charts to deploy within the host or virtual cluster.
 
@@ -14,7 +14,7 @@ Deploy allows you to configure manifests and Helm charts to deploy within the ho
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-host}
+### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host}
 
 Host defines what manifests to deploy into the host cluster
 
@@ -26,7 +26,7 @@ Host defines what manifests to deploy into the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-host-manifests}
+#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the host cluster.
 
@@ -41,7 +41,7 @@ Manifests are raw Kubernetes manifests that should get applied within the host c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-host-manifestsTemplate}
+#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the host cluster.
 
@@ -59,7 +59,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster}
+### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster}
 
 VCluster defines what manifests and charts to deploy into the vCluster
 
@@ -71,7 +71,7 @@ VCluster defines what manifests and charts to deploy into the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-manifests}
+#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the virtual cluster.
 
@@ -86,7 +86,7 @@ Manifests are raw Kubernetes manifests that should get applied within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-manifestsTemplate}
+#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the virtual cluster.
 
@@ -101,7 +101,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm}
+#### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm}
 
 Helm are Helm charts that should get deployed into the virtual cluster
 
@@ -113,7 +113,7 @@ Helm are Helm charts that should get deployed into the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart}
+##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart}
 
 Chart defines what chart should get deployed.
 
@@ -125,7 +125,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-name}
 
 
 
@@ -140,7 +140,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-repo}
 
 
 
@@ -155,7 +155,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-insecure}
+##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-insecure}
 
 
 
@@ -170,7 +170,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-version}
+##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-version}
 
 
 
@@ -185,7 +185,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-username}
+##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-username}
 
 
 
@@ -200,7 +200,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-password}
+##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-password}
 
 
 
@@ -218,7 +218,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-release}
+##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release}
 
 Release defines what release should get deployed.
 
@@ -230,7 +230,7 @@ Release defines what release should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-release-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release-name}
 
 Name of the release
 
@@ -245,7 +245,7 @@ Name of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-release-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release-namespace}
 
 Namespace of the release
 
@@ -263,7 +263,7 @@ Namespace of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-values}
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-values}
 
 Values defines what values should get used.
 
@@ -278,7 +278,7 @@ Values defines what values should get used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-timeout}
+##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-timeout}
 
 Timeout defines the timeout for Helm
 
@@ -293,7 +293,7 @@ Timeout defines the timeout for Helm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-bundle}
+##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-bundle}
 
 Bundle allows to compress the Helm chart and specify this instead of an online chart
 

--- a/vcluster/_partials/config/experimental/genericSync.mdx
+++ b/vcluster/_partials/config/experimental/genericSync.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `genericSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync}
+## `genericSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync}
 
 GenericSync holds options to generically sync resources from virtual cluster to host.
 
@@ -14,7 +14,7 @@ GenericSync holds options to generically sync resources from virtual cluster to 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-version}
+### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-version}
 
 Version is the config version
 
@@ -29,7 +29,7 @@ Version is the config version
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `export` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export}
+### `export` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export}
 
 Exports syncs a resource from the virtual cluster to the host
 
@@ -41,7 +41,7 @@ Exports syncs a resource from the virtual cluster to the host
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-apiVersion}
 
 APIVersion of the object to sync
 
@@ -56,7 +56,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-kind}
 
 Kind of the object to sync
 
@@ -71,7 +71,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-optional}
+#### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-optional}
 
 
 
@@ -86,7 +86,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-replaceOnConflict}
+#### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-replaceOnConflict}
 
 ReplaceWhenInvalid determines if the controller should try to recreate the object
 if there is a problem applying
@@ -102,7 +102,7 @@ if there is a problem applying
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches}
 
 Patches are the patches to apply on the virtual cluster objects
 when syncing them from the host cluster
@@ -115,7 +115,7 @@ when syncing them from the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-op}
 
 Operation is the type of the patch
 
@@ -130,7 +130,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -145,7 +145,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-path}
 
 Path is the path of the patch
 
@@ -160,7 +160,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -175,7 +175,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -190,7 +190,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-value}
 
 Value is the new value to be set to the path
 
@@ -205,7 +205,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -222,7 +222,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -235,7 +235,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -250,7 +250,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -265,7 +265,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -280,7 +280,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -295,7 +295,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -313,7 +313,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -328,7 +328,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -341,7 +341,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-sync-secret}
 
 
 
@@ -356,7 +356,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-sync-configmap}
 
 
 
@@ -377,7 +377,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches}
+#### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches}
 
 ReversePatches are the patches to apply to host cluster objects
 after it has been synced to the virtual cluster
@@ -390,7 +390,7 @@ after it has been synced to the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-op}
 
 Operation is the type of the patch
 
@@ -405,7 +405,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-fromPath}
 
 FromPath is the path from the other object
 
@@ -420,7 +420,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-path}
 
 Path is the path of the patch
 
@@ -435,7 +435,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -450,7 +450,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -465,7 +465,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-value}
 
 Value is the new value to be set to the path
 
@@ -480,7 +480,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -497,7 +497,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -510,7 +510,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-path}
 
 Path is the path within the object to select
 
@@ -525,7 +525,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -540,7 +540,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -555,7 +555,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -570,7 +570,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -588,7 +588,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -603,7 +603,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -616,7 +616,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-sync-secret}
 
 
 
@@ -631,7 +631,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-sync-configmap}
 
 
 
@@ -652,7 +652,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-selector}
+#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-selector}
 
 Selector is a label selector to select the synced objects in the virtual cluster.
 If empty, all objects will be synced.
@@ -665,7 +665,7 @@ If empty, all objects will be synced.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labelSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-selector-labelSelector}
+##### `labelSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-selector-labelSelector}
 
 LabelSelector are the labels to select the object from
 
@@ -686,7 +686,7 @@ LabelSelector are the labels to select the object from
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `import` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import}
+### `import` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import}
 
 Imports syncs a resource from the host cluster to virtual cluster
 
@@ -698,7 +698,7 @@ Imports syncs a resource from the host cluster to virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-apiVersion}
 
 APIVersion of the object to sync
 
@@ -713,7 +713,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-kind}
 
 Kind of the object to sync
 
@@ -728,7 +728,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-optional}
+#### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-optional}
 
 
 
@@ -743,7 +743,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-replaceOnConflict}
+#### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-replaceOnConflict}
 
 ReplaceWhenInvalid determines if the controller should try to recreate the object
 if there is a problem applying
@@ -759,7 +759,7 @@ if there is a problem applying
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches}
 
 Patches are the patches to apply on the virtual cluster objects
 when syncing them from the host cluster
@@ -772,7 +772,7 @@ when syncing them from the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-op}
 
 Operation is the type of the patch
 
@@ -787,7 +787,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -802,7 +802,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-path}
 
 Path is the path of the patch
 
@@ -817,7 +817,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -832,7 +832,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -847,7 +847,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-value}
 
 Value is the new value to be set to the path
 
@@ -862,7 +862,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -879,7 +879,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -892,7 +892,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -907,7 +907,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -922,7 +922,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -937,7 +937,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -952,7 +952,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -970,7 +970,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -985,7 +985,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -998,7 +998,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-sync-secret}
 
 
 
@@ -1013,7 +1013,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-sync-configmap}
 
 
 
@@ -1034,7 +1034,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches}
+#### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches}
 
 ReversePatches are the patches to apply to host cluster objects
 after it has been synced to the virtual cluster
@@ -1047,7 +1047,7 @@ after it has been synced to the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-op}
 
 Operation is the type of the patch
 
@@ -1062,7 +1062,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1077,7 +1077,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-path}
 
 Path is the path of the patch
 
@@ -1092,7 +1092,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1107,7 +1107,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1122,7 +1122,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-value}
 
 Value is the new value to be set to the path
 
@@ -1137,7 +1137,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1154,7 +1154,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1167,7 +1167,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1182,7 +1182,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1197,7 +1197,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1212,7 +1212,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1227,7 +1227,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1245,7 +1245,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1260,7 +1260,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1273,7 +1273,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-sync-secret}
 
 
 
@@ -1288,7 +1288,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-sync-configmap}
 
 
 
@@ -1312,7 +1312,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `hooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks}
+### `hooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks}
 
 Hooks are hooks that can be used to inject custom patches before syncing
 
@@ -1324,7 +1324,7 @@ Hooks are hooks that can be used to inject custom patches before syncing
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `hostToVirtual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual}
+#### `hostToVirtual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual}
 
 HostToVirtual is a hook that is executed before syncing from the host to the virtual cluster
 
@@ -1336,7 +1336,7 @@ HostToVirtual is a hook that is executed before syncing from the host to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-apiVersion}
 
 APIVersion of the object to sync
 
@@ -1351,7 +1351,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-kind}
 
 Kind of the object to sync
 
@@ -1366,7 +1366,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-verbs}
 
 Verbs are the verbs that the hook should mutate
 
@@ -1381,7 +1381,7 @@ Verbs are the verbs that the hook should mutate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches}
 
 Patches are the patches to apply on the object to be synced
 
@@ -1393,7 +1393,7 @@ Patches are the patches to apply on the object to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-op}
 
 Operation is the type of the patch
 
@@ -1408,7 +1408,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1423,7 +1423,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-path}
 
 Path is the path of the patch
 
@@ -1438,7 +1438,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1453,7 +1453,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1468,7 +1468,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-value}
 
 Value is the new value to be set to the path
 
@@ -1483,7 +1483,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1500,7 +1500,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1513,7 +1513,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1528,7 +1528,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1543,7 +1543,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1558,7 +1558,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1573,7 +1573,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1591,7 +1591,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1606,7 +1606,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1619,7 +1619,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-sync-secret}
 
 
 
@@ -1634,7 +1634,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-sync-configmap}
 
 
 
@@ -1658,7 +1658,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualToHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost}
+#### `virtualToHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost}
 
 VirtualToHost is a hook that is executed before syncing from the virtual to the host cluster
 
@@ -1670,7 +1670,7 @@ VirtualToHost is a hook that is executed before syncing from the virtual to the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-apiVersion}
 
 APIVersion of the object to sync
 
@@ -1685,7 +1685,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-kind}
 
 Kind of the object to sync
 
@@ -1700,7 +1700,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-verbs}
 
 Verbs are the verbs that the hook should mutate
 
@@ -1715,7 +1715,7 @@ Verbs are the verbs that the hook should mutate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches}
 
 Patches are the patches to apply on the object to be synced
 
@@ -1727,7 +1727,7 @@ Patches are the patches to apply on the object to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-op}
 
 Operation is the type of the patch
 
@@ -1742,7 +1742,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1757,7 +1757,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-path}
 
 Path is the path of the patch
 
@@ -1772,7 +1772,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1787,7 +1787,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1802,7 +1802,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-value}
 
 Value is the new value to be set to the path
 
@@ -1817,7 +1817,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1834,7 +1834,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1847,7 +1847,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1862,7 +1862,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1877,7 +1877,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1892,7 +1892,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1907,7 +1907,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1925,7 +1925,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1940,7 +1940,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1953,7 +1953,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-sync-secret}
 
 
 
@@ -1968,7 +1968,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-sync-configmap}
 
 
 
@@ -1995,7 +1995,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-clusterRole}
+### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-clusterRole}
 
 
 
@@ -2007,7 +2007,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-clusterRole-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#genericSync-clusterRole-extraRules}
 
 
 
@@ -2025,7 +2025,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-role}
+### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-role}
 
 
 
@@ -2037,7 +2037,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-role-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#genericSync-role-extraRules}
 
 
 

--- a/vcluster/_partials/config/experimental/isolatedControlPlane.mdx
+++ b/vcluster/_partials/config/experimental/isolatedControlPlane.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `isolatedControlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane}
+## `isolatedControlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane}
 
 IsolatedControlPlane is a feature to run the vCluster control plane in a different Kubernetes cluster than the workloads themselves.
 
@@ -14,7 +14,7 @@ IsolatedControlPlane is a feature to run the vCluster control plane in a differe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane-enabled}
 
 Enabled specifies if the isolated control plane feature should be enabled.
 
@@ -29,7 +29,7 @@ Enabled specifies if the isolated control plane feature should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `headless` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-headless}
+### `headless` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#isolatedControlPlane-headless}
 
 Headless states that Helm should deploy the vCluster in headless mode for the isolated control plane.
 
@@ -44,7 +44,7 @@ Headless states that Helm should deploy the vCluster in headless mode for the is
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-kubeConfig}
+### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane-kubeConfig}
 
 KubeConfig is the path where to find the remote workload cluster kubeconfig.
 
@@ -59,7 +59,7 @@ KubeConfig is the path where to find the remote workload cluster kubeconfig.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-namespace}
+### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane-namespace}
 
 Namespace is the namespace where to sync the workloads into.
 
@@ -74,7 +74,7 @@ Namespace is the namespace where to sync the workloads into.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-service}
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane-service}
 
 Service is the vCluster service in the remote cluster.
 

--- a/vcluster/_partials/config/experimental/syncSettings.mdx
+++ b/vcluster/_partials/config/experimental/syncSettings.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings}
+## `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings}
 
 SyncSettings are advanced settings for the syncer controller.
 
@@ -14,7 +14,7 @@ SyncSettings are advanced settings for the syncer controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `targetNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-targetNamespace}
+### `targetNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-targetNamespace}
 
 TargetNamespace is the namespace where the workloads should get synced to.
 
@@ -29,7 +29,7 @@ TargetNamespace is the namespace where the workloads should get synced to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-setOwner}
+### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#syncSettings-setOwner}
 
 SetOwner specifies if vCluster should set an owner reference on the synced objects to the vCluster service. This allows for easy garbage collection.
 
@@ -44,7 +44,7 @@ SetOwner specifies if vCluster should set an owner reference on the synced objec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-hostMetricsBindAddress}
+### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-hostMetricsBindAddress}
 
 HostMetricsBindAddress is the bind address for the local manager
 
@@ -59,7 +59,7 @@ HostMetricsBindAddress is the bind address for the local manager
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-virtualMetricsBindAddress}
+### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-virtualMetricsBindAddress}
 
 VirtualMetricsBindAddress is the bind address for the virtual manager
 

--- a/vcluster/_partials/config/experimental/virtualClusterKubeConfig.mdx
+++ b/vcluster/_partials/config/experimental/virtualClusterKubeConfig.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig}
+## `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig}
 
 VirtualClusterKubeConfig allows you to override distro specifics and specify where vCluster will find the required certificates and vCluster config.
 
@@ -14,7 +14,7 @@ VirtualClusterKubeConfig allows you to override distro specifics and specify whe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-kubeConfig}
+### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-kubeConfig}
 
 KubeConfig is the virtual cluster kubeconfig path.
 
@@ -29,7 +29,7 @@ KubeConfig is the virtual cluster kubeconfig path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-serverCAKey}
+### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-serverCAKey}
 
 ServerCAKey is the server ca key path.
 
@@ -44,7 +44,7 @@ ServerCAKey is the server ca key path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-serverCACert}
+### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-serverCACert}
 
 ServerCAKey is the server ca cert path.
 
@@ -59,7 +59,7 @@ ServerCAKey is the server ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-clientCACert}
+### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-clientCACert}
 
 ServerCAKey is the client ca cert path.
 
@@ -74,7 +74,7 @@ ServerCAKey is the client ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-requestHeaderCACert}
+### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-requestHeaderCACert}
 
 RequestHeaderCACert is the request header ca cert path.
 

--- a/vcluster/_partials/config/exportKubeConfig.mdx
+++ b/vcluster/_partials/config/exportKubeConfig.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `exportKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig}
+## `exportKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig}
 
 ExportKubeConfig describes how vCluster should export the vCluster kubeConfig file.
 
@@ -14,7 +14,7 @@ ExportKubeConfig describes how vCluster should export the vCluster kubeConfig fi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-context}
+### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-context}
 
 Context is the name of the context within the generated kubeconfig to use.
 
@@ -29,7 +29,7 @@ Context is the name of the context within the generated kubeconfig to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-server}
+### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-server}
 
 Override the default https://localhost:8443 and specify a custom hostname for the generated kubeconfig.
 
@@ -44,7 +44,7 @@ Override the default https://localhost:8443 and specify a custom hostname for th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-insecure}
+### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#exportKubeConfig-insecure}
 
 If tls should get skipped for the server
 
@@ -59,7 +59,7 @@ If tls should get skipped for the server
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-serviceAccount}
+### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount}
 
 ServiceAccount can be used to generate a service account token instead of the default certificates.
 
@@ -71,7 +71,7 @@ ServiceAccount can be used to generate a service account token instead of the de
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-serviceAccount-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-name}
 
 Name of the service account to be used to generate a service account token instead of the default certificates.
 
@@ -86,7 +86,7 @@ Name of the service account to be used to generate a service account token inste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-serviceAccount-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-namespace}
 
 Namespace of the service account to be used to generate a service account token instead of the default certificates.
 If omitted, will use the kube-system namespace.
@@ -102,7 +102,7 @@ If omitted, will use the kube-system namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-serviceAccount-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-clusterRole}
 
 ClusterRole to assign to the service account.
 
@@ -120,7 +120,7 @@ ClusterRole to assign to the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-secret}
+### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret}
 
 Declare in which host cluster secret vCluster should store the generated virtual cluster kubeconfig.
 If this is not defined, vCluster will create it with `vc-NAME`. If you specify another name,
@@ -136,7 +136,7 @@ Deprecated: Use AdditionalSecrets instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-secret-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret-name}
 
 Name is the name of the secret where the kubeconfig should get stored.
 
@@ -151,7 +151,7 @@ Name is the name of the secret where the kubeconfig should get stored.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-secret-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret-namespace}
 
 Namespace where vCluster should store the kubeconfig secret. If this is not equal to the namespace
 where you deployed vCluster, you need to make sure vCluster has access to this other namespace.
@@ -170,7 +170,7 @@ where you deployed vCluster, you need to make sure vCluster has access to this o
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `additionalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets}
+### `additionalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets}
 
 AdditionalSecrets specifies the additional host cluster secrets in which vCluster will store the
 generated virtual cluster kubeconfigs.
@@ -183,7 +183,7 @@ generated virtual cluster kubeconfigs.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-context}
+#### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-context}
 
 Context is the name of the context within the generated kubeconfig to use.
 
@@ -198,7 +198,7 @@ Context is the name of the context within the generated kubeconfig to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-server}
+#### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-server}
 
 Override the default https://localhost:8443 and specify a custom hostname for the generated kubeconfig.
 
@@ -213,7 +213,7 @@ Override the default https://localhost:8443 and specify a custom hostname for th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-insecure}
+#### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-insecure}
 
 If tls should get skipped for the server
 
@@ -228,7 +228,7 @@ If tls should get skipped for the server
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-serviceAccount}
+#### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount}
 
 ServiceAccount can be used to generate a service account token instead of the default certificates.
 
@@ -240,7 +240,7 @@ ServiceAccount can be used to generate a service account token instead of the de
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-serviceAccount-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-name}
 
 Name of the service account to be used to generate a service account token instead of the default certificates.
 
@@ -255,7 +255,7 @@ Name of the service account to be used to generate a service account token inste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-serviceAccount-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-namespace}
 
 Namespace of the service account to be used to generate a service account token instead of the default certificates.
 If omitted, will use the kube-system namespace.
@@ -271,7 +271,7 @@ If omitted, will use the kube-system namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-serviceAccount-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-clusterRole}
 
 ClusterRole to assign to the service account.
 
@@ -289,7 +289,7 @@ ClusterRole to assign to the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-name}
 
 Name is the name of the secret where the kubeconfig is stored.
 
@@ -304,7 +304,7 @@ Name is the name of the secret where the kubeconfig is stored.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-namespace}
 
 Namespace where vCluster stores the kubeconfig secret. If this is not equal to the namespace
 where you deployed vCluster, you need to make sure vCluster has access to this other namespace.

--- a/vcluster/_partials/config/integrations.mdx
+++ b/vcluster/_partials/config/integrations.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `integrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations}
+## `integrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations}
 
 Integrations holds config for vCluster integrations with other operators or tools running on the host cluster
 
@@ -14,7 +14,7 @@ Integrations holds config for vCluster integrations with other operators or tool
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer}
+### `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer}
 
 MetricsServer reuses the metrics server from the host cluster within the vCluster.
 
@@ -26,7 +26,7 @@ MetricsServer reuses the metrics server from the host cluster within the vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-metricsServer-enabled}
 
 Enabled signals the metrics server integration should be enabled.
 
@@ -41,7 +41,7 @@ Enabled signals the metrics server integration should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService}
+#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService}
 
 APIService holds information about where to find the metrics-server service. Defaults to metrics-server/kube-system.
 
@@ -53,7 +53,7 @@ APIService holds information about where to find the metrics-server service. Def
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -65,7 +65,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -80,7 +80,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -95,7 +95,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -116,7 +116,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-nodes}
+#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-metricsServer-nodes}
 
 Nodes defines if metrics-server nodes api should get proxied from host to virtual cluster.
 
@@ -131,7 +131,7 @@ Nodes defines if metrics-server nodes api should get proxied from host to virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-pods}
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-metricsServer-pods}
 
 Pods defines if metrics-server pods api should get proxied from host to virtual cluster.
 
@@ -149,7 +149,7 @@ Pods defines if metrics-server pods api should get proxied from host to virtual 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt}
+### `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt}
 
 KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside the vCluster
 
@@ -161,7 +161,7 @@ KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-enabled}
 
 Enabled signals if the integration should be enabled
 
@@ -176,7 +176,7 @@ Enabled signals if the integration should be enabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService}
+#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService}
 
 APIService holds information about where to find the virt-api service. Defaults to virt-api/kubevirt.
 
@@ -188,7 +188,7 @@ APIService holds information about where to find the virt-api service. Defaults 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -200,7 +200,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -215,7 +215,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -230,7 +230,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -251,7 +251,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-webhook}
+#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-webhook}
 
 Webhook holds configuration for enabling the webhook within the vCluster
 
@@ -263,7 +263,7 @@ Webhook holds configuration for enabling the webhook within the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-webhook-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -281,7 +281,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync}
+#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync}
 
 Sync holds configuration on what resources to sync
 
@@ -293,7 +293,7 @@ Sync holds configuration on what resources to sync
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-dataVolumes}
+##### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-dataVolumes}
 
 If DataVolumes should get synced
 
@@ -305,7 +305,7 @@ If DataVolumes should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-dataVolumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-dataVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -323,7 +323,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations}
+##### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations}
 
 If VirtualMachineInstanceMigrations should get synced
 
@@ -335,7 +335,7 @@ If VirtualMachineInstanceMigrations should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -353,7 +353,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineInstances}
+##### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstances}
 
 If VirtualMachineInstances should get synced
 
@@ -365,7 +365,7 @@ If VirtualMachineInstances should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineInstances-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstances-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -383,7 +383,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachines}
+##### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachines}
 
 If VirtualMachines should get synced
 
@@ -395,7 +395,7 @@ If VirtualMachines should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachines-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachines-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -413,7 +413,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineClones}
+##### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineClones}
 
 If VirtualMachineClones should get synced
 
@@ -425,7 +425,7 @@ If VirtualMachineClones should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineClones-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineClones-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -443,7 +443,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachinePools}
+##### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachinePools}
 
 If VirtualMachinePools should get synced
 
@@ -455,7 +455,7 @@ If VirtualMachinePools should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachinePools-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachinePools-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -479,7 +479,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets}
+### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets}
 
 ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster.
 - ExternalSecrets will be synced from the virtual cluster to the host cluster.
@@ -494,7 +494,7 @@ ExternalSecrets reuses a host external secret operator and makes certain CRDs fr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-enabled}
 
 Enabled defines whether the external secret integration is enabled or not
 
@@ -509,7 +509,7 @@ Enabled defines whether the external secret integration is enabled or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-webhook}
+#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-webhook}
 
 Webhook defines whether the host webhooks are reused or not
 
@@ -521,7 +521,7 @@ Webhook defines whether the host webhooks are reused or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-webhook-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -539,7 +539,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync}
+#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync}
 
 Sync defines the syncing behavior for the integration
 
@@ -551,7 +551,7 @@ Sync defines the syncing behavior for the integration
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-toHost}
+##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost}
 
 ToHost defines what resources are synced from the virtual cluster to the host
 
@@ -563,7 +563,7 @@ ToHost defines what resources are synced from the virtual cluster to the host
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-toHost-externalSecrets}
+##### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets}
 
 ExternalSecrets allows to configure if only a subset of ExternalSecrets matching a label selector should get synced from the virtual cluster to the host cluster.
 
@@ -575,7 +575,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector}
 
 
 
@@ -587,7 +587,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchLabels}
 
 
 
@@ -602,7 +602,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions}
 
 
 
@@ -614,22 +614,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-key}
 
 
 
@@ -644,7 +629,22 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-values}
 
 
 
@@ -668,7 +668,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-toHost-stores}
+##### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores}
 
 Stores defines if secret stores should get synced from the virtual cluster to the host cluster and then bi-directionally.
 
@@ -680,7 +680,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-toHost-stores-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector}
 
 
 
@@ -692,7 +692,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchLabels}
 
 
 
@@ -707,7 +707,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions}
 
 
 
@@ -719,22 +719,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions-key}
 
 
 
@@ -749,7 +734,22 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-selector-matchExpressions-values}
 
 
 
@@ -770,7 +770,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-toHost-stores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-toHost-stores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -791,7 +791,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-fromHost}
+##### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost}
 
 FromHost defines what resources are synced from the host cluster to the virtual cluster
 
@@ -803,7 +803,7 @@ FromHost defines what resources are synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-fromHost-clusterStores}
+##### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores}
 
 ClusterStores defines if cluster secrets stores should get synced from the host cluster to the virtual cluster.
 
@@ -815,7 +815,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector}
 
 
 
@@ -827,7 +827,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchLabels}
 
 
 
@@ -842,7 +842,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions}
 
 
 
@@ -854,22 +854,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-key}
 
 
 
@@ -884,7 +869,22 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-values}
 
 
 
@@ -905,7 +905,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-fromHost-clusterStores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-fromHost-clusterStores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -926,7 +926,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-externalSecrets}
+##### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-externalSecrets}
 
 ExternalSecrets defines if external secrets should get synced from the virtual cluster to the host cluster.
 
@@ -938,7 +938,7 @@ ExternalSecrets defines if external secrets should get synced from the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-externalSecrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-externalSecrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -956,7 +956,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-stores}
+##### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-stores}
 
 Stores defines if secret stores should get synced from the virtual cluster to the host cluster and then bi-directionally.
 Deprecated: Use Integrations.ExternalSecrets.Sync.ToHost.Stores instead.
@@ -969,7 +969,7 @@ Deprecated: Use Integrations.ExternalSecrets.Sync.ToHost.Stores instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-stores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-stores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -987,7 +987,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-clusterStores}
+##### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-clusterStores}
 
 ClusterStores defines if cluster secrets stores should get synced from the host cluster to the virtual cluster.
 Deprecated: Use Integrations.ExternalSecrets.Sync.FromHost.ClusterStores instead.
@@ -1000,7 +1000,7 @@ Deprecated: Use Integrations.ExternalSecrets.Sync.FromHost.ClusterStores instead
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-clusterStores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-clusterStores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1015,7 +1015,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-clusterStores-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-clusterStores-selector}
 
 Selector defines what cluster stores should be synced
 
@@ -1027,7 +1027,7 @@ Selector defines what cluster stores should be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-clusterStores-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-clusterStores-selector-labels}
 
 Labels defines what labels should be looked for
 
@@ -1054,7 +1054,7 @@ Labels defines what labels should be looked for
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager}
+### `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager}
 
 CertManager reuses a host cert-manager and makes its CRDs from it available inside the vCluster.
 - Certificates and Issuers will be synced from the virtual cluster to the host cluster.
@@ -1068,7 +1068,7 @@ CertManager reuses a host cert-manager and makes its CRDs from it available insi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-certManager-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1083,7 +1083,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync}
+#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync}
 
 Sync contains advanced configuration for syncing cert-manager resources.
 
@@ -1095,7 +1095,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost}
+##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost}
 
 
 
@@ -1107,7 +1107,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost-certificates}
+##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-certificates}
 
 Certificates defines if certificates should get synced from the virtual cluster to the host cluster.
 
@@ -1119,7 +1119,7 @@ Certificates defines if certificates should get synced from the virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost-certificates-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-certificates-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1137,7 +1137,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost-issuers}
+##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-issuers}
 
 Issuers defines if issuers should get synced from the virtual cluster to the host cluster.
 
@@ -1149,7 +1149,7 @@ Issuers defines if issuers should get synced from the virtual cluster to the hos
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost-issuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-issuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1170,7 +1170,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost}
+##### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost}
 
 
 
@@ -1182,7 +1182,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost-clusterIssuers}
+##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers}
 
 ClusterIssuers defines if (and which) cluster issuers should get synced from the host cluster to the virtual cluster.
 
@@ -1194,7 +1194,7 @@ ClusterIssuers defines if (and which) cluster issuers should get synced from the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost-clusterIssuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1209,7 +1209,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector}
 
 Selector defines what cluster issuers should be imported.
 
@@ -1221,7 +1221,7 @@ Selector defines what cluster issuers should be imported.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector-labels}
 
 Labels defines what labels should be looked for
 
@@ -1251,7 +1251,7 @@ Labels defines what labels should be looked for
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `istio` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio}
+### `istio` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio}
 
 Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster to the host.
 
@@ -1263,7 +1263,7 @@ Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-istio-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1278,7 +1278,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync}
+#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync}
 
 
 
@@ -1290,7 +1290,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost}
+##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost}
 
 
 
@@ -1302,7 +1302,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `destinationRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost-destinationRules}
+##### `destinationRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-destinationRules}
 
 
 
@@ -1314,37 +1314,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost-destinationRules-enabled}
-
-Enabled defines if this option should be enabled.
-
-</summary>
-
-
-
-</details>
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost-gateways}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost-gateways-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-destinationRules-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1362,7 +1332,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost-virtualServices}
+##### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-gateways}
 
 
 
@@ -1374,7 +1344,37 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost-virtualServices-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-gateways-enabled}
+
+Enabled defines if this option should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `virtualServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-virtualServices}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-virtualServices-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster/_partials/config/integrations/certManager.mdx
+++ b/vcluster/_partials/config/integrations/certManager.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager}
+## `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager}
 
 CertManager reuses a host cert-manager and makes its CRDs from it available inside the vCluster.
 - Certificates and Issuers will be synced from the virtual cluster to the host cluster.
@@ -16,7 +16,7 @@ CertManager reuses a host cert-manager and makes its CRDs from it available insi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#certManager-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -31,7 +31,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync}
+### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync}
 
 Sync contains advanced configuration for syncing cert-manager resources.
 
@@ -43,7 +43,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost}
+#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost}
 
 
 
@@ -55,7 +55,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-certificates}
+##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost-certificates}
 
 Certificates defines if certificates should get synced from the virtual cluster to the host cluster.
 
@@ -67,7 +67,7 @@ Certificates defines if certificates should get synced from the virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-certificates-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-toHost-certificates-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -85,7 +85,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-issuers}
+##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost-issuers}
 
 Issuers defines if issuers should get synced from the virtual cluster to the host cluster.
 
@@ -97,7 +97,7 @@ Issuers defines if issuers should get synced from the virtual cluster to the hos
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-issuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-toHost-issuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -118,7 +118,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost}
+#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost}
 
 
 
@@ -130,7 +130,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers}
+##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers}
 
 ClusterIssuers defines if (and which) cluster issuers should get synced from the host cluster to the virtual cluster.
 
@@ -142,7 +142,7 @@ ClusterIssuers defines if (and which) cluster issuers should get synced from the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -157,7 +157,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-selector}
 
 Selector defines what cluster issuers should be imported.
 
@@ -169,7 +169,7 @@ Selector defines what cluster issuers should be imported.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-selector-labels}
 
 Labels defines what labels should be looked for
 

--- a/vcluster/_partials/config/integrations/externalSecrets.mdx
+++ b/vcluster/_partials/config/integrations/externalSecrets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets}
+## `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets}
 
 ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster.
 - ExternalSecrets will be synced from the virtual cluster to the host cluster.
@@ -17,7 +17,7 @@ ExternalSecrets reuses a host external secret operator and makes certain CRDs fr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-enabled}
 
 Enabled defines whether the external secret integration is enabled or not
 
@@ -32,7 +32,7 @@ Enabled defines whether the external secret integration is enabled or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-webhook}
+### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-webhook}
 
 Webhook defines whether the host webhooks are reused or not
 
@@ -44,7 +44,7 @@ Webhook defines whether the host webhooks are reused or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-webhook-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -62,7 +62,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync}
+### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync}
 
 Sync defines the syncing behavior for the integration
 
@@ -74,7 +74,7 @@ Sync defines the syncing behavior for the integration
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-toHost}
+#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost}
 
 ToHost defines what resources are synced from the virtual cluster to the host
 
@@ -86,7 +86,7 @@ ToHost defines what resources are synced from the virtual cluster to the host
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-toHost-externalSecrets}
+##### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets}
 
 ExternalSecrets allows to configure if only a subset of ExternalSecrets matching a label selector should get synced from the virtual cluster to the host cluster.
 
@@ -98,7 +98,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-toHost-externalSecrets-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector}
 
 
 
@@ -110,7 +110,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchLabels}
 
 
 
@@ -125,7 +125,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions}
 
 
 
@@ -137,22 +137,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-key}
 
 
 
@@ -167,7 +152,22 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-externalSecrets-selector-matchExpressions-values}
 
 
 
@@ -191,7 +191,7 @@ ExternalSecrets allows to configure if only a subset of ExternalSecrets matching
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-toHost-stores}
+##### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores}
 
 Stores defines if secret stores should get synced from the virtual cluster to the host cluster and then bi-directionally.
 
@@ -203,7 +203,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-toHost-stores-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector}
 
 
 
@@ -215,7 +215,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-toHost-stores-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchLabels}
 
 
 
@@ -230,7 +230,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions}
 
 
 
@@ -242,22 +242,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions-key}
 
 
 
@@ -272,7 +257,22 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-selector-matchExpressions-values}
 
 
 
@@ -293,7 +293,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-toHost-stores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-sync-toHost-stores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -314,7 +314,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-fromHost}
+#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost}
 
 FromHost defines what resources are synced from the host cluster to the virtual cluster
 
@@ -326,7 +326,7 @@ FromHost defines what resources are synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-fromHost-clusterStores}
+##### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores}
 
 ClusterStores defines if cluster secrets stores should get synced from the host cluster to the virtual cluster.
 
@@ -338,7 +338,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-fromHost-clusterStores-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector}
 
 
 
@@ -350,7 +350,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchLabels}
 
 
 
@@ -365,7 +365,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions}
 
 
 
@@ -377,22 +377,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-key}
 
 
 
@@ -407,7 +392,22 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-selector-matchExpressions-values}
 
 
 
@@ -428,7 +428,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-fromHost-clusterStores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-sync-fromHost-clusterStores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -449,7 +449,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-externalSecrets}
+#### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-externalSecrets}
 
 ExternalSecrets defines if external secrets should get synced from the virtual cluster to the host cluster.
 
@@ -461,7 +461,7 @@ ExternalSecrets defines if external secrets should get synced from the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-externalSecrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#externalSecrets-sync-externalSecrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -479,7 +479,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-stores}
+#### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-stores}
 
 Stores defines if secret stores should get synced from the virtual cluster to the host cluster and then bi-directionally.
 Deprecated: Use Integrations.ExternalSecrets.Sync.ToHost.Stores instead.
@@ -492,7 +492,7 @@ Deprecated: Use Integrations.ExternalSecrets.Sync.ToHost.Stores instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-stores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-sync-stores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -510,7 +510,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-clusterStores}
+#### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-clusterStores}
 
 ClusterStores defines if cluster secrets stores should get synced from the host cluster to the virtual cluster.
 Deprecated: Use Integrations.ExternalSecrets.Sync.FromHost.ClusterStores instead.
@@ -523,7 +523,7 @@ Deprecated: Use Integrations.ExternalSecrets.Sync.FromHost.ClusterStores instead
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-clusterStores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-sync-clusterStores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -538,7 +538,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-clusterStores-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-clusterStores-selector}
 
 Selector defines what cluster stores should be synced
 
@@ -550,7 +550,7 @@ Selector defines what cluster stores should be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-clusterStores-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#externalSecrets-sync-clusterStores-selector-labels}
 
 Labels defines what labels should be looked for
 

--- a/vcluster/_partials/config/integrations/istio.mdx
+++ b/vcluster/_partials/config/integrations/istio.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `istio` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio}
+## `istio` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio}
 
 Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster to the host.
 
@@ -14,7 +14,7 @@ Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#istio-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync}
+### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync}
 
 
 
@@ -41,7 +41,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost}
+#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost}
 
 
 
@@ -53,7 +53,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `destinationRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost-destinationRules}
+##### `destinationRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-destinationRules}
 
 
 
@@ -65,37 +65,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost-destinationRules-enabled}
-
-Enabled defines if this option should be enabled.
-
-</summary>
-
-
-
-</details>
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost-gateways}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost-gateways-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-destinationRules-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -113,7 +83,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost-virtualServices}
+##### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-gateways}
 
 
 
@@ -125,7 +95,37 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost-virtualServices-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-gateways-enabled}
+
+Enabled defines if this option should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `virtualServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-virtualServices}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-virtualServices-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster/_partials/config/integrations/kubeVirt.mdx
+++ b/vcluster/_partials/config/integrations/kubeVirt.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt}
+## `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt}
 
 KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside the vCluster
 
@@ -14,7 +14,7 @@ KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVirt-enabled}
 
 Enabled signals if the integration should be enabled
 
@@ -29,7 +29,7 @@ Enabled signals if the integration should be enabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService}
+### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService}
 
 APIService holds information about where to find the virt-api service. Defaults to virt-api/kubevirt.
 
@@ -41,7 +41,7 @@ APIService holds information about where to find the virt-api service. Defaults 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService-service}
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -53,7 +53,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -68,7 +68,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -83,7 +83,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -104,7 +104,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-webhook}
+### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-webhook}
 
 Webhook holds configuration for enabling the webhook within the vCluster
 
@@ -116,7 +116,7 @@ Webhook holds configuration for enabling the webhook within the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-webhook-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -134,7 +134,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync}
+### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync}
 
 Sync holds configuration on what resources to sync
 
@@ -146,7 +146,7 @@ Sync holds configuration on what resources to sync
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-dataVolumes}
+#### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-dataVolumes}
 
 If DataVolumes should get synced
 
@@ -158,7 +158,7 @@ If DataVolumes should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-dataVolumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVirt-sync-dataVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -176,7 +176,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineInstanceMigrations}
+#### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstanceMigrations}
 
 If VirtualMachineInstanceMigrations should get synced
 
@@ -188,7 +188,7 @@ If VirtualMachineInstanceMigrations should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -206,7 +206,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineInstances}
+#### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstances}
 
 If VirtualMachineInstances should get synced
 
@@ -218,7 +218,7 @@ If VirtualMachineInstances should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineInstances-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstances-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -236,7 +236,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachines}
+#### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachines}
 
 If VirtualMachines should get synced
 
@@ -248,7 +248,7 @@ If VirtualMachines should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachines-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachines-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -266,7 +266,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineClones}
+#### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineClones}
 
 If VirtualMachineClones should get synced
 
@@ -278,7 +278,7 @@ If VirtualMachineClones should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineClones-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineClones-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -296,7 +296,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachinePools}
+#### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachinePools}
 
 If VirtualMachinePools should get synced
 
@@ -308,7 +308,7 @@ If VirtualMachinePools should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachinePools-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachinePools-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster/_partials/config/integrations/metricsServer.mdx
+++ b/vcluster/_partials/config/integrations/metricsServer.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer}
+## `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer}
 
 MetricsServer reuses the metrics server from the host cluster within the vCluster.
 
@@ -14,7 +14,7 @@ MetricsServer reuses the metrics server from the host cluster within the vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#metricsServer-enabled}
 
 Enabled signals the metrics server integration should be enabled.
 
@@ -29,7 +29,7 @@ Enabled signals the metrics server integration should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService}
+### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService}
 
 APIService holds information about where to find the metrics-server service. Defaults to metrics-server/kube-system.
 
@@ -41,7 +41,7 @@ APIService holds information about where to find the metrics-server service. Def
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService-service}
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -53,7 +53,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -68,7 +68,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -83,7 +83,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -104,7 +104,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-nodes}
+### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#metricsServer-nodes}
 
 Nodes defines if metrics-server nodes api should get proxied from host to virtual cluster.
 
@@ -119,7 +119,7 @@ Nodes defines if metrics-server nodes api should get proxied from host to virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-pods}
+### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#metricsServer-pods}
 
 Pods defines if metrics-server pods api should get proxied from host to virtual cluster.
 

--- a/vcluster/_partials/config/logging.mdx
+++ b/vcluster/_partials/config/logging.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `logging` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#logging}
+## `logging` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#logging}
 
 Logging provides structured logging options
 
@@ -14,7 +14,7 @@ Logging provides structured logging options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `encoding` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">console</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#logging-encoding}
+### `encoding` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">console</span> <span className="config-field-enum"></span> {#logging-encoding}
 
 Encoding specifies the format of vCluster logs, it can either be json or console.
 

--- a/vcluster/_partials/config/networking.mdx
+++ b/vcluster/_partials/config/networking.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `networking` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking}
+## `networking` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking}
 
 Networking options related to the virtual cluster.
 
@@ -14,7 +14,7 @@ Networking options related to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `serviceCIDR` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-serviceCIDR}
+### `serviceCIDR` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-serviceCIDR}
 
 ServiceCIDR holds the service cidr for the virtual cluster. This should only be set if privateNodes.enabled is true or vCluster cannot detect the host service cidr.
 
@@ -29,7 +29,7 @@ ServiceCIDR holds the service cidr for the virtual cluster. This should only be 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `podCIDR` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">10.244.0.0/16</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-podCIDR}
+### `podCIDR` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">10.244.0.0/16</span> <span className="config-field-enum"></span> {#networking-podCIDR}
 
 PodCIDR holds the pod cidr for the virtual cluster. This should only be set if privateNodes.enabled is true.
 
@@ -44,7 +44,7 @@ PodCIDR holds the pod cidr for the virtual cluster. This should only be set if p
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices}
+### `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices}
 
 ReplicateServices allows replicating services from the host within the virtual cluster or the other way around.
 
@@ -56,7 +56,7 @@ ReplicateServices allows replicating services from the host within the virtual c
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-toHost}
+#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost}
 
 ToHost defines the services that should get synced from virtual cluster to the host cluster. If services are
 synced to a different namespace than the virtual cluster is in, additional permissions for the other namespace
@@ -70,7 +70,7 @@ are required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-toHost-from}
+##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -85,7 +85,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-toHost-to}
+##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 
@@ -103,7 +103,7 @@ To is the target service that it should get synced to. Can be either in the form
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-fromHost}
+#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost}
 
 FromHost defines the services that should get synced from the host to the virtual cluster.
 
@@ -115,7 +115,7 @@ FromHost defines the services that should get synced from the host to the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-fromHost-from}
+##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -130,7 +130,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-fromHost-to}
+##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 
@@ -151,7 +151,7 @@ To is the target service that it should get synced to. Can be either in the form
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS}
+### `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS}
 
 ResolveDNS allows to define extra DNS rules. This only works if embedded coredns is configured.
 
@@ -163,7 +163,7 @@ ResolveDNS allows to define extra DNS rules. This only works if embedded coredns
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-hostname}
+#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-hostname}
 
 Hostname is the hostname within the vCluster that should be resolved from.
 
@@ -178,7 +178,7 @@ Hostname is the hostname within the vCluster that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-service}
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-service}
 
 Service is the virtual cluster service that should be resolved from.
 
@@ -193,7 +193,7 @@ Service is the virtual cluster service that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-namespace}
 
 Namespace is the virtual cluster namespace that should be resolved from.
 
@@ -208,7 +208,7 @@ Namespace is the virtual cluster namespace that should be resolved from.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target}
+#### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target}
 
 Target is the DNS target that should get mapped to
 
@@ -220,7 +220,7 @@ Target is the DNS target that should get mapped to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-hostname}
+##### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostname}
 
 Hostname to use as a DNS target
 
@@ -235,7 +235,7 @@ Hostname to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-ip}
+##### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-ip}
 
 IP to use as a DNS target
 
@@ -250,7 +250,7 @@ IP to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-hostService}
+##### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostService}
 
 HostService to target, format is hostNamespace/hostService
 
@@ -265,7 +265,7 @@ HostService to target, format is hostNamespace/hostService
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-hostNamespace}
+##### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostNamespace}
 
 HostNamespace to target
 
@@ -280,7 +280,7 @@ HostNamespace to target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-vClusterService}
+##### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-vClusterService}
 
 VClusterService format is hostNamespace/vClusterName/vClusterNamespace/vClusterService
 
@@ -301,7 +301,7 @@ VClusterService format is hostNamespace/vClusterName/vClusterNamespace/vClusterS
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced}
+### `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-advanced}
 
 Advanced holds advanced network options.
 
@@ -313,7 +313,7 @@ Advanced holds advanced network options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-clusterDomain}
+#### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> {#networking-advanced-clusterDomain}
 
 ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster.
 
@@ -328,7 +328,7 @@ ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-fallbackHostCluster}
+#### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networking-advanced-fallbackHostCluster}
 
 FallbackHostCluster allows to fallback dns to the host cluster. This is useful if you want to reach host services without
 any other modification. You will need to provide a namespace for the service, e.g. my-other-service.my-other-namespace
@@ -344,7 +344,7 @@ any other modification. You will need to provide a namespace for the service, e.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-proxyKubelets}
+#### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets}
 
 ProxyKubelets allows rewriting certain metrics and stats from the Kubelet to "fake" this for applications such as
 prometheus or other node exporters.
@@ -357,7 +357,7 @@ prometheus or other node exporters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-proxyKubelets-byHostname}
+##### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets-byHostname}
 
 ByHostname will add a special vCluster hostname to the nodes where the node can be reached at. This doesn't work
 for all applications, e.g. Prometheus requires a node IP.
@@ -373,7 +373,7 @@ for all applications, e.g. Prometheus requires a node IP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-proxyKubelets-byIP}
+##### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets-byIP}
 
 ByIP will create a separate service in the host cluster for every node that will point to virtual cluster and will be used to
 route traffic.

--- a/vcluster/_partials/config/networking/advanced.mdx
+++ b/vcluster/_partials/config/networking/advanced.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced}
+## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced}
 
 Advanced holds advanced network options.
 
@@ -14,7 +14,7 @@ Advanced holds advanced network options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-clusterDomain}
+### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> {#advanced-clusterDomain}
 
 ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster.
 
@@ -29,7 +29,7 @@ ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-fallbackHostCluster}
+### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-fallbackHostCluster}
 
 FallbackHostCluster allows to fallback dns to the host cluster. This is useful if you want to reach host services without
 any other modification. You will need to provide a namespace for the service, e.g. my-other-service.my-other-namespace
@@ -45,7 +45,7 @@ any other modification. You will need to provide a namespace for the service, e.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-proxyKubelets}
+### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-proxyKubelets}
 
 ProxyKubelets allows rewriting certain metrics and stats from the Kubelet to "fake" this for applications such as
 prometheus or other node exporters.
@@ -58,7 +58,7 @@ prometheus or other node exporters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-proxyKubelets-byHostname}
+#### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-proxyKubelets-byHostname}
 
 ByHostname will add a special vCluster hostname to the nodes where the node can be reached at. This doesn't work
 for all applications, e.g. Prometheus requires a node IP.
@@ -74,7 +74,7 @@ for all applications, e.g. Prometheus requires a node IP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-proxyKubelets-byIP}
+#### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-proxyKubelets-byIP}
 
 ByIP will create a separate service in the host cluster for every node that will point to virtual cluster and will be used to
 route traffic.

--- a/vcluster/_partials/config/networking/replicateServices.mdx
+++ b/vcluster/_partials/config/networking/replicateServices.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices}
+## `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices}
 
 ReplicateServices allows replicating services from the host within the virtual cluster or the other way around.
 
@@ -14,7 +14,7 @@ ReplicateServices allows replicating services from the host within the virtual c
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-toHost}
+### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost}
 
 ToHost defines the services that should get synced from virtual cluster to the host cluster. If services are
 synced to a different namespace than the virtual cluster is in, additional permissions for the other namespace
@@ -28,7 +28,7 @@ are required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-toHost-from}
+#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -43,7 +43,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-toHost-to}
+#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 
@@ -61,7 +61,7 @@ To is the target service that it should get synced to. Can be either in the form
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-fromHost}
+### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost}
 
 FromHost defines the services that should get synced from the host to the virtual cluster.
 
@@ -73,7 +73,7 @@ FromHost defines the services that should get synced from the host to the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-fromHost-from}
+#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -88,7 +88,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-fromHost-to}
+#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 

--- a/vcluster/_partials/config/networking/resolveDNS.mdx
+++ b/vcluster/_partials/config/networking/resolveDNS.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS}
+## `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS}
 
 ResolveDNS allows to define extra DNS rules. This only works if embedded coredns is configured.
 
@@ -14,7 +14,7 @@ ResolveDNS allows to define extra DNS rules. This only works if embedded coredns
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-hostname}
+### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-hostname}
 
 Hostname is the hostname within the vCluster that should be resolved from.
 
@@ -29,7 +29,7 @@ Hostname is the hostname within the vCluster that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-service}
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-service}
 
 Service is the virtual cluster service that should be resolved from.
 
@@ -44,7 +44,7 @@ Service is the virtual cluster service that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-namespace}
+### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-namespace}
 
 Namespace is the virtual cluster namespace that should be resolved from.
 
@@ -59,7 +59,7 @@ Namespace is the virtual cluster namespace that should be resolved from.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target}
+### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target}
 
 Target is the DNS target that should get mapped to
 
@@ -71,7 +71,7 @@ Target is the DNS target that should get mapped to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-hostname}
+#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostname}
 
 Hostname to use as a DNS target
 
@@ -86,7 +86,7 @@ Hostname to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-ip}
+#### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-ip}
 
 IP to use as a DNS target
 
@@ -101,7 +101,7 @@ IP to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-hostService}
+#### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostService}
 
 HostService to target, format is hostNamespace/hostService
 
@@ -116,7 +116,7 @@ HostService to target, format is hostNamespace/hostService
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-hostNamespace}
+#### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostNamespace}
 
 HostNamespace to target
 
@@ -131,7 +131,7 @@ HostNamespace to target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-vClusterService}
+#### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-vClusterService}
 
 VClusterService format is hostNamespace/vClusterName/vClusterNamespace/vClusterService
 

--- a/vcluster/_partials/config/plugins.mdx
+++ b/vcluster/_partials/config/plugins.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `plugins` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins}
+## `plugins` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins}
 
 Define which vCluster plugins to load.
 
@@ -14,7 +14,7 @@ Define which vCluster plugins to load.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-name}
 
 Name is the name of the init-container and NOT the plugin name
 
@@ -29,7 +29,7 @@ Name is the name of the init-container and NOT the plugin name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-image}
+### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-image}
 
 Image is the container image that should be used for the plugin
 
@@ -44,7 +44,7 @@ Image is the container image that should be used for the plugin
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-imagePullPolicy}
 
 ImagePullPolicy is the pull policy to use for the container image
 
@@ -59,7 +59,7 @@ ImagePullPolicy is the pull policy to use for the container image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-config}
+### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-config}
 
 Config is the plugin config to use. This can be arbitrary config used for the plugin.
 
@@ -74,7 +74,7 @@ Config is the plugin config to use. This can be arbitrary config used for the pl
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac}
+### `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac}
 
 RBAC holds additional rbac configuration for the plugin
 
@@ -86,7 +86,7 @@ RBAC holds additional rbac configuration for the plugin
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role}
+#### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role}
 
 Role holds extra virtual cluster role permissions for the plugin
 
@@ -98,7 +98,7 @@ Role holds extra virtual cluster role permissions for the plugin
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules}
 
 ExtraRules are extra rbac permissions roles that will be added to role or cluster role
 
@@ -110,7 +110,7 @@ ExtraRules are extra rbac permissions roles that will be added to role or cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-verbs}
 
 Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 
@@ -125,7 +125,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this r
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-apiGroups}
 
 APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
@@ -141,7 +141,7 @@ the enumerated resources in any API group will be allowed. "" represents the cor
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-resources}
 
 Resources is a list of resources this rule applies to. '*' represents all resources.
 
@@ -156,7 +156,7 @@ Resources is a list of resources this rule applies to. '*' represents all resour
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-resourceNames}
 
 ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 
@@ -171,7 +171,7 @@ ResourceNames is an optional white list of names that the rule applies to.  An e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-nonResourceURLs}
 
 NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
@@ -194,7 +194,7 @@ Rules can either apply to API resources (such as "pods" or "secrets") or non-res
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole}
 
 ClusterRole holds extra virtual cluster cluster role permissions required for the plugin
 
@@ -206,7 +206,7 @@ ClusterRole holds extra virtual cluster cluster role permissions required for th
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules}
 
 ExtraRules are extra rbac permissions roles that will be added to role or cluster role
 
@@ -218,7 +218,7 @@ ExtraRules are extra rbac permissions roles that will be added to role or cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-verbs}
 
 Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 
@@ -233,7 +233,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this r
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-apiGroups}
 
 APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
@@ -249,7 +249,7 @@ the enumerated resources in any API group will be allowed. "" represents the cor
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-resources}
 
 Resources is a list of resources this rule applies to. '*' represents all resources.
 
@@ -264,7 +264,7 @@ Resources is a list of resources this rule applies to. '*' represents all resour
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-resourceNames}
 
 ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 
@@ -279,7 +279,7 @@ ResourceNames is an optional white list of names that the rule applies to.  An e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-nonResourceURLs}
 
 NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
@@ -305,7 +305,7 @@ Rules can either apply to API resources (such as "pods" or "secrets") or non-res
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-command}
+### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-command}
 
 Command is the command that should be used for the init container
 
@@ -320,7 +320,7 @@ Command is the command that should be used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-args}
+### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-args}
 
 Args are the arguments that should be used for the init container
 
@@ -335,7 +335,7 @@ Args are the arguments that should be used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-securityContext}
+### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-securityContext}
 
 SecurityContext is the container security context used for the init container
 
@@ -350,7 +350,7 @@ SecurityContext is the container security context used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-resources}
 
 Resources are the container resources used for the init container
 
@@ -365,7 +365,7 @@ Resources are the container resources used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `volumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-volumeMounts}
+### `volumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-volumeMounts}
 
 VolumeMounts are extra volume mounts for the init container
 

--- a/vcluster/_partials/config/policies.mdx
+++ b/vcluster/_partials/config/policies.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `policies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies}
+## `policies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies}
 
 Policies to enforce for the virtual cluster deployment as well as within the virtual cluster.
 
@@ -14,7 +14,7 @@ Policies to enforce for the virtual cluster deployment as well as within the vir
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy}
+### `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy}
 
 NetworkPolicy specifies network policy options.
 
@@ -26,7 +26,7 @@ NetworkPolicy specifies network policy options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#policies-networkPolicy-enabled}
 
 Enabled defines if the network policy should be deployed by vCluster.
 
@@ -41,7 +41,7 @@ Enabled defines if the network policy should be deployed by vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-fallbackDns}
+#### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> {#policies-networkPolicy-fallbackDns}
 
 FallbackDNS is the fallback DNS server to use if the virtual cluster does not have a DNS server.
 
@@ -56,7 +56,7 @@ FallbackDNS is the fallback DNS server to use if the virtual cluster does not ha
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `outgoingConnections` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections}
+#### `outgoingConnections` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections}
 
 OutgoingConnections are the outgoing connections options for the vCluster workloads.
 
@@ -68,7 +68,7 @@ OutgoingConnections are the outgoing connections options for the vCluster worklo
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections-ipBlock}
 
 IPBlock describes a particular CIDR (Ex. "192.168.1.0/24","2001:db8::/64") that is allowed
 to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs
@@ -82,7 +82,7 @@ that should not be included within this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections-ipBlock-cidr}
 
 cidr is a string representing the IPBlock
 Valid examples are "192.168.1.0/24" or "2001:db8::/64"
@@ -98,7 +98,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections-ipBlock-except}
 
 except is a slice of CIDRs that should not be included within an IPBlock
 Valid examples are "192.168.1.0/24" or "2001:db8::/64"
@@ -118,7 +118,7 @@ Except values will be rejected if they are outside the cidr range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections-platform}
+##### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections-platform}
 
 Platform enables egress access towards loft platform
 
@@ -136,7 +136,7 @@ Platform enables egress access towards loft platform
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraControlPlaneRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-extraControlPlaneRules}
+#### `extraControlPlaneRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-extraControlPlaneRules}
 
 ExtraControlPlaneRules are extra allowed rules for the vCluster control plane.
 
@@ -151,7 +151,7 @@ ExtraControlPlaneRules are extra allowed rules for the vCluster control plane.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraWorkloadRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-extraWorkloadRules}
+#### `extraWorkloadRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-extraWorkloadRules}
 
 ExtraWorkloadRules are extra allowed rules for the vCluster workloads.
 
@@ -166,7 +166,7 @@ ExtraWorkloadRules are extra allowed rules for the vCluster workloads.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -181,7 +181,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-labels}
 
 Labels are extra labels for this resource.
 
@@ -199,7 +199,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-podSecurityStandard}
+### `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-podSecurityStandard}
 
 PodSecurityStandard that can be enforced can be one of: empty (""), baseline, restricted or privileged
 
@@ -214,7 +214,7 @@ PodSecurityStandard that can be enforced can be one of: empty (""), baseline, re
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota}
+### `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-resourceQuota}
 
 ResourceQuota specifies resource quota options.
 
@@ -226,7 +226,7 @@ ResourceQuota specifies resource quota options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#policies-resourceQuota-enabled}
 
 Enabled defines if the resource quota should be enabled. "auto" means that if limitRange is enabled,
 the resourceQuota will be enabled as well.
@@ -242,7 +242,7 @@ the resourceQuota will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-quota}
+#### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-quota}
 
 Quota are the quota options
 
@@ -257,7 +257,7 @@ Quota are the quota options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-scopeSelector}
+#### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-scopeSelector}
 
 ScopeSelector is the resource quota scope selector
 
@@ -272,7 +272,7 @@ ScopeSelector is the resource quota scope selector
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-scopes}
+#### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-scopes}
 
 Scopes are the resource quota scopes
 
@@ -287,7 +287,7 @@ Scopes are the resource quota scopes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -302,7 +302,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-labels}
 
 Labels are extra labels for this resource.
 
@@ -320,7 +320,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange}
+### `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-limitRange}
 
 LimitRange specifies limit range options.
 
@@ -332,7 +332,7 @@ LimitRange specifies limit range options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#policies-limitRange-enabled}
 
 Enabled defines if the limit range should be deployed by vCluster. "auto" means that if resourceQuota is enabled,
 the limitRange will be enabled as well.
@@ -348,7 +348,7 @@ the limitRange will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-default}
+#### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> {#policies-limitRange-default}
 
 Default are the default limits for the limit range
 
@@ -363,7 +363,7 @@ Default are the default limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-defaultRequest}
+#### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> {#policies-limitRange-defaultRequest}
 
 DefaultRequest are the default request options for the limit range
 
@@ -378,7 +378,7 @@ DefaultRequest are the default request options for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-max}
+#### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-max}
 
 Max are the max limits for the limit range
 
@@ -393,7 +393,7 @@ Max are the max limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-min}
+#### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-min}
 
 Min are the min limits for the limit range
 
@@ -408,7 +408,7 @@ Min are the min limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -423,7 +423,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-labels}
 
 Labels are extra labels for this resource.
 
@@ -441,7 +441,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission}
+### `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission}
 
 CentralAdmission defines what validating or mutating webhooks should be enforced within the virtual cluster.
 
@@ -453,7 +453,7 @@ CentralAdmission defines what validating or mutating webhooks should be enforced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks}
+#### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks}
 
 ValidatingWebhooks are validating webhooks that should be enforced in the virtual cluster
 
@@ -465,7 +465,7 @@ ValidatingWebhooks are validating webhooks that should be enforced in the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -481,7 +481,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -498,7 +498,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -510,7 +510,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -528,7 +528,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -545,7 +545,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -564,7 +564,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks}
+##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -576,7 +576,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -594,7 +594,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -606,7 +606,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -623,7 +623,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -638,7 +638,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -653,7 +653,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -668,7 +668,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -684,7 +684,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -704,7 +704,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -723,7 +723,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -739,7 +739,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -755,7 +755,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -771,7 +771,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -790,7 +790,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -808,7 +808,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -823,7 +823,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -838,7 +838,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -854,7 +854,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,
@@ -878,7 +878,7 @@ There are a maximum of 64 match conditions allowed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks}
+#### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks}
 
 MutatingWebhooks are mutating webhooks that should be enforced in the virtual cluster
 
@@ -890,7 +890,7 @@ MutatingWebhooks are mutating webhooks that should be enforced in the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -906,7 +906,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -923,7 +923,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -935,7 +935,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -953,7 +953,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -970,7 +970,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -989,7 +989,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks}
+##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -1001,7 +1001,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
+##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
 
 reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation.
 Allowed values are "Never" and "IfNeeded".
@@ -1017,7 +1017,7 @@ Allowed values are "Never" and "IfNeeded".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -1035,7 +1035,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -1047,7 +1047,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -1064,7 +1064,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -1079,7 +1079,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -1094,7 +1094,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -1109,7 +1109,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -1125,7 +1125,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -1145,7 +1145,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -1164,7 +1164,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -1180,7 +1180,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -1196,7 +1196,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -1212,7 +1212,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -1231,7 +1231,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -1249,7 +1249,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -1264,7 +1264,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -1279,7 +1279,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -1295,7 +1295,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,

--- a/vcluster/_partials/config/policies/centralAdmission.mdx
+++ b/vcluster/_partials/config/policies/centralAdmission.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission}
+## `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission}
 
 CentralAdmission defines what validating or mutating webhooks should be enforced within the virtual cluster.
 
@@ -14,7 +14,7 @@ CentralAdmission defines what validating or mutating webhooks should be enforced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks}
+### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks}
 
 ValidatingWebhooks are validating webhooks that should be enforced in the virtual cluster
 
@@ -26,7 +26,7 @@ ValidatingWebhooks are validating webhooks that should be enforced in the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -42,7 +42,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -59,7 +59,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -71,7 +71,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -89,7 +89,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -106,7 +106,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -125,7 +125,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks}
+#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -137,7 +137,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -155,7 +155,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -167,7 +167,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -184,7 +184,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -199,7 +199,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -214,7 +214,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -229,7 +229,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -245,7 +245,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -265,7 +265,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -284,7 +284,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -300,7 +300,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -316,7 +316,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -332,7 +332,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -351,7 +351,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -369,7 +369,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -384,7 +384,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -399,7 +399,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -415,7 +415,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,
@@ -439,7 +439,7 @@ There are a maximum of 64 match conditions allowed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks}
+### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks}
 
 MutatingWebhooks are mutating webhooks that should be enforced in the virtual cluster
 
@@ -451,7 +451,7 @@ MutatingWebhooks are mutating webhooks that should be enforced in the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -467,7 +467,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -484,7 +484,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -496,7 +496,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -514,7 +514,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -531,7 +531,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -550,7 +550,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks}
+#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -562,7 +562,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
+##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
 
 reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation.
 Allowed values are "Never" and "IfNeeded".
@@ -578,7 +578,7 @@ Allowed values are "Never" and "IfNeeded".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -596,7 +596,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -608,7 +608,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -625,7 +625,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -640,7 +640,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -655,7 +655,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -670,7 +670,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -686,7 +686,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -706,7 +706,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -725,7 +725,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -741,7 +741,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -757,7 +757,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -773,7 +773,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -792,7 +792,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -810,7 +810,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -825,7 +825,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -840,7 +840,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -856,7 +856,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,

--- a/vcluster/_partials/config/policies/limitRange.mdx
+++ b/vcluster/_partials/config/policies/limitRange.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange}
+## `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#limitRange}
 
 LimitRange specifies limit range options.
 
@@ -14,7 +14,7 @@ LimitRange specifies limit range options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#limitRange-enabled}
 
 Enabled defines if the limit range should be deployed by vCluster. "auto" means that if resourceQuota is enabled,
 the limitRange will be enabled as well.
@@ -30,7 +30,7 @@ the limitRange will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-default}
+### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> {#limitRange-default}
 
 Default are the default limits for the limit range
 
@@ -45,7 +45,7 @@ Default are the default limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-defaultRequest}
+### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> {#limitRange-defaultRequest}
 
 DefaultRequest are the default request options for the limit range
 
@@ -60,7 +60,7 @@ DefaultRequest are the default request options for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-max}
+### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-max}
 
 Max are the max limits for the limit range
 
@@ -75,7 +75,7 @@ Max are the max limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-min}
+### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-min}
 
 Min are the min limits for the limit range
 
@@ -90,7 +90,7 @@ Min are the min limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -105,7 +105,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster/_partials/config/policies/networkPolicy.mdx
+++ b/vcluster/_partials/config/policies/networkPolicy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy}
+## `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy}
 
 NetworkPolicy specifies network policy options.
 
@@ -14,7 +14,7 @@ NetworkPolicy specifies network policy options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networkPolicy-enabled}
 
 Enabled defines if the network policy should be deployed by vCluster.
 
@@ -29,7 +29,7 @@ Enabled defines if the network policy should be deployed by vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-fallbackDns}
+### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> {#networkPolicy-fallbackDns}
 
 FallbackDNS is the fallback DNS server to use if the virtual cluster does not have a DNS server.
 
@@ -44,7 +44,7 @@ FallbackDNS is the fallback DNS server to use if the virtual cluster does not ha
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `outgoingConnections` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections}
+### `outgoingConnections` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections}
 
 OutgoingConnections are the outgoing connections options for the vCluster workloads.
 
@@ -56,7 +56,7 @@ OutgoingConnections are the outgoing connections options for the vCluster worklo
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections-ipBlock}
+#### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections-ipBlock}
 
 IPBlock describes a particular CIDR (Ex. "192.168.1.0/24","2001:db8::/64") that is allowed
 to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs
@@ -70,7 +70,7 @@ that should not be included within this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections-ipBlock-cidr}
 
 cidr is a string representing the IPBlock
 Valid examples are "192.168.1.0/24" or "2001:db8::/64"
@@ -86,7 +86,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections-ipBlock-except}
 
 except is a slice of CIDRs that should not be included within an IPBlock
 Valid examples are "192.168.1.0/24" or "2001:db8::/64"
@@ -106,7 +106,7 @@ Except values will be rejected if they are outside the cidr range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections-platform}
+#### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections-platform}
 
 Platform enables egress access towards loft platform
 
@@ -124,7 +124,7 @@ Platform enables egress access towards loft platform
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraControlPlaneRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-extraControlPlaneRules}
+### `extraControlPlaneRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#networkPolicy-extraControlPlaneRules}
 
 ExtraControlPlaneRules are extra allowed rules for the vCluster control plane.
 
@@ -139,7 +139,7 @@ ExtraControlPlaneRules are extra allowed rules for the vCluster control plane.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraWorkloadRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-extraWorkloadRules}
+### `extraWorkloadRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#networkPolicy-extraWorkloadRules}
 
 ExtraWorkloadRules are extra allowed rules for the vCluster workloads.
 
@@ -154,7 +154,7 @@ ExtraWorkloadRules are extra allowed rules for the vCluster workloads.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#networkPolicy-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -169,7 +169,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#networkPolicy-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster/_partials/config/policies/podSecurityStandard.mdx
+++ b/vcluster/_partials/config/policies/podSecurityStandard.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podSecurityStandard}
+## `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podSecurityStandard}
 
 PodSecurityStandard that can be enforced can be one of: empty (""), baseline, restricted or privileged
 

--- a/vcluster/_partials/config/policies/resourceQuota.mdx
+++ b/vcluster/_partials/config/policies/resourceQuota.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota}
+## `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resourceQuota}
 
 ResourceQuota specifies resource quota options.
 
@@ -14,7 +14,7 @@ ResourceQuota specifies resource quota options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#resourceQuota-enabled}
 
 Enabled defines if the resource quota should be enabled. "auto" means that if limitRange is enabled,
 the resourceQuota will be enabled as well.
@@ -30,7 +30,7 @@ the resourceQuota will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-quota}
+### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-quota}
 
 Quota are the quota options
 
@@ -45,7 +45,7 @@ Quota are the quota options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-scopeSelector}
+### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-scopeSelector}
 
 ScopeSelector is the resource quota scope selector
 
@@ -60,7 +60,7 @@ ScopeSelector is the resource quota scope selector
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-scopes}
+### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-scopes}
 
 Scopes are the resource quota scopes
 
@@ -75,7 +75,7 @@ Scopes are the resource quota scopes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#resourceQuota-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -90,7 +90,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#resourceQuota-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster/_partials/config/privateNodes.mdx
+++ b/vcluster/_partials/config/privateNodes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `privateNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes}
+## `privateNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes}
 
 PrivateNodes holds configuration for vCluster private nodes mode.
 
@@ -14,7 +14,7 @@ PrivateNodes holds configuration for vCluster private nodes mode.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-enabled}
 
 Enabled defines if dedicated nodes should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if dedicated nodes should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `importNodeBinaries` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-importNodeBinaries}
+### `importNodeBinaries` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-importNodeBinaries}
 
 ImportNodeBinaries defines to use the loft-sh/kubernetes:VERSION-full image to also copy the node binaries to the control plane. This allows upgrades and
 joining new nodes into the cluster without having to download the binaries from the internet.
@@ -45,7 +45,7 @@ joining new nodes into the cluster without having to download the binaries from 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `kubelet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-kubelet}
+### `kubelet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-kubelet}
 
 Kubelet holds kubelet configuration that is used for all nodes.
 
@@ -57,7 +57,7 @@ Kubelet holds kubelet configuration that is used for all nodes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `cgroupDriver` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-kubelet-cgroupDriver}
+#### `cgroupDriver` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-kubelet-cgroupDriver}
 
 CgroupDriver defines the cgroup driver to use for the kubelet.
 
@@ -75,7 +75,7 @@ CgroupDriver defines the cgroup driver to use for the kubelet.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoUpgrade` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-autoUpgrade}
+### `autoUpgrade` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade}
 
 AutoUpgrade holds configuration for auto upgrade.
 
@@ -87,7 +87,7 @@ AutoUpgrade holds configuration for auto upgrade.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-autoUpgrade-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-enabled}
 
 Enabled defines if auto upgrade should be enabled.
 
@@ -102,7 +102,7 @@ Enabled defines if auto upgrade should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-autoUpgrade-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-image}
 
 Image is the image for the auto upgrade pod started by vCluster. If empty defaults to the controlPlane.statefulSet.image.
 
@@ -117,7 +117,7 @@ Image is the image for the auto upgrade pod started by vCluster. If empty defaul
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-autoUpgrade-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -132,7 +132,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-autoUpgrade-nodeSelector}
+#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-nodeSelector}
 
 NodeSelector is the node selector for the auto upgrade. If empty will select all worker nodes.
 
@@ -147,7 +147,7 @@ NodeSelector is the node selector for the auto upgrade. If empty will select all
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `bundleRepository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-autoUpgrade-bundleRepository}
+#### `bundleRepository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-bundleRepository}
 
 BundleRepository is the repository to use for downloading the Kubernetes bundle. Defaults to https://github.com/loft-sh/kubernetes/releases/download
 
@@ -162,7 +162,7 @@ BundleRepository is the repository to use for downloading the Kubernetes bundle.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `binariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-autoUpgrade-binariesPath}
+#### `binariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-binariesPath}
 
 BinariesPath is the base path for the kubeadm binaries. Defaults to /usr/local/bin
 
@@ -177,7 +177,7 @@ BinariesPath is the base path for the kubeadm binaries. Defaults to /usr/local/b
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `cniBinariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-autoUpgrade-cniBinariesPath}
+#### `cniBinariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-cniBinariesPath}
 
 CNIBinariesPath is the base path for the CNI binaries. Defaults to /opt/cni/bin
 
@@ -192,7 +192,7 @@ CNIBinariesPath is the base path for the CNI binaries. Defaults to /opt/cni/bin
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `concurrency` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-autoUpgrade-concurrency}
+#### `concurrency` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-concurrency}
 
 Concurrency is the number of nodes that can be upgraded at the same time.
 
@@ -210,7 +210,7 @@ Concurrency is the number of nodes that can be upgraded at the same time.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `joinNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode}
+### `joinNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode}
 
 JoinNode holds configuration specifically used during joining the node (see "kubeadm join").
 
@@ -222,7 +222,7 @@ JoinNode holds configuration specifically used during joining the node (see "kub
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `preJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-preJoinCommands}
+#### `preJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-preJoinCommands}
 
 PreJoinCommands are commands that will be executed before the join process starts.
 
@@ -237,7 +237,7 @@ PreJoinCommands are commands that will be executed before the join process start
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `postJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-postJoinCommands}
+#### `postJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-postJoinCommands}
 
 PostJoinCommands are commands that will be executed after the join process starts.
 
@@ -252,7 +252,7 @@ PostJoinCommands are commands that will be executed after the join process start
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `containerd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-containerd}
+#### `containerd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd}
 
 Containerd holds configuration for the containerd join process.
 
@@ -264,7 +264,7 @@ Containerd holds configuration for the containerd join process.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-containerd-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-enabled}
 
 Enabled defines if containerd should be installed and configured by vCluster.
 
@@ -279,7 +279,7 @@ Enabled defines if containerd should be installed and configured by vCluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-containerd-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry}
 
 Registry holds configuration for how containerd should be configured to use a registries.
 
@@ -291,7 +291,7 @@ Registry holds configuration for how containerd should be configured to use a re
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-containerd-registry-configPath}
+##### `configPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-configPath}
 
 ConfigPath is the path to the containerd registry config.
 
@@ -306,7 +306,7 @@ ConfigPath is the path to the containerd registry config.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mirrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-containerd-registry-mirrors}
+##### `mirrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors}
 
 Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry.io:5000 or docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -318,7 +318,7 @@ Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-containerd-registry-mirrors-server}
+##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-server}
 
 Server is the fallback server to use for the containerd registry mirror. E.g. https://registry-1.docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -333,7 +333,7 @@ Server is the fallback server to use for the containerd registry mirror. E.g. ht
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-containerd-registry-mirrors-caCert}
+##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror.
 
@@ -348,7 +348,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-containerd-registry-mirrors-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -363,7 +363,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-containerd-registry-mirrors-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -378,7 +378,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `hosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts}
+##### `hosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts}
 
 Hosts holds configuration for the containerd registry mirror hosts. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
 
@@ -390,7 +390,7 @@ Hosts holds configuration for the containerd registry mirror hosts. See https://
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-server}
+##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-server}
 
 Server is the server to use for the containerd registry mirror host. E.g. http://192.168.31.250:5000.
 
@@ -405,7 +405,7 @@ Server is the server to use for the containerd registry mirror host. E.g. http:/
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-caCert}
+##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-caCert}
 
 CACert are paths to CA certificates to use for the containerd registry mirror host.
 
@@ -420,7 +420,7 @@ CACert are paths to CA certificates to use for the containerd registry mirror ho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-skipVerify}
+##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-skipVerify}
 
 SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
 
@@ -435,7 +435,7 @@ SkipVerify is a boolean to skip the certificate verification for the containerd 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-capabilities}
+##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-capabilities}
 
 Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
 
@@ -459,7 +459,7 @@ Capabilities is a list of capabilities to enable for the containerd registry mir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `importImages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-containerd-importImages}
+##### `importImages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-importImages}
 
 ImportImages is a list of images to import into the containerd registry from local files. If the path is a folder, all files that end with .tar or .tar.gz in the folder will be imported.
 
@@ -474,7 +474,7 @@ ImportImages is a list of images to import into the containerd registry from loc
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `pauseImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-containerd-pauseImage}
+##### `pauseImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-pauseImage}
 
 PauseImage is the image for the pause container.
 
@@ -492,7 +492,7 @@ PauseImage is the image for the pause container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `caCertPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-caCertPath}
+#### `caCertPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-caCertPath}
 
 CACertPath is the path to the SSL certificate authority used to
 secure communications between node and control-plane.
@@ -509,7 +509,7 @@ Defaults to "/etc/kubernetes/pki/ca.crt".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `skipPhases` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-skipPhases}
+#### `skipPhases` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-skipPhases}
 
 SkipPhases is a list of phases to skip during command execution.
 The list of phases can be obtained with the "kubeadm join --help" command.
@@ -525,7 +525,7 @@ The list of phases can be obtained with the "kubeadm join --help" command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodeRegistration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-nodeRegistration}
+#### `nodeRegistration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration}
 
 NodeRegistration holds configuration for the node registration similar to the kubeadm node registration.
 
@@ -537,7 +537,7 @@ NodeRegistration holds configuration for the node registration similar to the ku
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `criSocket` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-nodeRegistration-criSocket}
+##### `criSocket` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-criSocket}
 
 CRI socket is the socket for the CRI.
 
@@ -552,7 +552,7 @@ CRI socket is the socket for the CRI.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `kubeletExtraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs}
+##### `kubeletExtraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs}
 
 KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
 kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config ConfigMap
@@ -568,7 +568,7 @@ Extra arguments will override existing default arguments. Duplicate extra argume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs-name}
 
 Name is the name of the argument.
 
@@ -583,7 +583,7 @@ Name is the name of the argument.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs-value}
 
 Value is the value of the argument.
 
@@ -601,7 +601,7 @@ Value is the value of the argument.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-nodeRegistration-taints}
+##### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints}
 
 Taints are additional taints to set for the kubelet.
 
@@ -613,7 +613,7 @@ Taints are additional taints to set for the kubelet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-nodeRegistration-taints-key}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints-key}
 
 Required. The taint key to be applied to a node.
 
@@ -628,7 +628,7 @@ Required. The taint key to be applied to a node.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-nodeRegistration-taints-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints-value}
 
 The taint value corresponding to the taint key.
 
@@ -643,7 +643,7 @@ The taint value corresponding to the taint key.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-nodeRegistration-taints-effect}
+##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints-effect}
 
 Required. The effect of the taint on pods
 that do not tolerate the taint.
@@ -663,7 +663,7 @@ Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignorePreflightErrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-nodeRegistration-ignorePreflightErrors}
+##### `ignorePreflightErrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-ignorePreflightErrors}
 
 IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered, e.g. 'IsPrivilegedUser,Swap'.
 Value 'all' ignores errors from all checks.
@@ -679,7 +679,7 @@ Value 'all' ignores errors from all checks.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#privateNodes-joinNode-nodeRegistration-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-imagePullPolicy}
 
 ImagePullPolicy specifies the policy for image pulling during kubeadm "init" and "join" operations.
 The value of this field must be one of "Always", "IfNotPresent" or "Never".

--- a/vcluster/_partials/config/privateNodes/autoUpgrade.mdx
+++ b/vcluster/_partials/config/privateNodes/autoUpgrade.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `autoUpgrade` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoUpgrade}
+## `autoUpgrade` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade}
 
 AutoUpgrade holds configuration for auto upgrade.
 
@@ -14,7 +14,7 @@ AutoUpgrade holds configuration for auto upgrade.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoUpgrade-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#autoUpgrade-enabled}
 
 Enabled defines if auto upgrade should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if auto upgrade should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoUpgrade-image}
+### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-image}
 
 Image is the image for the auto upgrade pod started by vCluster. If empty defaults to the controlPlane.statefulSet.image.
 
@@ -44,7 +44,7 @@ Image is the image for the auto upgrade pod started by vCluster. If empty defaul
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoUpgrade-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -59,7 +59,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoUpgrade-nodeSelector}
+### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-nodeSelector}
 
 NodeSelector is the node selector for the auto upgrade. If empty will select all worker nodes.
 
@@ -74,7 +74,7 @@ NodeSelector is the node selector for the auto upgrade. If empty will select all
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `bundleRepository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoUpgrade-bundleRepository}
+### `bundleRepository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-bundleRepository}
 
 BundleRepository is the repository to use for downloading the Kubernetes bundle. Defaults to https://github.com/loft-sh/kubernetes/releases/download
 
@@ -89,7 +89,7 @@ BundleRepository is the repository to use for downloading the Kubernetes bundle.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `binariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoUpgrade-binariesPath}
+### `binariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-binariesPath}
 
 BinariesPath is the base path for the kubeadm binaries. Defaults to /usr/local/bin
 
@@ -104,7 +104,7 @@ BinariesPath is the base path for the kubeadm binaries. Defaults to /usr/local/b
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `cniBinariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoUpgrade-cniBinariesPath}
+### `cniBinariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-cniBinariesPath}
 
 CNIBinariesPath is the base path for the CNI binaries. Defaults to /opt/cni/bin
 
@@ -119,7 +119,7 @@ CNIBinariesPath is the base path for the CNI binaries. Defaults to /opt/cni/bin
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `concurrency` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#autoUpgrade-concurrency}
+### `concurrency` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#autoUpgrade-concurrency}
 
 Concurrency is the number of nodes that can be upgraded at the same time.
 

--- a/vcluster/_partials/config/rbac.mdx
+++ b/vcluster/_partials/config/rbac.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac}
+## `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac}
 
 RBAC options for the virtual cluster.
 
@@ -14,7 +14,7 @@ RBAC options for the virtual cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-role}
+### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-role}
 
 Role holds virtual cluster role configuration
 
@@ -26,7 +26,7 @@ Role holds virtual cluster role configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-role-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#rbac-role-enabled}
 
 Enabled defines if the role should be enabled or disabled.
 
@@ -41,7 +41,7 @@ Enabled defines if the role should be enabled or disabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-role-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-role-extraRules}
 
 ExtraRules will add rules to the role.
 
@@ -56,7 +56,7 @@ ExtraRules will add rules to the role.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-role-overwriteRules}
+#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-role-overwriteRules}
 
 OverwriteRules will overwrite the role rules completely.
 
@@ -74,7 +74,7 @@ OverwriteRules will overwrite the role rules completely.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-clusterRole}
+### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-clusterRole}
 
 ClusterRole holds virtual cluster cluster role configuration
 
@@ -86,7 +86,7 @@ ClusterRole holds virtual cluster cluster role configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-clusterRole-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#rbac-clusterRole-enabled}
 
 Enabled defines if the cluster role should be enabled or disabled. If auto, vCluster automatically determines whether the virtual cluster requires a cluster role.
 
@@ -101,7 +101,7 @@ Enabled defines if the cluster role should be enabled or disabled. If auto, vClu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-clusterRole-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-clusterRole-extraRules}
 
 ExtraRules will add rules to the cluster role.
 
@@ -116,7 +116,7 @@ ExtraRules will add rules to the cluster role.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-clusterRole-overwriteRules}
+#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-clusterRole-overwriteRules}
 
 OverwriteRules will overwrite the cluster role rules completely.
 

--- a/vcluster/_partials/config/sleepMode.mdx
+++ b/vcluster/_partials/config/sleepMode.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `sleepMode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode}
+## `sleepMode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode}
 
 SleepMode holds the native sleep mode configuration for Pro clusters
 
@@ -14,7 +14,7 @@ SleepMode holds the native sleep mode configuration for Pro clusters
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-enabled}
 
 Enabled toggles the sleep mode functionality, allowing for disabling sleep mode without removing other config
 
@@ -29,7 +29,7 @@ Enabled toggles the sleep mode functionality, allowing for disabling sleep mode 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `timeZone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-timeZone}
+### `timeZone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-timeZone}
 
 Timezone represents the timezone a sleep schedule should run against, defaulting to UTC if unset
 
@@ -44,7 +44,7 @@ Timezone represents the timezone a sleep schedule should run against, defaulting
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep}
+### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep}
 
 AutoSleep holds autoSleep details
 
@@ -56,7 +56,7 @@ AutoSleep holds autoSleep details
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-afterInactivity}
+#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-afterInactivity}
 
 AfterInactivity represents how long a vCluster can be idle before workloads are automaticaly put to sleep
 
@@ -71,7 +71,7 @@ AfterInactivity represents how long a vCluster can be idle before workloads are 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-schedule}
+#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-schedule}
 
 Schedule represents a cron schedule for when to sleep workloads
 
@@ -86,7 +86,7 @@ Schedule represents a cron schedule for when to sleep workloads
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `exclude` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-exclude}
+#### `exclude` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-exclude}
 
 Exclude holds configuration for labels that, if present, will prevent a workload from going to sleep
 
@@ -98,7 +98,7 @@ Exclude holds configuration for labels that, if present, will prevent a workload
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-exclude-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-exclude-selector}
 
 
 
@@ -110,7 +110,7 @@ Exclude holds configuration for labels that, if present, will prevent a workload
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-exclude-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-exclude-selector-labels}
 
 Labels defines what labels should be looked for
 
@@ -134,7 +134,7 @@ Labels defines what labels should be looked for
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoWakeup}
+### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoWakeup}
 
 AutoWakeup holds configuration for waking the vCluster on a schedule rather than waiting for some activity.
 
@@ -146,7 +146,7 @@ AutoWakeup holds configuration for waking the vCluster on a schedule rather than
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoWakeup-schedule}
+#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoWakeup-schedule}
 
 
 

--- a/vcluster/_partials/config/sync.mdx
+++ b/vcluster/_partials/config/sync.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync}
+## `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync}
 
 Sync describes how to sync resources from the virtual cluster to host cluster and back.
 
@@ -14,7 +14,7 @@ Sync describes how to sync resources from the virtual cluster to host cluster an
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost}
+### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost}
 
 Configure resources to sync from the virtual cluster to the host cluster.
 
@@ -26,7 +26,7 @@ Configure resources to sync from the virtual cluster to the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods}
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods}
 
 Pods defines if pods created within the virtual cluster should get synced to the host cluster.
 
@@ -38,7 +38,7 @@ Pods defines if pods created within the virtual cluster should get synced to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-pods-enabled}
 
 Enabled defines if pod syncing should be enabled.
 
@@ -53,7 +53,7 @@ Enabled defines if pod syncing should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-translateImage}
+##### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-translateImage}
 
 TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite
 a certain image that is used within the virtual cluster to be another image on the host cluster
@@ -69,7 +69,7 @@ a certain image that is used within the virtual cluster to be another image on t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-enforceTolerations}
+##### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-enforceTolerations}
 
 EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster.
 
@@ -84,7 +84,7 @@ EnforceTolerations will add the specified tolerations to all pods synced by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-useSecretsForSATokens}
+##### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-pods-useSecretsForSATokens}
 
 UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a
 pod annotation.
@@ -100,7 +100,7 @@ pod annotation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-runtimeClassName}
+##### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for synced pods.
 
@@ -115,7 +115,7 @@ RuntimeClassName is the runtime class to set for synced pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-priorityClassName}
 
 PriorityClassName is the priority class to set for synced pods.
 
@@ -130,7 +130,7 @@ PriorityClassName is the priority class to set for synced pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts}
+##### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts}
 
 RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
 a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
@@ -144,7 +144,7 @@ the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-enabled}
 
 Enabled specifies if rewriting stateful set pods should be enabled.
 
@@ -159,7 +159,7 @@ Enabled specifies if rewriting stateful set pods should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer}
+##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer}
 
 InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
 
@@ -171,7 +171,7 @@ InitContainer holds extra options for the init container used by vCluster to rew
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image}
 
 Image is the image virtual cluster should use to rewrite this FQDN.
 
@@ -183,7 +183,7 @@ Image is the image virtual cluster should use to rewrite this FQDN.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -199,7 +199,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -214,7 +214,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.20</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.20</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -232,7 +232,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources}
 
 Resources are the resources that should be assigned to the init container for each stateful set init container.
 
@@ -244,7 +244,7 @@ Resources are the resources that should be assigned to the init container for ea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-limits}
 
 Limits are resource limits for the container
 
@@ -259,7 +259,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -283,7 +283,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -295,7 +295,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -310,7 +310,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -325,7 +325,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -340,7 +340,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -354,7 +354,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -369,7 +369,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -384,7 +384,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -399,7 +399,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -414,7 +414,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -429,7 +429,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -448,7 +448,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -466,7 +466,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `hybridScheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-hybridScheduling}
+##### `hybridScheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-hybridScheduling}
 
 HybridScheduling is used to enable and configure hybrid scheduling for pods in the virtual cluster.
 
@@ -478,7 +478,7 @@ HybridScheduling is used to enable and configure hybrid scheduling for pods in t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-hybridScheduling-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-pods-hybridScheduling-enabled}
 
 Enabled specifies if hybrid scheduling is enabled.
 
@@ -493,7 +493,7 @@ Enabled specifies if hybrid scheduling is enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostSchedulers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-hybridScheduling-hostSchedulers}
+##### `hostSchedulers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-hybridScheduling-hostSchedulers}
 
 HostSchedulers is a list of schedulers that are deployed on the host cluster.
 
@@ -514,7 +514,7 @@ HostSchedulers is a list of schedulers that are deployed on the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets}
+#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets}
 
 Secrets defines if secrets created within the virtual cluster should get synced to the host cluster.
 
@@ -526,7 +526,7 @@ Secrets defines if secrets created within the virtual cluster should get synced 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -541,7 +541,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-all}
+##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-secrets-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -556,7 +556,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -568,7 +568,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -583,7 +583,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -598,7 +598,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -613,7 +613,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -627,7 +627,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -642,7 +642,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -657,7 +657,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -672,7 +672,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -687,7 +687,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -702,7 +702,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -721,7 +721,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -742,7 +742,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps}
+#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps}
 
 ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster.
 
@@ -754,7 +754,7 @@ ConfigMaps defines if config maps created within the virtual cluster should get 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -769,7 +769,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-all}
+##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -784,7 +784,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -796,7 +796,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -811,7 +811,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -826,7 +826,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -841,7 +841,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -855,7 +855,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -870,7 +870,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -885,7 +885,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -900,7 +900,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -915,7 +915,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -930,7 +930,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -949,7 +949,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -970,7 +970,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses}
+#### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses}
 
 Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster.
 
@@ -982,7 +982,7 @@ Ingresses defines if ingresses created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -997,7 +997,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1009,7 +1009,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1024,7 +1024,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1039,7 +1039,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1054,7 +1054,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1068,7 +1068,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1083,7 +1083,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1098,7 +1098,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1113,7 +1113,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1128,7 +1128,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1143,7 +1143,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1162,7 +1162,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1183,7 +1183,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services}
+#### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services}
 
 Services defines if services created within the virtual cluster should get synced to the host cluster.
 
@@ -1195,7 +1195,7 @@ Services defines if services created within the virtual cluster should get synce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-services-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1210,7 +1210,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1222,7 +1222,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1237,7 +1237,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1252,7 +1252,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1267,7 +1267,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1281,7 +1281,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1296,7 +1296,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1311,7 +1311,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1326,7 +1326,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1341,7 +1341,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1356,7 +1356,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1375,7 +1375,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1396,7 +1396,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints}
+#### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints}
 
 Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
 
@@ -1408,7 +1408,7 @@ Endpoints defines if endpoints created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1423,7 +1423,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1435,7 +1435,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1450,7 +1450,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1465,7 +1465,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1480,7 +1480,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1494,7 +1494,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1509,7 +1509,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1524,7 +1524,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1539,7 +1539,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1554,7 +1554,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1569,7 +1569,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1588,7 +1588,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1609,7 +1609,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies}
+#### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies}
 
 NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster.
 
@@ -1621,7 +1621,7 @@ NetworkPolicies defines if network policies created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1636,7 +1636,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1648,7 +1648,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1663,7 +1663,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1678,7 +1678,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1693,7 +1693,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1707,7 +1707,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1722,7 +1722,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1737,7 +1737,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1752,7 +1752,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1767,7 +1767,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1782,7 +1782,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1801,7 +1801,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1822,7 +1822,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims}
+#### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims}
 
 PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster.
 
@@ -1834,7 +1834,7 @@ PersistentVolumeClaims defines if persistent volume claims created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1849,7 +1849,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1861,7 +1861,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1876,7 +1876,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1891,7 +1891,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1906,7 +1906,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1920,7 +1920,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1935,7 +1935,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1950,7 +1950,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1965,7 +1965,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1980,7 +1980,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1995,7 +1995,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2014,7 +2014,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2035,7 +2035,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes}
+#### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes}
 
 PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster.
 
@@ -2047,7 +2047,7 @@ PersistentVolumes defines if persistent volumes created within the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2062,7 +2062,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2074,7 +2074,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2089,7 +2089,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2104,7 +2104,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2119,7 +2119,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2133,7 +2133,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2148,7 +2148,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2163,7 +2163,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2178,7 +2178,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2193,7 +2193,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2208,7 +2208,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2227,7 +2227,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2248,7 +2248,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots}
+#### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots}
 
 VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
 
@@ -2260,7 +2260,7 @@ VolumeSnapshots defines if volume snapshots created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2275,7 +2275,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2287,7 +2287,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2302,7 +2302,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2317,7 +2317,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2332,7 +2332,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2346,7 +2346,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2361,7 +2361,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2376,7 +2376,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2391,7 +2391,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2406,7 +2406,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2421,7 +2421,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2440,7 +2440,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2461,7 +2461,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents}
+#### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents}
 
 VolumeSnapshotContents defines if volume snapshot contents created within the virtual cluster should get synced to the host cluster.
 
@@ -2473,7 +2473,7 @@ VolumeSnapshotContents defines if volume snapshot contents created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2488,7 +2488,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2500,7 +2500,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2515,7 +2515,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2530,7 +2530,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2545,7 +2545,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2559,7 +2559,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2574,7 +2574,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2589,7 +2589,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2604,7 +2604,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2619,7 +2619,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2634,7 +2634,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2653,7 +2653,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2674,7 +2674,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses}
+#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses}
 
 StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
 
@@ -2686,7 +2686,7 @@ StorageClasses defines if storage classes created within the virtual cluster sho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2701,7 +2701,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2713,7 +2713,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2728,7 +2728,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2743,7 +2743,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2758,7 +2758,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2772,7 +2772,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2787,7 +2787,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2802,7 +2802,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2817,7 +2817,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2832,7 +2832,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2847,7 +2847,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2866,7 +2866,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2887,7 +2887,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts}
+#### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts}
 
 ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster.
 
@@ -2899,7 +2899,7 @@ ServiceAccounts defines if service accounts created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2914,7 +2914,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2926,7 +2926,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2941,7 +2941,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2956,7 +2956,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2971,7 +2971,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2985,7 +2985,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3000,7 +3000,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3015,7 +3015,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3030,7 +3030,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3045,7 +3045,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3060,7 +3060,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3079,7 +3079,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3100,7 +3100,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets}
+#### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets}
 
 PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster.
 
@@ -3112,7 +3112,7 @@ PodDisruptionBudgets defines if pod disruption budgets created within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3127,7 +3127,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3139,7 +3139,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3154,7 +3154,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3169,7 +3169,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3184,7 +3184,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3198,7 +3198,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3213,7 +3213,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3228,7 +3228,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3243,7 +3243,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3258,7 +3258,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3273,7 +3273,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3292,7 +3292,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3313,7 +3313,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses}
+#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses}
 
 PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster.
 
@@ -3325,7 +3325,7 @@ PriorityClasses defines if priority classes created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3340,7 +3340,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3352,7 +3352,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3367,7 +3367,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3382,7 +3382,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3397,7 +3397,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3411,7 +3411,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3426,7 +3426,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3441,7 +3441,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3456,7 +3456,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3471,7 +3471,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3486,7 +3486,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3505,7 +3505,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3526,7 +3526,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources}
+#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources}
 
 CustomResources defines what custom resources should get synced from the virtual cluster to the host cluster. vCluster will copy the definition automatically from host cluster to virtual cluster on startup.
 vCluster will also automatically add any required RBAC permissions to the vCluster role for this to work.
@@ -3539,7 +3539,7 @@ vCluster will also automatically add any required RBAC permissions to the vClust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3554,7 +3554,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-scope}
+##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-scope}
 
 Scope defines the scope of the resource. If undefined, will use Namespaced. Currently only Namespaced is supported.
 
@@ -3569,7 +3569,7 @@ Scope defines the scope of the resource. If undefined, will use Namespaced. Curr
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3581,7 +3581,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3596,7 +3596,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3611,7 +3611,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3626,7 +3626,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3640,7 +3640,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3655,7 +3655,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3670,7 +3670,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3685,7 +3685,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3700,7 +3700,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3715,7 +3715,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3734,7 +3734,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3755,7 +3755,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces}
+#### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces}
 
 Namespaces defines if namespaces created within the virtual cluster should get synced to the host cluster.
 
@@ -3767,7 +3767,7 @@ Namespaces defines if namespaces created within the virtual cluster should get s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3782,7 +3782,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3794,7 +3794,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3809,7 +3809,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3824,7 +3824,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3839,7 +3839,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3853,7 +3853,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3868,7 +3868,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3883,7 +3883,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3898,7 +3898,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3913,7 +3913,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3928,7 +3928,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3947,7 +3947,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3965,7 +3965,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-mappings}
+##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-mappings}
 
 Mappings for Namespace and Object
 
@@ -3977,7 +3977,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -4011,7 +4011,7 @@ byName:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mappingsOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-mappingsOnly}
+##### `mappingsOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-mappingsOnly}
 
 MappingsOnly defines if creation of namespaces not matched by mappings should be allowed.
 
@@ -4026,7 +4026,7 @@ MappingsOnly defines if creation of namespaces not matched by mappings should be
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-extraLabels}
+##### `extraLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-extraLabels}
 
 ExtraLabels are additional labels to add to the namespace in the host cluster.
 
@@ -4047,7 +4047,7 @@ ExtraLabels are additional labels to add to the namespace in the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost}
+### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost}
 
 Configure what resources vCluster should sync from the host cluster to the virtual cluster.
 
@@ -4059,7 +4059,7 @@ Configure what resources vCluster should sync from the host cluster to the virtu
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes}
+#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes}
 
 Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -4071,7 +4071,7 @@ Nodes defines if nodes should get synced from the host cluster to the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-enabled}
 
 Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead.
 
@@ -4086,7 +4086,7 @@ Enabled specifies if syncing real nodes should be enabled. If this is disabled, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-syncBackChanges}
+##### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-syncBackChanges}
 
 SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node.
 
@@ -4101,7 +4101,7 @@ SyncBackChanges enables syncing labels and taints from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-clearImageStatus}
+##### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-clearImageStatus}
 
 ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node.
 
@@ -4116,7 +4116,7 @@ ClearImageStatus will erase the image status when syncing a node. This allows to
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector}
 
 Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster.
 
@@ -4128,7 +4128,7 @@ Selector can be used to define more granular what nodes should get synced from t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-selector-all}
+##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector-all}
 
 All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to.
 
@@ -4143,7 +4143,7 @@ All specifies if all nodes should get synced by vCluster from the host to the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector-labels}
 
 Labels are the node labels used to sync nodes from host cluster to virtual cluster. This will also set the node selector when syncing a pod from virtual cluster to host cluster to the same value.
 
@@ -4161,7 +4161,7 @@ Labels are the node labels used to sync nodes from host cluster to virtual clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4173,7 +4173,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4188,7 +4188,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4203,7 +4203,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4218,7 +4218,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4232,7 +4232,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4247,7 +4247,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4262,7 +4262,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4277,7 +4277,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4292,7 +4292,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4307,7 +4307,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4326,7 +4326,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4347,7 +4347,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events}
+#### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events}
 
 Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -4359,7 +4359,7 @@ Events defines if events should get synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-fromHost-events-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4374,7 +4374,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4386,7 +4386,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4401,7 +4401,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4416,7 +4416,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4431,7 +4431,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4445,7 +4445,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4460,7 +4460,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4475,7 +4475,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4490,7 +4490,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4505,7 +4505,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4520,7 +4520,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4539,7 +4539,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4560,7 +4560,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses}
+#### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses}
 
 IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -4572,7 +4572,7 @@ IngressClasses defines if ingress classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4587,7 +4587,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4599,7 +4599,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4614,7 +4614,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4629,7 +4629,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4644,7 +4644,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4658,7 +4658,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4673,7 +4673,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4688,7 +4688,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4703,7 +4703,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4718,7 +4718,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4733,7 +4733,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4752,7 +4752,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4770,7 +4770,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -4782,7 +4782,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchLabels}
 
 
 
@@ -4797,7 +4797,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions}
 
 
 
@@ -4809,22 +4809,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions-key}
 
 
 
@@ -4839,7 +4824,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions-values}
 
 
 
@@ -4863,7 +4863,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses}
+#### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses}
 
 RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -4875,7 +4875,7 @@ RuntimeClasses defines if runtime classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4890,7 +4890,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4902,7 +4902,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4917,7 +4917,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4932,7 +4932,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4947,7 +4947,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4961,7 +4961,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4976,7 +4976,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4991,7 +4991,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5006,7 +5006,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5021,7 +5021,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5036,7 +5036,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5055,7 +5055,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5073,7 +5073,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -5085,7 +5085,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchLabels}
 
 
 
@@ -5100,7 +5100,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions}
 
 
 
@@ -5112,22 +5112,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-key}
 
 
 
@@ -5142,7 +5127,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-values}
 
 
 
@@ -5166,7 +5166,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses}
+#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses}
 
 PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -5178,7 +5178,7 @@ PriorityClasses defines if priority classes classes should get synced from the h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5193,7 +5193,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5205,7 +5205,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5220,7 +5220,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5235,7 +5235,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5250,7 +5250,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5264,7 +5264,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5279,7 +5279,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5294,7 +5294,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5309,7 +5309,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5324,7 +5324,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5339,7 +5339,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5358,7 +5358,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5376,7 +5376,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -5388,7 +5388,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchLabels}
 
 
 
@@ -5403,7 +5403,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions}
 
 
 
@@ -5415,22 +5415,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions-key}
 
 
 
@@ -5445,7 +5430,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions-values}
 
 
 
@@ -5469,7 +5469,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses}
+#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses}
 
 StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -5481,7 +5481,7 @@ StorageClasses defines if storage classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5496,7 +5496,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5508,7 +5508,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5523,7 +5523,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5538,7 +5538,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5553,7 +5553,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5567,7 +5567,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5582,7 +5582,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5597,7 +5597,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5612,7 +5612,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5627,7 +5627,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5642,7 +5642,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5661,7 +5661,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5679,7 +5679,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -5691,7 +5691,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchLabels}
 
 
 
@@ -5706,7 +5706,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions}
 
 
 
@@ -5718,22 +5718,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions-key}
 
 
 
@@ -5748,7 +5733,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions-values}
 
 
 
@@ -5772,7 +5772,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes}
+#### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes}
 
 CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -5784,7 +5784,7 @@ CSINodes defines if csi nodes should get synced from the host cluster to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5799,7 +5799,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5811,7 +5811,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5826,7 +5826,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5841,7 +5841,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5856,7 +5856,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5870,7 +5870,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5885,7 +5885,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5900,7 +5900,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5915,7 +5915,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5930,7 +5930,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5945,7 +5945,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5964,7 +5964,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5985,7 +5985,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers}
+#### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers}
 
 CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -5997,7 +5997,7 @@ CSIDrivers defines if csi drivers should get synced from the host cluster to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -6012,7 +6012,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6024,7 +6024,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6039,7 +6039,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6054,7 +6054,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6069,7 +6069,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6083,7 +6083,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6098,7 +6098,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6113,7 +6113,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6128,7 +6128,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6143,7 +6143,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6158,7 +6158,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6177,7 +6177,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6198,7 +6198,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities}
+#### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities}
 
 CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -6210,7 +6210,7 @@ CSIStorageCapacities defines if csi storage capacities should get synced from th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -6225,7 +6225,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6237,7 +6237,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6252,7 +6252,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6267,7 +6267,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6282,7 +6282,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6296,7 +6296,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6311,7 +6311,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6326,7 +6326,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6341,7 +6341,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6356,7 +6356,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6371,7 +6371,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6390,7 +6390,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6411,7 +6411,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources}
+#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources}
 
 CustomResources defines what custom resources should get synced read-only to the virtual cluster from the host cluster. vCluster will automatically add any required RBAC to the vCluster cluster role.
 
@@ -6423,7 +6423,7 @@ CustomResources defines what custom resources should get synced read-only to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -6438,7 +6438,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-scope}
+##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-scope}
 
 Scope defines the scope of the resource
 
@@ -6453,7 +6453,7 @@ Scope defines the scope of the resource
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6465,7 +6465,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6480,7 +6480,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6495,7 +6495,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6510,7 +6510,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6524,7 +6524,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6539,7 +6539,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6554,7 +6554,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6569,7 +6569,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6584,7 +6584,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6599,7 +6599,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6618,7 +6618,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6636,7 +6636,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-mappings}
+##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-mappings}
 
 Mappings for Namespace and Object
 
@@ -6648,7 +6648,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -6685,7 +6685,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses}
+#### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses}
 
 VolumeSnapshotClasses defines if volume snapshot classes created within the virtual cluster should get synced to the host cluster.
 
@@ -6697,7 +6697,7 @@ VolumeSnapshotClasses defines if volume snapshot classes created within the virt
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -6712,7 +6712,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6724,7 +6724,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6739,7 +6739,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6754,7 +6754,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6769,7 +6769,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6783,7 +6783,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6798,7 +6798,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6813,7 +6813,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6828,7 +6828,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6843,7 +6843,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6858,7 +6858,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6877,7 +6877,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6898,7 +6898,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps}
+#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps}
 
 ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
 
@@ -6910,7 +6910,7 @@ ConfigMaps defines if config maps in the host should get synced to the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -6925,7 +6925,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6937,7 +6937,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6952,7 +6952,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6967,7 +6967,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6982,7 +6982,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6996,7 +6996,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -7011,7 +7011,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -7026,7 +7026,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -7041,7 +7041,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -7056,7 +7056,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -7071,7 +7071,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -7090,7 +7090,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -7108,7 +7108,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-mappings}
+##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-mappings}
 
 Mappings for Namespace and Object
 
@@ -7120,7 +7120,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -7157,7 +7157,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets}
+#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets}
 
 Secrets defines if secrets in the host should get synced to the virtual cluster.
 
@@ -7169,7 +7169,7 @@ Secrets defines if secrets in the host should get synced to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -7184,7 +7184,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -7196,7 +7196,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -7211,7 +7211,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -7226,7 +7226,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -7241,7 +7241,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -7255,7 +7255,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -7270,7 +7270,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -7285,7 +7285,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -7300,7 +7300,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -7315,7 +7315,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -7330,7 +7330,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -7349,7 +7349,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -7367,7 +7367,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-mappings}
+##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-mappings}
 
 Mappings for Namespace and Object
 
@@ -7379,7 +7379,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster/_partials/config/sync/fromHost.mdx
+++ b/vcluster/_partials/config/sync/fromHost.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost}
+## `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost}
 
 Configure what resources vCluster should sync from the host cluster to the virtual cluster.
 
@@ -14,7 +14,7 @@ Configure what resources vCluster should sync from the host cluster to the virtu
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes}
+### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes}
 
 Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -26,7 +26,7 @@ Nodes defines if nodes should get synced from the host cluster to the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-enabled}
 
 Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead.
 
@@ -41,7 +41,7 @@ Enabled specifies if syncing real nodes should be enabled. If this is disabled, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-syncBackChanges}
+#### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-syncBackChanges}
 
 SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node.
 
@@ -56,7 +56,7 @@ SyncBackChanges enables syncing labels and taints from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-clearImageStatus}
+#### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-clearImageStatus}
 
 ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node.
 
@@ -71,7 +71,7 @@ ClearImageStatus will erase the image status when syncing a node. This allows to
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-selector}
+#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-selector}
 
 Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster.
 
@@ -83,7 +83,7 @@ Selector can be used to define more granular what nodes should get synced from t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-selector-all}
+##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-selector-all}
 
 All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to.
 
@@ -98,7 +98,7 @@ All specifies if all nodes should get synced by vCluster from the host to the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-nodes-selector-labels}
 
 Labels are the node labels used to sync nodes from host cluster to virtual cluster. This will also set the node selector when syncing a pod from virtual cluster to host cluster to the same value.
 
@@ -116,7 +116,7 @@ Labels are the node labels used to sync nodes from host cluster to virtual clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -128,7 +128,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -143,7 +143,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -158,7 +158,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -173,7 +173,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -187,7 +187,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -202,7 +202,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -217,7 +217,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -232,7 +232,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -247,7 +247,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -262,7 +262,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -281,7 +281,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -302,7 +302,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events}
+### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events}
 
 Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -314,7 +314,7 @@ Events defines if events should get synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#fromHost-events-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -329,7 +329,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -341,7 +341,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -356,7 +356,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -371,7 +371,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -386,7 +386,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -400,7 +400,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -415,7 +415,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -430,7 +430,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -445,7 +445,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -460,7 +460,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -475,7 +475,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -494,7 +494,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -515,7 +515,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses}
+### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses}
 
 IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -527,7 +527,7 @@ IngressClasses defines if ingress classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -542,7 +542,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -554,7 +554,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -569,7 +569,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -584,7 +584,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -599,7 +599,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -613,7 +613,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -628,7 +628,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -643,7 +643,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -658,7 +658,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -673,7 +673,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -688,7 +688,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -707,7 +707,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -725,7 +725,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -737,7 +737,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchLabels}
 
 
 
@@ -752,7 +752,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions}
 
 
 
@@ -764,22 +764,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions-key}
 
 
 
@@ -794,7 +779,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions-values}
 
 
 
@@ -818,7 +818,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses}
+### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses}
 
 RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -830,7 +830,7 @@ RuntimeClasses defines if runtime classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -845,7 +845,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -857,7 +857,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -872,7 +872,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -887,7 +887,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -902,7 +902,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -916,7 +916,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -931,7 +931,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -946,7 +946,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -961,7 +961,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -976,7 +976,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -991,7 +991,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1010,7 +1010,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1028,7 +1028,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -1040,7 +1040,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchLabels}
 
 
 
@@ -1055,7 +1055,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions}
 
 
 
@@ -1067,22 +1067,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions-key}
 
 
 
@@ -1097,7 +1082,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions-values}
 
 
 
@@ -1121,7 +1121,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses}
+### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses}
 
 PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -1133,7 +1133,7 @@ PriorityClasses defines if priority classes classes should get synced from the h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1148,7 +1148,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1160,7 +1160,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1175,7 +1175,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1190,7 +1190,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1205,7 +1205,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1219,7 +1219,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1234,7 +1234,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1249,7 +1249,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1264,7 +1264,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1279,7 +1279,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1294,7 +1294,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1313,7 +1313,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1331,7 +1331,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -1343,7 +1343,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchLabels}
 
 
 
@@ -1358,7 +1358,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions}
 
 
 
@@ -1370,22 +1370,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions-key}
 
 
 
@@ -1400,7 +1385,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions-values}
 
 
 
@@ -1424,7 +1424,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses}
+### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses}
 
 StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -1436,7 +1436,7 @@ StorageClasses defines if storage classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1451,7 +1451,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1463,7 +1463,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1478,7 +1478,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1493,7 +1493,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1508,7 +1508,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1522,7 +1522,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1537,7 +1537,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1552,7 +1552,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1567,7 +1567,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1582,7 +1582,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1597,7 +1597,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1616,7 +1616,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1634,7 +1634,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -1646,7 +1646,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchLabels}
 
 
 
@@ -1661,7 +1661,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions}
 
 
 
@@ -1673,22 +1673,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions-key}
 
 
 
@@ -1703,7 +1688,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions-values}
 
 
 
@@ -1727,7 +1727,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes}
+### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes}
 
 CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -1739,7 +1739,7 @@ CSINodes defines if csi nodes should get synced from the host cluster to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiNodes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1754,7 +1754,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1766,7 +1766,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1781,7 +1781,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1796,7 +1796,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1811,7 +1811,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1825,7 +1825,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1840,7 +1840,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1855,7 +1855,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1870,7 +1870,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1885,7 +1885,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1900,7 +1900,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1919,7 +1919,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1940,7 +1940,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers}
+### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers}
 
 CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -1952,7 +1952,7 @@ CSIDrivers defines if csi drivers should get synced from the host cluster to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1967,7 +1967,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1979,7 +1979,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1994,7 +1994,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2009,7 +2009,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2024,7 +2024,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2038,7 +2038,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2053,7 +2053,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2068,7 +2068,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2083,7 +2083,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2098,7 +2098,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2113,7 +2113,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2132,7 +2132,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2153,7 +2153,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities}
+### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities}
 
 CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -2165,7 +2165,7 @@ CSIStorageCapacities defines if csi storage capacities should get synced from th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2180,7 +2180,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2192,7 +2192,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2207,7 +2207,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2222,7 +2222,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2237,7 +2237,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2251,7 +2251,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2266,7 +2266,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2281,7 +2281,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2296,7 +2296,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2311,7 +2311,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2326,7 +2326,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2345,7 +2345,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2366,7 +2366,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources}
+### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources}
 
 CustomResources defines what custom resources should get synced read-only to the virtual cluster from the host cluster. vCluster will automatically add any required RBAC to the vCluster cluster role.
 
@@ -2378,7 +2378,7 @@ CustomResources defines what custom resources should get synced read-only to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2393,7 +2393,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-scope}
+#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-scope}
 
 Scope defines the scope of the resource
 
@@ -2408,7 +2408,7 @@ Scope defines the scope of the resource
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2420,7 +2420,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2435,7 +2435,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2450,7 +2450,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2465,7 +2465,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2479,7 +2479,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2494,7 +2494,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2509,7 +2509,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2524,7 +2524,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2539,7 +2539,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2554,7 +2554,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2573,7 +2573,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2591,7 +2591,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-mappings}
+#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-mappings}
 
 Mappings for Namespace and Object
 
@@ -2603,7 +2603,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -2640,7 +2640,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses}
+### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses}
 
 VolumeSnapshotClasses defines if volume snapshot classes created within the virtual cluster should get synced to the host cluster.
 
@@ -2652,7 +2652,7 @@ VolumeSnapshotClasses defines if volume snapshot classes created within the virt
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2667,7 +2667,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2679,7 +2679,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2694,7 +2694,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2709,7 +2709,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2724,7 +2724,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2738,7 +2738,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2753,7 +2753,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2768,7 +2768,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2783,7 +2783,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2798,7 +2798,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2813,7 +2813,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2832,7 +2832,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2853,7 +2853,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps}
+### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps}
 
 ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
 
@@ -2865,7 +2865,7 @@ ConfigMaps defines if config maps in the host should get synced to the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2880,7 +2880,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2892,7 +2892,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2907,7 +2907,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2922,7 +2922,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2937,7 +2937,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2951,7 +2951,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2966,7 +2966,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2981,7 +2981,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2996,7 +2996,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3011,7 +3011,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3026,7 +3026,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3045,7 +3045,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3063,7 +3063,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-mappings}
+#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-mappings}
 
 Mappings for Namespace and Object
 
@@ -3075,7 +3075,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-configMaps-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -3112,7 +3112,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets}
+### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets}
 
 Secrets defines if secrets in the host should get synced to the virtual cluster.
 
@@ -3124,7 +3124,7 @@ Secrets defines if secrets in the host should get synced to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3139,7 +3139,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3151,7 +3151,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3166,7 +3166,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3181,7 +3181,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3196,7 +3196,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3210,7 +3210,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3225,7 +3225,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3240,7 +3240,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3255,7 +3255,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3270,7 +3270,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3285,7 +3285,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3304,7 +3304,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3322,7 +3322,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-mappings}
+#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-mappings}
 
 Mappings for Namespace and Object
 
@@ -3334,7 +3334,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-secrets-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster/_partials/config/sync/fromHost/configMaps.mdx
+++ b/vcluster/_partials/config/sync/fromHost/configMaps.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps}
+## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps}
 
 ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
 
@@ -14,7 +14,7 @@ ConfigMaps defines if config maps in the host should get synced to the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-mappings}
+### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-mappings}
 
 Mappings for Namespace and Object
 
@@ -224,7 +224,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-mappings-byName}
+#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#configMaps-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster/_partials/config/sync/fromHost/csiDrivers.mdx
+++ b/vcluster/_partials/config/sync/fromHost/csiDrivers.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers}
+## `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers}
 
 CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ CSIDrivers defines if csi drivers should get synced from the host cluster to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiDrivers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/fromHost/csiNodes.mdx
+++ b/vcluster/_partials/config/sync/fromHost/csiNodes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes}
+## `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes}
 
 CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ CSINodes defines if csi nodes should get synced from the host cluster to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiNodes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/fromHost/csiStorageCapacities.mdx
+++ b/vcluster/_partials/config/sync/fromHost/csiStorageCapacities.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities}
+## `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities}
 
 CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ CSIStorageCapacities defines if csi storage capacities should get synced from th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiStorageCapacities-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/fromHost/customResources.mdx
+++ b/vcluster/_partials/config/sync/fromHost/customResources.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources}
+## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources}
 
 CustomResources defines what custom resources should get synced read-only to the virtual cluster from the host cluster. vCluster will automatically add any required RBAC to the vCluster cluster role.
 
@@ -14,7 +14,7 @@ CustomResources defines what custom resources should get synced read-only to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-scope}
+### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-scope}
 
 Scope defines the scope of the resource
 
@@ -44,7 +44,7 @@ Scope defines the scope of the resource
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -56,7 +56,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -71,7 +71,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -101,7 +101,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -115,7 +115,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -130,7 +130,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -145,7 +145,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -160,7 +160,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -175,7 +175,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -190,7 +190,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -209,7 +209,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -227,7 +227,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-mappings}
+### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-mappings}
 
 Mappings for Namespace and Object
 
@@ -239,7 +239,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-mappings-byName}
+#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster/_partials/config/sync/fromHost/events.mdx
+++ b/vcluster/_partials/config/sync/fromHost/events.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events}
+## `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events}
 
 Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ Events defines if events should get synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#events-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/fromHost/ingressClasses.mdx
+++ b/vcluster/_partials/config/sync/fromHost/ingressClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses}
+## `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses}
 
 IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ IngressClasses defines if ingress classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingressClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-selector}
+### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -224,7 +224,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-selector-matchLabels}
+#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchLabels}
 
 
 
@@ -239,7 +239,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-selector-matchExpressions}
+#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions}
 
 
 
@@ -251,22 +251,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions-key}
 
 
 
@@ -281,7 +266,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster/_partials/config/sync/fromHost/nodes.mdx
+++ b/vcluster/_partials/config/sync/fromHost/nodes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes}
+## `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes}
 
 Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ Nodes defines if nodes should get synced from the host cluster to the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-enabled}
 
 Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead.
 
@@ -29,7 +29,7 @@ Enabled specifies if syncing real nodes should be enabled. If this is disabled, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-syncBackChanges}
+### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-syncBackChanges}
 
 SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node.
 
@@ -44,7 +44,7 @@ SyncBackChanges enables syncing labels and taints from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-clearImageStatus}
+### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-clearImageStatus}
 
 ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node.
 
@@ -59,7 +59,7 @@ ClearImageStatus will erase the image status when syncing a node. This allows to
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-selector}
+### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-selector}
 
 Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster.
 
@@ -71,7 +71,7 @@ Selector can be used to define more granular what nodes should get synced from t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-selector-all}
+#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-selector-all}
 
 All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to.
 
@@ -86,7 +86,7 @@ All specifies if all nodes should get synced by vCluster from the host to the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-selector-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#nodes-selector-labels}
 
 Labels are the node labels used to sync nodes from host cluster to virtual cluster. This will also set the node selector when syncing a pod from virtual cluster to host cluster to the same value.
 
@@ -104,7 +104,7 @@ Labels are the node labels used to sync nodes from host cluster to virtual clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -116,7 +116,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -131,7 +131,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -146,7 +146,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -161,7 +161,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -175,7 +175,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -190,7 +190,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -205,7 +205,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -220,7 +220,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -235,7 +235,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -250,7 +250,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -269,7 +269,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/fromHost/priorityClasses.mdx
+++ b/vcluster/_partials/config/sync/fromHost/priorityClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses}
+## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses}
 
 PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ PriorityClasses defines if priority classes classes should get synced from the h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-selector}
+### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -224,7 +224,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-selector-matchLabels}
+#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchLabels}
 
 
 
@@ -239,7 +239,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-selector-matchExpressions}
+#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions}
 
 
 
@@ -251,22 +251,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions-key}
 
 
 
@@ -281,7 +266,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster/_partials/config/sync/fromHost/runtimeClasses.mdx
+++ b/vcluster/_partials/config/sync/fromHost/runtimeClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses}
+## `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses}
 
 RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ RuntimeClasses defines if runtime classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#runtimeClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-selector}
+### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -224,7 +224,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-selector-matchLabels}
+#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchLabels}
 
 
 
@@ -239,7 +239,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-selector-matchExpressions}
+#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions}
 
 
 
@@ -251,22 +251,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions-key}
 
 
 
@@ -281,7 +266,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster/_partials/config/sync/fromHost/secrets.mdx
+++ b/vcluster/_partials/config/sync/fromHost/secrets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets}
+## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets}
 
 Secrets defines if secrets in the host should get synced to the virtual cluster.
 
@@ -14,7 +14,7 @@ Secrets defines if secrets in the host should get synced to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-mappings}
+### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-mappings}
 
 Mappings for Namespace and Object
 
@@ -224,7 +224,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-mappings-byName}
+#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#secrets-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster/_partials/config/sync/fromHost/storageClasses.mdx
+++ b/vcluster/_partials/config/sync/fromHost/storageClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses}
+## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses}
 
 StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ StorageClasses defines if storage classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-selector}
+### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -224,7 +224,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-selector-matchLabels}
+#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchLabels}
 
 
 
@@ -239,7 +239,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-selector-matchExpressions}
+#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions}
 
 
 
@@ -251,22 +251,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions-key}
 
 
 
@@ -281,7 +266,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster/_partials/config/sync/toHost.mdx
+++ b/vcluster/_partials/config/sync/toHost.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost}
+## `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost}
 
 Configure resources to sync from the virtual cluster to the host cluster.
 
@@ -14,7 +14,7 @@ Configure resources to sync from the virtual cluster to the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods}
+### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods}
 
 Pods defines if pods created within the virtual cluster should get synced to the host cluster.
 
@@ -26,7 +26,7 @@ Pods defines if pods created within the virtual cluster should get synced to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-pods-enabled}
 
 Enabled defines if pod syncing should be enabled.
 
@@ -41,7 +41,7 @@ Enabled defines if pod syncing should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-translateImage}
+#### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#toHost-pods-translateImage}
 
 TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite
 a certain image that is used within the virtual cluster to be another image on the host cluster
@@ -57,7 +57,7 @@ a certain image that is used within the virtual cluster to be another image on t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-enforceTolerations}
+#### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-enforceTolerations}
 
 EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster.
 
@@ -72,7 +72,7 @@ EnforceTolerations will add the specified tolerations to all pods synced by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-useSecretsForSATokens}
+#### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-pods-useSecretsForSATokens}
 
 UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a
 pod annotation.
@@ -88,7 +88,7 @@ pod annotation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-runtimeClassName}
+#### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for synced pods.
 
@@ -103,7 +103,7 @@ RuntimeClassName is the runtime class to set for synced pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-priorityClassName}
+#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-priorityClassName}
 
 PriorityClassName is the priority class to set for synced pods.
 
@@ -118,7 +118,7 @@ PriorityClassName is the priority class to set for synced pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts}
+#### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts}
 
 RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
 a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
@@ -132,7 +132,7 @@ the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-enabled}
 
 Enabled specifies if rewriting stateful set pods should be enabled.
 
@@ -147,7 +147,7 @@ Enabled specifies if rewriting stateful set pods should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer}
+##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer}
 
 InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
 
@@ -159,7 +159,7 @@ InitContainer holds extra options for the init container used by vCluster to rew
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image}
 
 Image is the image virtual cluster should use to rewrite this FQDN.
 
@@ -171,7 +171,7 @@ Image is the image virtual cluster should use to rewrite this FQDN.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -187,7 +187,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -202,7 +202,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.20</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.20</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -220,7 +220,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources}
 
 Resources are the resources that should be assigned to the init container for each stateful set init container.
 
@@ -232,7 +232,7 @@ Resources are the resources that should be assigned to the init container for ea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources-limits}
 
 Limits are resource limits for the container
 
@@ -247,7 +247,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -271,7 +271,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -283,7 +283,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -298,7 +298,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -313,7 +313,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -328,7 +328,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -342,7 +342,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -357,7 +357,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -372,7 +372,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -387,7 +387,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -402,7 +402,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -417,7 +417,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -436,7 +436,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -454,7 +454,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `hybridScheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-hybridScheduling}
+#### `hybridScheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-hybridScheduling}
 
 HybridScheduling is used to enable and configure hybrid scheduling for pods in the virtual cluster.
 
@@ -466,7 +466,7 @@ HybridScheduling is used to enable and configure hybrid scheduling for pods in t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-hybridScheduling-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-pods-hybridScheduling-enabled}
 
 Enabled specifies if hybrid scheduling is enabled.
 
@@ -481,7 +481,7 @@ Enabled specifies if hybrid scheduling is enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostSchedulers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-hybridScheduling-hostSchedulers}
+##### `hostSchedulers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-hybridScheduling-hostSchedulers}
 
 HostSchedulers is a list of schedulers that are deployed on the host cluster.
 
@@ -502,7 +502,7 @@ HostSchedulers is a list of schedulers that are deployed on the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets}
+### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets}
 
 Secrets defines if secrets created within the virtual cluster should get synced to the host cluster.
 
@@ -514,7 +514,7 @@ Secrets defines if secrets created within the virtual cluster should get synced 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -529,7 +529,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-all}
+#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-secrets-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -544,7 +544,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -556,7 +556,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -571,7 +571,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -586,7 +586,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -601,7 +601,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -615,7 +615,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -630,7 +630,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -645,7 +645,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -660,7 +660,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -675,7 +675,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -690,7 +690,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -709,7 +709,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -730,7 +730,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps}
+### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps}
 
 ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster.
 
@@ -742,7 +742,7 @@ ConfigMaps defines if config maps created within the virtual cluster should get 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -757,7 +757,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-all}
+#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-configMaps-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -772,7 +772,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -784,7 +784,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -799,7 +799,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -814,7 +814,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -829,7 +829,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -843,7 +843,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -858,7 +858,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -873,7 +873,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -888,7 +888,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -903,7 +903,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -918,7 +918,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -937,7 +937,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -958,7 +958,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses}
+### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses}
 
 Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster.
 
@@ -970,7 +970,7 @@ Ingresses defines if ingresses created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-ingresses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -985,7 +985,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -997,7 +997,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1012,7 +1012,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1027,7 +1027,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1042,7 +1042,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1056,7 +1056,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1071,7 +1071,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1086,7 +1086,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1101,7 +1101,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1116,7 +1116,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1131,7 +1131,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1150,7 +1150,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1171,7 +1171,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services}
+### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services}
 
 Services defines if services created within the virtual cluster should get synced to the host cluster.
 
@@ -1183,7 +1183,7 @@ Services defines if services created within the virtual cluster should get synce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-services-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1198,7 +1198,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1210,7 +1210,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1225,7 +1225,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1240,7 +1240,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1255,7 +1255,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1269,7 +1269,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1284,7 +1284,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1299,7 +1299,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1314,7 +1314,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1329,7 +1329,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1344,7 +1344,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1363,7 +1363,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1384,7 +1384,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints}
+### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints}
 
 Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
 
@@ -1396,7 +1396,7 @@ Endpoints defines if endpoints created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-endpoints-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1411,7 +1411,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1423,7 +1423,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1438,7 +1438,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1453,7 +1453,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1468,7 +1468,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1482,7 +1482,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1497,7 +1497,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1512,7 +1512,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1527,7 +1527,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1542,7 +1542,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1557,7 +1557,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1576,7 +1576,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1597,7 +1597,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies}
+### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies}
 
 NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster.
 
@@ -1609,7 +1609,7 @@ NetworkPolicies defines if network policies created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-networkPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1624,7 +1624,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1636,7 +1636,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1651,7 +1651,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1666,7 +1666,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1681,7 +1681,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1695,7 +1695,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1710,7 +1710,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1725,7 +1725,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1740,7 +1740,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1755,7 +1755,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1770,7 +1770,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1789,7 +1789,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1810,7 +1810,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims}
+### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims}
 
 PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster.
 
@@ -1822,7 +1822,7 @@ PersistentVolumeClaims defines if persistent volume claims created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1837,7 +1837,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1849,7 +1849,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1864,7 +1864,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1879,7 +1879,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1894,7 +1894,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1908,7 +1908,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1923,7 +1923,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1938,7 +1938,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1953,7 +1953,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1968,7 +1968,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1983,7 +1983,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2002,7 +2002,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2023,7 +2023,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes}
+### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes}
 
 PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster.
 
@@ -2035,7 +2035,7 @@ PersistentVolumes defines if persistent volumes created within the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2050,7 +2050,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2062,7 +2062,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2077,7 +2077,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2092,7 +2092,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2107,7 +2107,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2121,7 +2121,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2136,7 +2136,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2151,7 +2151,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2166,7 +2166,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2181,7 +2181,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2196,7 +2196,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2215,7 +2215,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2236,7 +2236,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots}
+### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots}
 
 VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
 
@@ -2248,7 +2248,7 @@ VolumeSnapshots defines if volume snapshots created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2263,7 +2263,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2275,7 +2275,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2290,7 +2290,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2305,7 +2305,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2320,7 +2320,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2334,7 +2334,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2349,7 +2349,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2364,7 +2364,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2379,7 +2379,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2394,7 +2394,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2409,7 +2409,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2428,7 +2428,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2449,7 +2449,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents}
+### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents}
 
 VolumeSnapshotContents defines if volume snapshot contents created within the virtual cluster should get synced to the host cluster.
 
@@ -2461,7 +2461,7 @@ VolumeSnapshotContents defines if volume snapshot contents created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2476,7 +2476,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2488,7 +2488,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2503,7 +2503,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2518,7 +2518,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2533,7 +2533,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2547,7 +2547,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2562,7 +2562,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2577,7 +2577,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2592,7 +2592,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2607,7 +2607,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2622,7 +2622,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2641,7 +2641,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2662,7 +2662,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses}
+### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses}
 
 StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
 
@@ -2674,7 +2674,7 @@ StorageClasses defines if storage classes created within the virtual cluster sho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2689,7 +2689,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2701,7 +2701,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2716,7 +2716,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2731,7 +2731,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2746,7 +2746,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2760,7 +2760,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2775,7 +2775,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2790,7 +2790,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2805,7 +2805,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2820,7 +2820,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2835,7 +2835,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2854,7 +2854,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2875,7 +2875,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts}
+### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts}
 
 ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster.
 
@@ -2887,7 +2887,7 @@ ServiceAccounts defines if service accounts created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2902,7 +2902,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2914,7 +2914,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2929,7 +2929,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2944,7 +2944,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2959,7 +2959,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2973,7 +2973,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2988,7 +2988,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3003,7 +3003,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3018,7 +3018,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3033,7 +3033,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3048,7 +3048,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3067,7 +3067,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3088,7 +3088,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets}
+### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets}
 
 PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster.
 
@@ -3100,7 +3100,7 @@ PodDisruptionBudgets defines if pod disruption budgets created within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3115,7 +3115,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3127,7 +3127,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3142,7 +3142,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3157,7 +3157,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3172,7 +3172,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3186,7 +3186,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3201,7 +3201,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3216,7 +3216,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3231,7 +3231,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3246,7 +3246,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3261,7 +3261,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3280,7 +3280,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3301,7 +3301,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses}
+### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses}
 
 PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster.
 
@@ -3313,7 +3313,7 @@ PriorityClasses defines if priority classes created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3328,7 +3328,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3340,7 +3340,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3355,7 +3355,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3370,7 +3370,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3385,7 +3385,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3399,7 +3399,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3414,7 +3414,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3429,7 +3429,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3444,7 +3444,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3459,7 +3459,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3474,7 +3474,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3493,7 +3493,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3514,7 +3514,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources}
+### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources}
 
 CustomResources defines what custom resources should get synced from the virtual cluster to the host cluster. vCluster will copy the definition automatically from host cluster to virtual cluster on startup.
 vCluster will also automatically add any required RBAC permissions to the vCluster role for this to work.
@@ -3527,7 +3527,7 @@ vCluster will also automatically add any required RBAC permissions to the vClust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3542,7 +3542,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-scope}
+#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-scope}
 
 Scope defines the scope of the resource. If undefined, will use Namespaced. Currently only Namespaced is supported.
 
@@ -3557,7 +3557,7 @@ Scope defines the scope of the resource. If undefined, will use Namespaced. Curr
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3569,7 +3569,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3584,7 +3584,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3599,7 +3599,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3614,7 +3614,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3628,7 +3628,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3643,7 +3643,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3658,7 +3658,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3673,7 +3673,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3688,7 +3688,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3703,7 +3703,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3722,7 +3722,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3743,7 +3743,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces}
+### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces}
 
 Namespaces defines if namespaces created within the virtual cluster should get synced to the host cluster.
 
@@ -3755,7 +3755,7 @@ Namespaces defines if namespaces created within the virtual cluster should get s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-namespaces-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3770,7 +3770,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3782,7 +3782,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3797,7 +3797,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3812,7 +3812,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3827,7 +3827,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3841,7 +3841,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3856,7 +3856,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3871,7 +3871,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3886,7 +3886,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3901,7 +3901,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3916,7 +3916,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3935,7 +3935,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3953,7 +3953,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-mappings}
+#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-mappings}
 
 Mappings for Namespace and Object
 
@@ -3965,7 +3965,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -3999,7 +3999,7 @@ byName:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `mappingsOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-mappingsOnly}
+#### `mappingsOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-namespaces-mappingsOnly}
 
 MappingsOnly defines if creation of namespaces not matched by mappings should be allowed.
 
@@ -4014,7 +4014,7 @@ MappingsOnly defines if creation of namespaces not matched by mappings should be
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-extraLabels}
+#### `extraLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-extraLabels}
 
 ExtraLabels are additional labels to add to the namespace in the host cluster.
 

--- a/vcluster/_partials/config/sync/toHost/configMaps.mdx
+++ b/vcluster/_partials/config/sync/toHost/configMaps.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps}
+## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps}
 
 ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ ConfigMaps defines if config maps created within the virtual cluster should get 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-all}
+### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#configMaps-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -44,7 +44,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -56,7 +56,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -71,7 +71,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -101,7 +101,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -115,7 +115,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -130,7 +130,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -145,7 +145,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -160,7 +160,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -175,7 +175,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -190,7 +190,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -209,7 +209,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/customResources.mdx
+++ b/vcluster/_partials/config/sync/toHost/customResources.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources}
+## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources}
 
 CustomResources defines what custom resources should get synced from the virtual cluster to the host cluster. vCluster will copy the definition automatically from host cluster to virtual cluster on startup.
 vCluster will also automatically add any required RBAC permissions to the vCluster role for this to work.
@@ -15,7 +15,7 @@ vCluster will also automatically add any required RBAC permissions to the vClust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -30,7 +30,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-scope}
+### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-scope}
 
 Scope defines the scope of the resource. If undefined, will use Namespaced. Currently only Namespaced is supported.
 
@@ -45,7 +45,7 @@ Scope defines the scope of the resource. If undefined, will use Namespaced. Curr
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -57,7 +57,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -72,7 +72,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -87,7 +87,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -102,7 +102,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -116,7 +116,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -131,7 +131,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -146,7 +146,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -161,7 +161,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -176,7 +176,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -191,7 +191,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -210,7 +210,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/endpoints.mdx
+++ b/vcluster/_partials/config/sync/toHost/endpoints.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints}
+## `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints}
 
 Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Endpoints defines if endpoints created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#endpoints-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/ingresses.mdx
+++ b/vcluster/_partials/config/sync/toHost/ingresses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses}
+## `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses}
 
 Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Ingresses defines if ingresses created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingresses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/networkPolicies.mdx
+++ b/vcluster/_partials/config/sync/toHost/networkPolicies.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies}
+## `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies}
 
 NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ NetworkPolicies defines if network policies created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networkPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/persistentVolumeClaims.mdx
+++ b/vcluster/_partials/config/sync/toHost/persistentVolumeClaims.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims}
+## `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims}
 
 PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PersistentVolumeClaims defines if persistent volume claims created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#persistentVolumeClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/persistentVolumes.mdx
+++ b/vcluster/_partials/config/sync/toHost/persistentVolumes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes}
+## `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes}
 
 PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PersistentVolumes defines if persistent volumes created within the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#persistentVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/podDisruptionBudgets.mdx
+++ b/vcluster/_partials/config/sync/toHost/podDisruptionBudgets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets}
+## `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets}
 
 PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PodDisruptionBudgets defines if pod disruption budgets created within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#podDisruptionBudgets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/pods.mdx
+++ b/vcluster/_partials/config/sync/toHost/pods.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods}
+## `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods}
 
 Pods defines if pods created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Pods defines if pods created within the virtual cluster should get synced to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#pods-enabled}
 
 Enabled defines if pod syncing should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if pod syncing should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-translateImage}
+### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#pods-translateImage}
 
 TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite
 a certain image that is used within the virtual cluster to be another image on the host cluster
@@ -45,7 +45,7 @@ a certain image that is used within the virtual cluster to be another image on t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-enforceTolerations}
+### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#pods-enforceTolerations}
 
 EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster.
 
@@ -60,7 +60,7 @@ EnforceTolerations will add the specified tolerations to all pods synced by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-useSecretsForSATokens}
+### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#pods-useSecretsForSATokens}
 
 UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a
 pod annotation.
@@ -76,7 +76,7 @@ pod annotation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-runtimeClassName}
+### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for synced pods.
 
@@ -91,7 +91,7 @@ RuntimeClassName is the runtime class to set for synced pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-priorityClassName}
+### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-priorityClassName}
 
 PriorityClassName is the priority class to set for synced pods.
 
@@ -106,7 +106,7 @@ PriorityClassName is the priority class to set for synced pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts}
+### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts}
 
 RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
 a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
@@ -120,7 +120,7 @@ the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-enabled}
 
 Enabled specifies if rewriting stateful set pods should be enabled.
 
@@ -135,7 +135,7 @@ Enabled specifies if rewriting stateful set pods should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer}
+#### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer}
 
 InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
 
@@ -147,7 +147,7 @@ InitContainer holds extra options for the init container used by vCluster to rew
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image}
 
 Image is the image virtual cluster should use to rewrite this FQDN.
 
@@ -159,7 +159,7 @@ Image is the image virtual cluster should use to rewrite this FQDN.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -175,7 +175,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -190,7 +190,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.20</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.20</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image-tag}
 
 Tag is the tag of the container image, and is the default version.
 
@@ -208,7 +208,7 @@ Tag is the tag of the container image, and is the default version.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources}
 
 Resources are the resources that should be assigned to the init container for each stateful set init container.
 
@@ -220,7 +220,7 @@ Resources are the resources that should be assigned to the init container for ea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources-limits}
 
 Limits are resource limits for the container
 
@@ -235,7 +235,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -259,7 +259,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -271,7 +271,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -286,7 +286,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -301,7 +301,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -316,7 +316,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -330,7 +330,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -345,7 +345,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -360,7 +360,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -375,7 +375,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -390,7 +390,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -405,7 +405,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -424,7 +424,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -442,7 +442,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `hybridScheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-hybridScheduling}
+### `hybridScheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-hybridScheduling}
 
 HybridScheduling is used to enable and configure hybrid scheduling for pods in the virtual cluster.
 
@@ -454,7 +454,7 @@ HybridScheduling is used to enable and configure hybrid scheduling for pods in t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-hybridScheduling-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#pods-hybridScheduling-enabled}
 
 Enabled specifies if hybrid scheduling is enabled.
 
@@ -469,7 +469,7 @@ Enabled specifies if hybrid scheduling is enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostSchedulers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-hybridScheduling-hostSchedulers}
+#### `hostSchedulers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#pods-hybridScheduling-hostSchedulers}
 
 HostSchedulers is a list of schedulers that are deployed on the host cluster.
 

--- a/vcluster/_partials/config/sync/toHost/priorityClasses.mdx
+++ b/vcluster/_partials/config/sync/toHost/priorityClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses}
+## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses}
 
 PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PriorityClasses defines if priority classes created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/secrets.mdx
+++ b/vcluster/_partials/config/sync/toHost/secrets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets}
+## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets}
 
 Secrets defines if secrets created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Secrets defines if secrets created within the virtual cluster should get synced 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-all}
+### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#secrets-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -44,7 +44,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -56,7 +56,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -71,7 +71,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -101,7 +101,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -115,7 +115,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -130,7 +130,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -145,7 +145,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -160,7 +160,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -175,7 +175,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -190,7 +190,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -209,7 +209,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/serviceAccounts.mdx
+++ b/vcluster/_partials/config/sync/toHost/serviceAccounts.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts}
+## `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts}
 
 ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ ServiceAccounts defines if service accounts created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#serviceAccounts-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/services.mdx
+++ b/vcluster/_partials/config/sync/toHost/services.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services}
+## `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services}
 
 Services defines if services created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Services defines if services created within the virtual cluster should get synce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#services-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/storageClasses.mdx
+++ b/vcluster/_partials/config/sync/toHost/storageClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses}
+## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses}
 
 StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ StorageClasses defines if storage classes created within the virtual cluster sho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/sync/toHost/volumeSnapshots.mdx
+++ b/vcluster/_partials/config/sync/toHost/volumeSnapshots.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots}
+## `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots}
 
 VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ VolumeSnapshots defines if volume snapshots created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#volumeSnapshots-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster/_partials/config/telemetry.mdx
+++ b/vcluster/_partials/config/telemetry.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `telemetry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry}
+## `telemetry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry}
 
 Configuration related to telemetry gathered about vCluster usage.
 
@@ -14,7 +14,7 @@ Configuration related to telemetry gathered about vCluster usage.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#telemetry-enabled}
 
 Enabled specifies that the telemetry for the vCluster control plane should be enabled.
 
@@ -29,7 +29,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `instanceCreator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-instanceCreator}
+### `instanceCreator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-instanceCreator}
 
 
 
@@ -44,7 +44,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `machineID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-machineID}
+### `machineID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-machineID}
 
 
 
@@ -59,7 +59,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `platformUserID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-platformUserID}
+### `platformUserID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-platformUserID}
 
 
 
@@ -74,7 +74,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `platformInstanceID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-platformInstanceID}
+### `platformInstanceID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-platformInstanceID}
 
 
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `controlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane}
+## `controlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane}
 
 Configure vCluster's control plane components and deployment.
 
@@ -14,7 +14,7 @@ Configure vCluster's control plane components and deployment.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-endpoint}
+### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-endpoint}
 
 Endpoint is the endpoint of the virtual cluster. This is used to connect to the virtual cluster.
 
@@ -29,7 +29,7 @@ Endpoint is the endpoint of the virtual cluster. This is used to connect to the 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro}
+### `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro}
 
 Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed.
 
@@ -41,7 +41,7 @@ Distro holds virtual cluster related distro options. A distro cannot be changed 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s}
+#### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s}
 
 K8S holds K8s relevant configuration.
 
@@ -53,7 +53,7 @@ K8S holds K8s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-enabled}
 
 Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -68,7 +68,7 @@ Enabled specifies if the K8s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-version}
+##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-version}
 
 [Deprecated] Version field is deprecated.
 Use controlPlane.distro.k8s.image.tag to specify the Kubernetes version instead.
@@ -84,7 +84,7 @@ Use controlPlane.distro.k8s.image.tag to specify the Kubernetes version instead.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer}
+##### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer}
 
 APIServer holds configuration specific to starting the api server.
 
@@ -96,7 +96,7 @@ APIServer holds configuration specific to starting the api server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -111,7 +111,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -126,7 +126,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-apiServer-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-apiServer-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -144,7 +144,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager}
+##### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager}
 
 ControllerManager holds configuration specific to starting the controller manager.
 
@@ -156,7 +156,7 @@ ControllerManager holds configuration specific to starting the controller manage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -171,7 +171,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -186,7 +186,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-controllerManager-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-controllerManager-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -204,7 +204,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-scheduler}
+##### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler}
 
 Scheduler holds configuration specific to starting the scheduler. Enable this via controlPlane.advanced.virtualScheduler.enabled
 
@@ -216,7 +216,7 @@ Scheduler holds configuration specific to starting the scheduler. Enable this vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-scheduler-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -231,7 +231,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-scheduler-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -246,7 +246,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-scheduler-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-scheduler-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -264,7 +264,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image}
 
 Image is the distro image
 
@@ -276,7 +276,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -292,7 +292,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -307,7 +307,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -325,7 +325,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -340,7 +340,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-env}
+##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -355,7 +355,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-resources}
 
 Resources for the distro init container
 
@@ -370,7 +370,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k8s-securityContext}
+##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k8s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -388,7 +388,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s}
+#### `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s}
 
 [Deprecated] K3S holds K3s relevant configuration.
 
@@ -400,7 +400,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-enabled}
 
 Enabled specifies if the K3s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -415,7 +415,7 @@ Enabled specifies if the K3s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-token}
+##### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-token}
 
 Token is the K3s token to use. If empty, vCluster will choose one.
 
@@ -430,7 +430,7 @@ Token is the K3s token to use. If empty, vCluster will choose one.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-image}
 
 Image is the distro image
 
@@ -442,7 +442,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -458,7 +458,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -473,7 +473,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1-k3s1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1-k3s1</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -491,7 +491,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -506,7 +506,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-env}
+##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -521,7 +521,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-resources}
 
 Resources for the distro init container
 
@@ -536,7 +536,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-securityContext}
+##### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -551,7 +551,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -566,7 +566,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#controlPlane-distro-k3s-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-distro-k3s-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -581,5 +581,4442 @@ ExtraArgs are additional arguments to pass to the distro binary.
 
 
 </details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `standalone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone}
+
+Standalone holds configuration for standalone mode. Standalone mode is set automatically when no container is detected and
+also implies privateNodes.enabled.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-enabled}
+
+Enabled defines if standalone mode should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `dataDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">/var/lib/vcluster</span> <span className="config-field-enum"></span> {#controlPlane-standalone-dataDir}
+
+DataDir defines the data directory for the standalone mode.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `bundleRepository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">https://github.com/loft-sh/kubernetes/releases/download</span> <span className="config-field-enum"></span> {#controlPlane-standalone-bundleRepository}
+
+BundleRepository is the repository to use for downloading the Kubernetes bundle. Defaults to https://github.com/loft-sh/kubernetes/releases/download
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-bundle}
+
+Bundle is a path to a Kubernetes bundle to use for the standalone mode. If empty, will use the bundleRepository to download the bundle.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `joinNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode}
+
+JoinNode holds configuration for the standalone control plane node.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-enabled}
+
+Enabled defines if the standalone node should be joined into the cluster. If false, only the control plane binaries will be executed and no node will show up in the actual cluster.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-name}
+
+Name defines the name of the standalone node. If empty the node will get the hostname as name.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `preJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-preJoinCommands}
+
+PreJoinCommands are commands that will be executed before the join process starts.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `postJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-postJoinCommands}
+
+PostJoinCommands are commands that will be executed after the join process starts.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `containerd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd}
+
+Containerd holds configuration for the containerd join process.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-enabled}
+
+Enabled defines if containerd should be installed and configured by vCluster.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry}
+
+Registry holds configuration for how containerd should be configured to use a registries.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `configPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-configPath}
+
+ConfigPath is the path to the containerd registry config.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `mirrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors}
+
+Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry.io:5000 or docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-server}
+
+Server is the fallback server to use for the containerd registry mirror. E.g. https://registry-1.docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-caCert}
+
+CACert are paths to CA certificates to use for the containerd registry mirror.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-skipVerify}
+
+SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-capabilities}
+
+Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `hosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts}
+
+Hosts holds configuration for the containerd registry mirror hosts. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-server}
+
+Server is the server to use for the containerd registry mirror host. E.g. http://192.168.31.250:5000.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-caCert}
+
+CACert are paths to CA certificates to use for the containerd registry mirror host.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-skipVerify}
+
+SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-registry-mirrors-hosts-capabilities}
+
+Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `importImages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-importImages}
+
+ImportImages is a list of images to import into the containerd registry from local files. If the path is a folder, all files that end with .tar or .tar.gz in the folder will be imported.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `pauseImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-containerd-pauseImage}
+
+PauseImage is the image for the pause container.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `caCertPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-caCertPath}
+
+CACertPath is the path to the SSL certificate authority used to
+secure communications between node and control-plane.
+Defaults to "/etc/kubernetes/pki/ca.crt".
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipPhases` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-skipPhases}
+
+SkipPhases is a list of phases to skip during command execution.
+The list of phases can be obtained with the "kubeadm join --help" command.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `nodeRegistration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration}
+
+NodeRegistration holds configuration for the node registration similar to the kubeadm node registration.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `criSocket` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-criSocket}
+
+CRI socket is the socket for the CRI.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `kubeletExtraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs}
+
+KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config ConfigMap
+Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+An argument name in this list is the flag name as it appears on the command line except without leading dash(es).
+Extra arguments will override existing default arguments. Duplicate extra arguments are allowed.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs-name}
+
+Name is the name of the argument.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-kubeletExtraArgs-value}
+
+Value is the value of the argument.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints}
+
+Taints are additional taints to set for the kubelet.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-key}
+
+Required. The taint key to be applied to a node.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-value}
+
+The taint value corresponding to the taint key.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-taints-effect}
+
+Required. The effect of the taint on pods
+that do not tolerate the taint.
+Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignorePreflightErrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-ignorePreflightErrors}
+
+IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered, e.g. 'IsPrivilegedUser,Swap'.
+Value 'all' ignores errors from all checks.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-standalone-joinNode-nodeRegistration-imagePullPolicy}
+
+ImagePullPolicy specifies the policy for image pulling during kubeadm "init" and "join" operations.
+The value of this field must be one of "Always", "IfNotPresent" or "Never".
+If this field is unset kubeadm will default it to "IfNotPresent", or pull the required images if not present on the host.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `backingStore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore}
+
+BackingStore defines which backing store to use for virtual cluster. If not defined will use embedded database as a default backing store.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `etcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd}
+
+Etcd defines that etcd should be used as the backend for the virtual cluster
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded}
+
+Embedded defines to use embedded etcd as a storage backend for the virtual cluster
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-enabled}
+
+Enabled defines if the embedded etcd should be used.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-migrateFromDeployedEtcd}
+
+MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-snapshotCount}
+
+SnapshotCount defines the number of snapshots to keep for the embedded etcd. Defaults to 10000 if less than 1.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-embedded-extraArgs}
+
+ExtraArgs are additional arguments to pass to the embedded etcd.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy}
+
+Deploy defines to use an external etcd that is deployed by the helm chart
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-enabled}
+
+Enabled defines that an external etcd should be deployed.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet}
+
+StatefulSet holds options for the external etcd statefulSet.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enabled}
+
+Enabled defines if the statefulSet should be deployed
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-enableServiceLinks}
+
+EnableServiceLinks for the StatefulSet pod
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image}
+
+Image is the image to use for the external etcd statefulSet
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-registry}
+
+Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
+overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-repository}
+
+Repository is the repository of the container image, e.g. my-repo/my-image
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.21-0</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-image-tag}
+
+Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-imagePullPolicy}
+
+ImagePullPolicy is the pull policy for the external etcd image
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-env}
+
+Env are extra environment variables
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-extraArgs}
+
+ExtraArgs are appended to the etcd command.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources}
+
+Resources the etcd can consume
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-limits}
+
+Limits are resource limits for the container
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-resources-requests}
+
+Requests are minimal resources that will be consumed by the container
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods}
+
+Pods defines extra metadata for the etcd pods.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-annotations}
+
+Annotations are extra annotations for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-pods-labels}
+
+Labels are extra labels for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability}
+
+HighAvailability are high availability options
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
+
+Replicas are the amount of pods to use.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling}
+
+Scheduling options for the etcd pods.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
+
+NodeSelector is the node selector to apply to the pod.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-affinity}
+
+Affinity is the affinity to apply to the pod.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
+
+Tolerations are the tolerations to apply to the pod.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
+
+PriorityClassName is the priority class name for the the pod.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
+
+PodManagementPolicy is the statefulSet pod management policy.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
+
+TopologySpreadConstraints are the topology spread constraints for the pod.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security}
+
+Security options for the etcd pods.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
+
+PodSecurityContext specifies security context options on the pod level.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
+
+ContainerSecurityContext specifies security context options on the container level.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence}
+
+Persistence options for the etcd pods.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
+
+VolumeClaim can be used to configure the persistent volume claim.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
+
+Enabled enables deploying a persistent volume claim.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
+
+AccessModes are the persistent volume claim access modes.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
+
+RetentionPolicy is the persistent volume claim retention policy.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
+
+Size is the persistent volume claim storage size.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
+
+StorageClass is the persistent volume claim storage class.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
+
+VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
+
+AddVolumes defines extra volumes for the pod
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
+
+AddVolumeMounts defines extra volume mounts for the container
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
+
+This must match the Name of a Volume.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
+
+Mounted read-only if true, read-write otherwise (false or unspecified).
+Defaults to false.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
+
+Path within the container at which the volume should be mounted.  Must
+not contain ':'.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
+
+Path within the volume from which the container's volume should be mounted.
+Defaults to "" (volume's root).
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
+
+mountPropagation determines how mounts are propagated from the host
+to container and the other way around.
+When not set, MountPropagationNone is used.
+This field is beta in 1.10.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
+
+Expanded path within the volume from which the container's volume should be mounted.
+Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+Defaults to "" (volume's root).
+SubPathExpr and SubPath are mutually exclusive.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-annotations}
+
+Annotations are extra annotations for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-statefulSet-labels}
+
+Labels are extra labels for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service}
+
+Service holds options for the external etcd service.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service-enabled}
+
+Enabled defines if the etcd service should be deployed
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-service-annotations}
+
+Annotations are extra annotations for the external etcd service
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-headlessService}
+
+HeadlessService holds options for the external etcd headless service.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-deploy-headlessService-annotations}
+
+Annotations are extra annotations for the external etcd headless service
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external}
+
+External defines to use a self-hosted external etcd that is not deployed by the helm chart
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-enabled}
+
+Enabled defines if the external etcd should be used.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-endpoint}
+
+Endpoint holds the endpoint of the external etcd server, e.g. my-example-service:2379
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `tls` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls}
+
+TLS defines the tls configuration for the external etcd server
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-caFile}
+
+CaFile is the path to the ca file
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-certFile}
+
+CertFile is the path to the cert file
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-etcd-external-tls-keyFile}
+
+KeyFile is the path to the key file
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database}
+
+Database defines that a database backend should be used as the backend for the virtual cluster. This uses a project called kine under the hood which is a shim for bridging Kubernetes and relational databases.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded}
+
+Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-enabled}
+
+Enabled defines if the database should be used.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-dataSource}
+
+DataSource is the kine dataSource to use for the database. This depends on the database format.
+This is optional for the embedded database. Examples:
+* mysql: mysql://username:password@tcp(hostname:3306)/k3s
+* postgres: postgres://username:password@hostname:5432/k3s
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-keyFile}
+
+KeyFile is the key file to use for the database. This is optional.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-certFile}
+
+CertFile is the cert file to use for the database. This is optional.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-caFile}
+
+CaFile is the ca file to use for the database. This is optional.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-embedded-extraArgs}
+
+ExtraArgs are additional arguments to pass to Kine.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external}
+
+External defines that an external database should be used as the backend for the virtual cluster
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-enabled}
+
+Enabled defines if the database should be used.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-dataSource}
+
+DataSource is the kine dataSource to use for the database. This depends on the database format.
+This is optional for the embedded database. Examples:
+* mysql: mysql://username:password@tcp(hostname:3306)/k3s
+* postgres: postgres://username:password@hostname:5432/k3s
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-keyFile}
+
+KeyFile is the key file to use for the database. This is optional.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-certFile}
+
+CertFile is the cert file to use for the database. This is optional.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-caFile}
+
+CaFile is the ca file to use for the database. This is optional.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-extraArgs}
+
+ExtraArgs are additional arguments to pass to Kine.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-backingStore-database-external-connector}
+
+Connector specifies a secret located in a connected vCluster Platform that contains database server connection information
+to be used by Platform to create a database and database user for the vCluster.
+and non-privileged user. A kine endpoint should be created using the database and user on Platform registration.
+This is optional.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `coredns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns}
+
+CoreDNS defines everything related to the coredns that is deployed and used within the vCluster.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-coredns-enabled}
+
+Enabled defines if coredns is enabled
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-coredns-embedded}
+
+Embedded defines if vCluster will start the embedded coredns service within the control-plane and not as a separate deployment. This is a PRO feature.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-security}
+
+Security defines pod or container security context.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-security-podSecurityContext}
+
+PodSecurityContext specifies security context options on the pod level.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-security-containerSecurityContext}
+
+ContainerSecurityContext specifies security context options on the container level.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-service}
+
+Service holds extra options for the coredns service deployed within the virtual cluster
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-spec}
+
+Spec holds extra options for the coredns service
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-annotations}
+
+Annotations are extra annotations for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-service-labels}
+
+Labels are extra labels for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `deployment` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment}
+
+Deployment holds extra options for the coredns deployment deployed within the virtual cluster
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-image}
+
+Image is the coredns image to use
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-replicas}
+
+Replicas is the amount of coredns pods to run.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-nodeSelector}
+
+NodeSelector is the node selector to use for coredns.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-affinity}
+
+Affinity is the affinity to apply to the pod.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-tolerations}
+
+Tolerations are the tolerations to apply to the pod.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources}
+
+Resources are the desired resources for coredns.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources-limits}
+
+Limits are resource limits for the container
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-resources-requests}
+
+Requests are minimal resources that will be consumed by the container
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods}
+
+Pods is additional metadata for the coredns pods.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods-annotations}
+
+Annotations are extra annotations for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-pods-labels}
+
+Labels are extra labels for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-annotations}
+
+Annotations are extra annotations for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-labels}
+
+Labels are extra labels for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-coredns-deployment-topologySpreadConstraints}
+
+TopologySpreadConstraints are the topology spread constraints for the CoreDNS pod.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `overwriteConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-overwriteConfig}
+
+OverwriteConfig can be used to overwrite the coredns config
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `overwriteManifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-overwriteManifests}
+
+OverwriteManifests can be used to overwrite the coredns manifests used to deploy coredns
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-coredns-priorityClassName}
+
+PriorityClassName specifies the priority class name for the CoreDNS pods.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-proxy}
+
+Proxy defines options for the virtual cluster control plane proxy that is used to do authentication and intercept requests.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `bindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> {#controlPlane-proxy-bindAddress}
+
+BindAddress under which vCluster will expose the proxy.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> {#controlPlane-proxy-port}
+
+Port under which vCluster will expose the proxy. Changing port is currently not supported.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `extraSANs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-proxy-extraSANs}
+
+ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `hostPathMapper` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper}
+
+HostPathMapper defines if vCluster should rewrite host paths.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper-enabled}
+
+Enabled specifies if the host path mapper will be used
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `central` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-hostPathMapper-central}
+
+Central specifies if the central host path mapper will be used
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-ingress}
+
+Ingress defines options for vCluster ingress deployed by Helm.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-ingress-enabled}
+
+Enabled defines if the control plane ingress should be enabled
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#controlPlane-ingress-host}
+
+Host is the host where vCluster will be reachable
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `pathType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> {#controlPlane-ingress-pathType}
+
+PathType is the path type of the ingress
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-spec}
+
+Spec allows you to configure extra ingress options.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-annotations}
+
+Annotations are extra annotations for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-ingress-labels}
+
+Labels are extra labels for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-service}
+
+Service defines options for vCluster service deployed by Helm.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-service-enabled}
+
+Enabled defines if the control plane service should be enabled
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#controlPlane-service-spec}
+
+Spec allows you to configure extra service options.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `kubeletNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#controlPlane-service-kubeletNodePort}
+
+KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 0.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `httpsNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#controlPlane-service-httpsNodePort}
+
+HTTPSNodePort is the node port where https is exposed. Defaults to 0.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-service-annotations}
+
+Annotations are extra annotations for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-service-labels}
+
+Labels are extra labels for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet}
+
+StatefulSet defines options for vCluster statefulSet deployed by Helm.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability}
+
+HighAvailability holds options related to high availability.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-replicas}
+
+Replicas is the amount of replicas to use for the statefulSet.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `leaseDuration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-leaseDuration}
+
+LeaseDuration is the time to lease for the leader.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `renewDeadline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-renewDeadline}
+
+RenewDeadline is the deadline to renew a lease for the leader.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `retryPeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-highAvailability-retryPeriod}
+
+RetryPeriod is the time until a replica will retry to get a lease.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources}
+
+Resources are the resource requests and limits for the statefulSet container.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:8Gi memory:2Gi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources-limits}
+
+Limits are resource limits for the container
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:400Mi memory:256Mi&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-resources-requests}
+
+Requests are minimal resources that will be consumed by the container
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling}
+
+Scheduling holds options related to scheduling.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-nodeSelector}
+
+NodeSelector is the node selector to apply to the pod.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-affinity}
+
+Affinity is the affinity to apply to the pod.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-tolerations}
+
+Tolerations are the tolerations to apply to the pod.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-priorityClassName}
+
+PriorityClassName is the priority class name for the the pod.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-podManagementPolicy}
+
+PodManagementPolicy is the statefulSet pod management policy.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-scheduling-topologySpreadConstraints}
+
+TopologySpreadConstraints are the topology spread constraints for the pod.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security}
+
+Security defines pod or container security context.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security-podSecurityContext}
+
+PodSecurityContext specifies security context options on the pod level.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-security-containerSecurityContext}
+
+ContainerSecurityContext specifies security context options on the container level.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `probes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes}
+
+Probes enables or disables the main container probes.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `livenessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe}
+
+LivenessProbe specifies if the liveness probe for the container should be enabled
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-enabled}
+
+Enabled defines if this option should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-failureThreshold}
+
+Number of consecutive failures for the probe to be considered failed
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `initialDelaySeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-initialDelaySeconds}
+
+Time (in seconds) to wait before starting the liveness probe
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-timeoutSeconds}
+
+Maximum duration (in seconds) that the probe will wait for a response.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-livenessProbe-periodSeconds}
+
+Frequency (in seconds) to perform the probe
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `readinessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe}
+
+ReadinessProbe specifies if the readiness probe for the container should be enabled
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-enabled}
+
+Enabled defines if this option should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-failureThreshold}
+
+Number of consecutive failures for the probe to be considered failed
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-timeoutSeconds}
+
+Maximum duration (in seconds) that the probe will wait for a response.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-readinessProbe-periodSeconds}
+
+Frequency (in seconds) to perform the probe
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `startupProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe}
+
+StartupProbe specifies if the startup probe for the container should be enabled
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-enabled}
+
+Enabled defines if this option should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">300</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-failureThreshold}
+
+Number of consecutive failures allowed before failing the pod
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-timeoutSeconds}
+
+Maximum duration (in seconds) that the probe will wait for a response.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">6</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-probes-startupProbe-periodSeconds}
+
+Frequency (in seconds) to perform the probe
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence}
+
+Persistence defines options around persistence for the statefulSet.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim}
+
+VolumeClaim can be used to configure the persistent volume claim.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-enabled}
+
+Enabled enables deploying a persistent volume claim. If auto, vCluster will automatically determine
+based on the chosen distro and other options if this is required.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-accessModes}
+
+AccessModes are the persistent volume claim access modes.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-retentionPolicy}
+
+RetentionPolicy is the persistent volume claim retention policy.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-size}
+
+Size is the persistent volume claim storage size.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaim-storageClass}
+
+StorageClass is the persistent volume claim storage class.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-volumeClaimTemplates}
+
+VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `dataVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-dataVolume}
+
+Allows you to override the dataVolume. Only works correctly if volumeClaim.enabled=false.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `binariesVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-binariesVolume}
+
+BinariesVolume defines a binaries volume that is used to retrieve
+distro specific executables to be run by the syncer controller.
+This volume doesn't need to be persistent.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumes}
+
+AddVolumes defines extra volumes for the pod
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts}
+
+AddVolumeMounts defines extra volume mounts for the container
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-name}
+
+This must match the Name of a Volume.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-readOnly}
+
+Mounted read-only if true, read-write otherwise (false or unspecified).
+Defaults to false.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPath}
+
+Path within the container at which the volume should be mounted.  Must
+not contain ':'.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPath}
+
+Path within the volume from which the container's volume should be mounted.
+Defaults to "" (volume's root).
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-mountPropagation}
+
+mountPropagation determines how mounts are propagated from the host
+to container and the other way around.
+When not set, MountPropagationNone is used.
+This field is beta in 1.10.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-persistence-addVolumeMounts-subPathExpr}
+
+Expanded path within the volume from which the container's volume should be mounted.
+Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+Defaults to "" (volume's root).
+SubPathExpr and SubPath are mutually exclusive.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-enableServiceLinks}
+
+EnableServiceLinks for the StatefulSet pod
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-annotations}
+
+Annotations are extra annotations for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-labels}
+
+Labels are extra labels for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods}
+
+Additional labels or annotations for the statefulSet pods.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods-annotations}
+
+Annotations are extra annotations for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-pods-labels}
+
+Labels are extra labels for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image}
+
+Image is the image for the controlPlane statefulSet container
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-registry}
+
+Configure the registry of the container image, e.g. my-registry.com or ghcr.io
+It defaults to ghcr.io and can be overriding either by using this field or controlPlane.advanced.defaultImageRegistry
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-repository}
+
+Configure the repository of the container image, e.g. my-repo/my-image.
+It defaults to the vCluster pro repository that includes the optional pro modules that are turned off by default.
+If you still want to use the pure OSS build, use 'loft-sh/vcluster-oss' instead.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-image-tag}
+
+Tag is the tag of the container image, e.g. latest
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-imagePullPolicy}
+
+ImagePullPolicy is the policy how to pull the image.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `workingDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-workingDir}
+
+WorkingDir specifies in what folder the main process should get started.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-command}
+
+Command allows you to override the main command.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-args}
+
+Args allows you to override the main arguments.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-env}
+
+Env are additional environment variables for the statefulSet container.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `dnsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsPolicy}
+
+Set DNS policy for the pod.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `dnsConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig}
+
+Specifies the DNS parameters of a pod.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `nameservers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-nameservers}
+
+A list of DNS name server IP addresses.
+This will be appended to the base nameservers generated from DNSPolicy.
+Duplicated nameservers will be removed.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `searches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-searches}
+
+A list of DNS search domains for host-name lookup.
+This will be appended to the base search paths generated from DNSPolicy.
+Duplicated search paths will be removed.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options}
+
+A list of DNS resolver options.
+This will be merged with the base options generated from DNSPolicy.
+Duplicated entries will be removed. Resolution options given in Options
+will override those that appear in the base DNSPolicy.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options-name}
+
+Required.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-statefulSet-dnsConfig-options-value}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `serviceMonitor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor}
+
+ServiceMonitor can be used to automatically create a service monitor for vCluster deployment itself.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-enabled}
+
+Enabled configures if Helm should create the service monitor.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-labels}
+
+Labels are the extra labels to add to the service monitor.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-serviceMonitor-annotations}
+
+Annotations are the extra annotations to add to the service monitor.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced}
+
+Advanced holds additional configuration for the vCluster control plane.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-defaultImageRegistry}
+
+DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
+upload all required vCluster images to a single private repository and set this value. Workload images are not affected by this.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-virtualScheduler}
+
+VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.
+Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-virtualScheduler-enabled}
+
+Enabled defines if this option should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount}
+
+ServiceAccount specifies options for the vCluster control plane service account.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-enabled}
+
+Enabled specifies if the service account should get deployed.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-name}
+
+Name specifies what name to use for the service account.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-imagePullSecrets}
+
+ImagePullSecrets defines extra image pull secrets for the service account.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-imagePullSecrets-name}
+
+Name of the image pull secret to use.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-annotations}
+
+Annotations are extra annotations for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-serviceAccount-labels}
+
+Labels are extra labels for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount}
+
+WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-enabled}
+
+Enabled specifies if the service account for the workloads should get deployed.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-name}
+
+Name specifies what name to use for the service account for the virtual cluster workloads.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets}
+
+ImagePullSecrets defines extra image pull secrets for the workload service account.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-imagePullSecrets-name}
+
+Name of the image pull secret to use.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-annotations}
+
+Annotations are extra annotations for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-workloadServiceAccount-labels}
+
+Labels are extra labels for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService}
+
+HeadlessService specifies options for the headless service used for the vCluster StatefulSet.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService-annotations}
+
+Annotations are extra annotations for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-headlessService-labels}
+
+Labels are extra labels for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `konnectivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity}
+
+Konnectivity holds dedicated konnectivity configuration. This is only available when privateNodes.enabled is true.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-server}
+
+Server holds configuration for the konnectivity server.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-server-enabled}
+
+Enabled defines if the konnectivity server should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-server-extraArgs}
+
+ExtraArgs are additional arguments to pass to the konnectivity server.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `agent` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent}
+
+Agent holds configuration for the konnectivity agent.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-enabled}
+
+Enabled defines if the konnectivity agent should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-replicas}
+
+Replicas is the number of replicas for the konnectivity agent.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-image}
+
+Image is the image for the konnectivity agent.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-imagePullPolicy}
+
+ImagePullPolicy is the policy how to pull the image.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-nodeSelector}
+
+NodeSelector is the node selector for the konnectivity agent.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-priorityClassName}
+
+PriorityClassName is the priority class name for the konnectivity agent.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-tolerations}
+
+Tolerations is the tolerations for the konnectivity agent.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-extraEnv}
+
+ExtraEnv is the extra environment variables for the konnectivity agent.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-konnectivity-agent-extraArgs}
+
+ExtraArgs are additional arguments to pass to the konnectivity agent.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry}
+
+Registry allows enabling an embedded docker image registry in vCluster. This is useful for air-gapped environments or when you don't have a public registry available to distribute images.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry-enabled}
+
+Enabled defines if the embedded registry should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `anonymousPull` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry-anonymousPull}
+
+AnonymousPull allows enabling anonymous pull for the embedded registry. This allows anybody to pull images from the registry without authentication.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-registry-config}
+
+Config is the regular docker registry config. See https://distribution.github.io/distribution/about/configuration/ for more details.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#controlPlane-advanced-globalMetadata}
+
+GlobalMetadata is metadata that will be added to all resources deployed by Helm.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#controlPlane-advanced-globalMetadata-annotations}
+
+Annotations are extra annotations for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
 
 </details>

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/advanced.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/advanced.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced}
+## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced}
 
 Advanced holds additional configuration for the vCluster control plane.
 
@@ -14,7 +14,7 @@ Advanced holds additional configuration for the vCluster control plane.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-defaultImageRegistry}
+### `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-defaultImageRegistry}
 
 DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
 upload all required vCluster images to a single private repository and set this value. Workload images are not affected by this.
@@ -30,7 +30,7 @@ upload all required vCluster images to a single private repository and set this 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-virtualScheduler}
+### `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-virtualScheduler}
 
 VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.
 Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
@@ -43,7 +43,7 @@ Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-virtualScheduler-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-virtualScheduler-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -61,7 +61,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount}
+### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount}
 
 ServiceAccount specifies options for the vCluster control plane service account.
 
@@ -73,7 +73,7 @@ ServiceAccount specifies options for the vCluster control plane service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-enabled}
 
 Enabled specifies if the service account should get deployed.
 
@@ -88,7 +88,7 @@ Enabled specifies if the service account should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-name}
 
 Name specifies what name to use for the service account.
 
@@ -103,7 +103,7 @@ Name specifies what name to use for the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-imagePullSecrets}
+#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the service account.
 
@@ -115,7 +115,7 @@ ImagePullSecrets defines extra image pull secrets for the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-serviceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -133,7 +133,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -148,7 +148,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-serviceAccount-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-serviceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -166,7 +166,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount}
+### `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount}
 
 WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster.
 
@@ -178,7 +178,7 @@ WorkloadServiceAccount specifies options for the service account that will be us
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-enabled}
 
 Enabled specifies if the service account for the workloads should get deployed.
 
@@ -193,7 +193,7 @@ Enabled specifies if the service account for the workloads should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-name}
 
 Name specifies what name to use for the service account for the virtual cluster workloads.
 
@@ -208,7 +208,7 @@ Name specifies what name to use for the service account for the virtual cluster 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-imagePullSecrets}
+#### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the workload service account.
 
@@ -220,7 +220,7 @@ ImagePullSecrets defines extra image pull secrets for the workload service accou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-imagePullSecrets-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -238,7 +238,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -253,7 +253,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-workloadServiceAccount-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-workloadServiceAccount-labels}
 
 Labels are extra labels for this resource.
 
@@ -271,7 +271,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-headlessService}
+### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-headlessService}
 
 HeadlessService specifies options for the headless service used for the vCluster StatefulSet.
 
@@ -283,7 +283,7 @@ HeadlessService specifies options for the headless service used for the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-headlessService-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-headlessService-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -298,7 +298,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-headlessService-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-headlessService-labels}
 
 Labels are extra labels for this resource.
 
@@ -310,5 +310,306 @@ Labels are extra labels for this resource.
 
 
 </details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `konnectivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity}
+
+Konnectivity holds dedicated konnectivity configuration. This is only available when privateNodes.enabled is true.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-server}
+
+Server holds configuration for the konnectivity server.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-konnectivity-server-enabled}
+
+Enabled defines if the konnectivity server should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-server-extraArgs}
+
+ExtraArgs are additional arguments to pass to the konnectivity server.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `agent` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent}
+
+Agent holds configuration for the konnectivity agent.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-enabled}
+
+Enabled defines if the konnectivity agent should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-replicas}
+
+Replicas is the number of replicas for the konnectivity agent.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-image}
+
+Image is the image for the konnectivity agent.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-imagePullPolicy}
+
+ImagePullPolicy is the policy how to pull the image.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-nodeSelector}
+
+NodeSelector is the node selector for the konnectivity agent.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-priorityClassName}
+
+PriorityClassName is the priority class name for the konnectivity agent.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-tolerations}
+
+Tolerations is the tolerations for the konnectivity agent.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `extraEnv` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-extraEnv}
+
+ExtraEnv is the extra environment variables for the konnectivity agent.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#advanced-konnectivity-agent-extraArgs}
+
+ExtraArgs are additional arguments to pass to the konnectivity agent.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-registry}
+
+Registry allows enabling an embedded docker image registry in vCluster. This is useful for air-gapped environments or when you don't have a public registry available to distribute images.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-registry-enabled}
+
+Enabled defines if the embedded registry should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `anonymousPull` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-registry-anonymousPull}
+
+AnonymousPull allows enabling anonymous pull for the embedded registry. This allows anybody to pull images from the registry without authentication.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-registry-config}
+
+Config is the regular docker registry config. See https://distribution.github.io/distribution/about/configuration/ for more details.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-globalMetadata}
+
+GlobalMetadata is metadata that will be added to all resources deployed by Helm.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#advanced-globalMetadata-annotations}
+
+Annotations are extra annotations for this resource.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
 
 </details>

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/advanced/defaultImageRegistry.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/advanced/defaultImageRegistry.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#defaultImageRegistry}
+## `defaultImageRegistry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#defaultImageRegistry}
 
 DefaultImageRegistry will be used as a prefix for all internal images deployed by vCluster or Helm. This makes it easy to
 upload all required vCluster images to a single private repository and set this value. Workload images are not affected by this.

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/advanced/globalMetadata.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/advanced/globalMetadata.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#globalMetadata}
+## `globalMetadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#globalMetadata}
 
 GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 
@@ -14,7 +14,7 @@ GlobalMetadata is metadata that will be added to all resources deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#globalMetadata-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#globalMetadata-annotations}
 
 Annotations are extra annotations for this resource.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/advanced/headlessService.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/advanced/headlessService.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#headlessService}
+## `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#headlessService}
 
 HeadlessService specifies options for the headless service used for the vCluster StatefulSet.
 
@@ -14,7 +14,7 @@ HeadlessService specifies options for the headless service used for the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#headlessService-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#headlessService-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -29,7 +29,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#headlessService-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#headlessService-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/advanced/serviceAccount.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/advanced/serviceAccount.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount}
+## `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount}
 
 ServiceAccount specifies options for the vCluster control plane service account.
 
@@ -14,7 +14,7 @@ ServiceAccount specifies options for the vCluster control plane service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#serviceAccount-enabled}
 
 Enabled specifies if the service account should get deployed.
 
@@ -29,7 +29,7 @@ Enabled specifies if the service account should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-name}
 
 Name specifies what name to use for the service account.
 
@@ -44,7 +44,7 @@ Name specifies what name to use for the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-imagePullSecrets}
+### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the service account.
 
@@ -56,7 +56,7 @@ ImagePullSecrets defines extra image pull secrets for the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-imagePullSecrets-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -74,7 +74,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccount-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceAccount-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/advanced/virtualScheduler.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/advanced/virtualScheduler.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualScheduler}
+## `virtualScheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualScheduler}
 
 VirtualScheduler defines if a scheduler should be used within the virtual cluster or the scheduling decision for workloads will be made by the host cluster.
 Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
@@ -15,7 +15,7 @@ Deprecated: Use ControlPlane.Distro.K8S.Scheduler instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualScheduler-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#virtualScheduler-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/advanced/workloadServiceAccount.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/advanced/workloadServiceAccount.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount}
+## `workloadServiceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount}
 
 WorkloadServiceAccount specifies options for the service account that will be used for the workloads that run within the virtual cluster.
 
@@ -14,7 +14,7 @@ WorkloadServiceAccount specifies options for the service account that will be us
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#workloadServiceAccount-enabled}
 
 Enabled specifies if the service account for the workloads should get deployed.
 
@@ -29,7 +29,7 @@ Enabled specifies if the service account for the workloads should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-name}
 
 Name specifies what name to use for the service account for the virtual cluster workloads.
 
@@ -44,7 +44,7 @@ Name specifies what name to use for the service account for the virtual cluster 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-imagePullSecrets}
+### `imagePullSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-imagePullSecrets}
 
 ImagePullSecrets defines extra image pull secrets for the workload service account.
 
@@ -56,7 +56,7 @@ ImagePullSecrets defines extra image pull secrets for the workload service accou
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-imagePullSecrets-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#workloadServiceAccount-imagePullSecrets-name}
 
 Name of the image pull secret to use.
 
@@ -74,7 +74,7 @@ Name of the image pull secret to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#workloadServiceAccount-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#workloadServiceAccount-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#workloadServiceAccount-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/backingStore.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/backingStore.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `backingStore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore}
+## `backingStore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore}
 
 BackingStore defines which backing store to use for virtual cluster. If not defined will use embedded database as a default backing store.
 
@@ -14,7 +14,7 @@ BackingStore defines which backing store to use for virtual cluster. If not defi
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `etcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd}
+### `etcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd}
 
 Etcd defines that etcd should be used as the backend for the virtual cluster
 
@@ -26,7 +26,7 @@ Etcd defines that etcd should be used as the backend for the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-embedded}
+#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded}
 
 Embedded defines to use embedded etcd as a storage backend for the virtual cluster
 
@@ -38,7 +38,7 @@ Embedded defines to use embedded etcd as a storage backend for the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-enabled}
 
 Enabled defines if the embedded etcd should be used.
 
@@ -53,7 +53,7 @@ Enabled defines if the embedded etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-embedded-migrateFromDeployedEtcd}
+##### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-migrateFromDeployedEtcd}
 
 MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd.
 
@@ -68,7 +68,7 @@ MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-embedded-snapshotCount}
+##### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-snapshotCount}
 
 SnapshotCount defines the number of snapshots to keep for the embedded etcd. Defaults to 10000 if less than 1.
 
@@ -83,7 +83,7 @@ SnapshotCount defines the number of snapshots to keep for the embedded etcd. Def
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-embedded-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to the embedded etcd.
 
@@ -101,7 +101,7 @@ ExtraArgs are additional arguments to pass to the embedded etcd.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy}
+#### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy}
 
 Deploy defines to use an external etcd that is deployed by the helm chart
 
@@ -113,7 +113,7 @@ Deploy defines to use an external etcd that is deployed by the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-enabled}
 
 Enabled defines that an external etcd should be deployed.
 
@@ -128,7 +128,7 @@ Enabled defines that an external etcd should be deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet}
+##### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet}
 
 StatefulSet holds options for the external etcd statefulSet.
 
@@ -140,7 +140,7 @@ StatefulSet holds options for the external etcd statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-enabled}
 
 Enabled defines if the statefulSet should be deployed
 
@@ -155,7 +155,7 @@ Enabled defines if the statefulSet should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-enableServiceLinks}
+##### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -170,7 +170,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image}
 
 Image is the image to use for the external etcd statefulSet
 
@@ -182,7 +182,7 @@ Image is the image to use for the external etcd statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -198,7 +198,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -213,7 +213,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.21-0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.21-0</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -231,7 +231,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-imagePullPolicy}
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the external etcd image
 
@@ -246,7 +246,7 @@ ImagePullPolicy is the pull policy for the external etcd image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-env}
+##### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-env}
 
 Env are extra environment variables
 
@@ -261,7 +261,7 @@ Env are extra environment variables
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-extraArgs}
 
 ExtraArgs are appended to the etcd command.
 
@@ -276,7 +276,7 @@ ExtraArgs are appended to the etcd command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources}
 
 Resources the etcd can consume
 
@@ -288,7 +288,7 @@ Resources the etcd can consume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -303,7 +303,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -321,7 +321,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-pods}
+##### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods}
 
 Pods defines extra metadata for the etcd pods.
 
@@ -333,7 +333,7 @@ Pods defines extra metadata for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -348,7 +348,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -366,7 +366,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-highAvailability}
+##### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-highAvailability}
 
 HighAvailability are high availability options
 
@@ -378,7 +378,7 @@ HighAvailability are high availability options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-highAvailability-replicas}
 
 Replicas are the amount of pods to use.
 
@@ -396,7 +396,7 @@ Replicas are the amount of pods to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling}
+##### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling}
 
 Scheduling options for the etcd pods.
 
@@ -408,7 +408,7 @@ Scheduling options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -423,7 +423,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -438,7 +438,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -453,7 +453,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -468,7 +468,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -483,7 +483,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -501,7 +501,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-security}
+##### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security}
 
 Security options for the etcd pods.
 
@@ -513,7 +513,7 @@ Security options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -528,7 +528,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -546,7 +546,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence}
+##### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence}
 
 Persistence options for the etcd pods.
 
@@ -558,7 +558,7 @@ Persistence options for the etcd pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -570,7 +570,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim.
 
@@ -585,7 +585,7 @@ Enabled enables deploying a persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -600,7 +600,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -615,7 +615,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -630,7 +630,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -648,7 +648,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -663,7 +663,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -678,7 +678,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -690,7 +690,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -705,7 +705,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -721,7 +721,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -737,7 +737,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -753,7 +753,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -771,7 +771,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -795,7 +795,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -810,7 +810,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-statefulSet-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -828,7 +828,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service}
 
 Service holds options for the external etcd service.
 
@@ -840,7 +840,7 @@ Service holds options for the external etcd service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-service-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service-enabled}
 
 Enabled defines if the etcd service should be deployed
 
@@ -855,7 +855,7 @@ Enabled defines if the etcd service should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-service-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-service-annotations}
 
 Annotations are extra annotations for the external etcd service
 
@@ -873,7 +873,7 @@ Annotations are extra annotations for the external etcd service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-headlessService}
+##### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-headlessService}
 
 HeadlessService holds options for the external etcd headless service.
 
@@ -885,7 +885,7 @@ HeadlessService holds options for the external etcd headless service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-deploy-headlessService-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#backingStore-etcd-deploy-headlessService-annotations}
 
 Annotations are extra annotations for the external etcd headless service
 
@@ -906,7 +906,7 @@ Annotations are extra annotations for the external etcd headless service
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external}
+#### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external}
 
 External defines to use a self-hosted external etcd that is not deployed by the helm chart
 
@@ -918,7 +918,7 @@ External defines to use a self-hosted external etcd that is not deployed by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-etcd-external-enabled}
 
 Enabled defines if the external etcd should be used.
 
@@ -933,7 +933,7 @@ Enabled defines if the external etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external-endpoint}
+##### `endpoint` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-endpoint}
 
 Endpoint holds the endpoint of the external etcd server, e.g. my-example-service:2379
 
@@ -948,7 +948,7 @@ Endpoint holds the endpoint of the external etcd server, e.g. my-example-service
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `tls` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external-tls}
+##### `tls` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls}
 
 TLS defines the tls configuration for the external etcd server
 
@@ -960,7 +960,7 @@ TLS defines the tls configuration for the external etcd server
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external-tls-caFile}
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-caFile}
 
 CaFile is the path to the ca file
 
@@ -975,7 +975,7 @@ CaFile is the path to the ca file
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external-tls-certFile}
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-certFile}
 
 CertFile is the path to the cert file
 
@@ -990,7 +990,7 @@ CertFile is the path to the cert file
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-etcd-external-tls-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-etcd-external-tls-keyFile}
 
 KeyFile is the path to the key file
 
@@ -1014,7 +1014,7 @@ KeyFile is the path to the key file
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database}
+### `database` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database}
 
 Database defines that a database backend should be used as the backend for the virtual cluster. This uses a project called kine under the hood which is a shim for bridging Kubernetes and relational databases.
 
@@ -1026,7 +1026,7 @@ Database defines that a database backend should be used as the backend for the v
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded}
+#### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded}
 
 Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster
 
@@ -1038,7 +1038,7 @@ Embedded defines that an embedded database (sqlite) should be used as the backen
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-database-embedded-enabled}
 
 Enabled defines if the database should be used.
 
@@ -1053,7 +1053,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -1071,7 +1071,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -1086,7 +1086,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-certFile}
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -1101,7 +1101,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-caFile}
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-embedded-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -1116,7 +1116,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-embedded-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-database-embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 
@@ -1134,7 +1134,7 @@ ExtraArgs are additional arguments to pass to Kine.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external}
+#### `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external}
 
 External defines that an external database should be used as the backend for the virtual cluster
 
@@ -1146,7 +1146,7 @@ External defines that an external database should be used as the backend for the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#backingStore-database-external-enabled}
 
 Enabled defines if the database should be used.
 
@@ -1161,7 +1161,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-dataSource}
+##### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -1179,7 +1179,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-keyFile}
+##### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -1194,7 +1194,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-certFile}
+##### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -1209,7 +1209,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-caFile}
+##### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -1224,7 +1224,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#backingStore-database-external-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 
@@ -1239,7 +1239,7 @@ ExtraArgs are additional arguments to pass to Kine.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#backingStore-database-external-connector}
+##### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#backingStore-database-external-connector}
 
 Connector specifies a secret located in a connected vCluster Platform that contains database server connection information
 to be used by Platform to create a database and database user for the vCluster.

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/backingStore/backing-store-migration.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/backingStore/backing-store-migration.mdx
@@ -1,3 +1,0 @@
-:::warning
-After deploying your vCluster, there are limited migration paths to change your backing store. Review the backing store migration options before deploying.
-:::

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/backingStore/database/embedded.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/backingStore/database/embedded.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded}
+## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded}
 
 Embedded defines that an embedded database (sqlite) should be used as the backend for the virtual cluster
 
@@ -14,7 +14,7 @@ Embedded defines that an embedded database (sqlite) should be used as the backen
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-enabled}
 
 Enabled defines if the database should be used.
 
@@ -29,7 +29,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-dataSource}
+### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -47,7 +47,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-keyFile}
+### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -62,7 +62,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-certFile}
+### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -77,7 +77,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-caFile}
+### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -92,7 +92,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/backingStore/database/external.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/backingStore/database/external.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external}
+## `external` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external}
 
 External defines that an external database should be used as the backend for the virtual cluster
 
@@ -14,7 +14,7 @@ External defines that an external database should be used as the backend for the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#external-enabled}
 
 Enabled defines if the database should be used.
 
@@ -29,7 +29,7 @@ Enabled defines if the database should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-dataSource}
+### `dataSource` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-dataSource}
 
 DataSource is the kine dataSource to use for the database. This depends on the database format.
 This is optional for the embedded database. Examples:
@@ -47,7 +47,7 @@ This is optional for the embedded database. Examples:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-keyFile}
+### `keyFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-keyFile}
 
 KeyFile is the key file to use for the database. This is optional.
 
@@ -62,7 +62,7 @@ KeyFile is the key file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-certFile}
+### `certFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-certFile}
 
 CertFile is the cert file to use for the database. This is optional.
 
@@ -77,7 +77,7 @@ CertFile is the cert file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-caFile}
+### `caFile` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-caFile}
 
 CaFile is the ca file to use for the database. This is optional.
 
@@ -92,7 +92,7 @@ CaFile is the ca file to use for the database. This is optional.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#external-extraArgs}
 
 ExtraArgs are additional arguments to pass to Kine.
 
@@ -107,7 +107,7 @@ ExtraArgs are additional arguments to pass to Kine.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#external-connector}
+### `connector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#external-connector}
 
 Connector specifies a secret located in a connected vCluster Platform that contains database server connection information
 to be used by Platform to create a database and database user for the vCluster.

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/backingStore/etcd/deploy.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/backingStore/etcd/deploy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy}
+## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
 
 Deploy defines to use an external etcd that is deployed by the helm chart
 
@@ -14,7 +14,7 @@ Deploy defines to use an external etcd that is deployed by the helm chart
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deploy-enabled}
 
 Enabled defines that an external etcd should be deployed.
 
@@ -29,7 +29,7 @@ Enabled defines that an external etcd should be deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet}
+### `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet}
 
 StatefulSet holds options for the external etcd statefulSet.
 
@@ -41,7 +41,7 @@ StatefulSet holds options for the external etcd statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-enabled}
 
 Enabled defines if the statefulSet should be deployed
 
@@ -56,7 +56,7 @@ Enabled defines if the statefulSet should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-enableServiceLinks}
+#### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -71,7 +71,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-image}
 
 Image is the image to use for the external etcd statefulSet
 
@@ -83,7 +83,7 @@ Image is the image to use for the external etcd statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">registry.k8s.io</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -99,7 +99,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">etcd</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -114,7 +114,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.21-0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">3.5.21-0</span> <span className="config-field-enum"></span> {#deploy-statefulSet-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -132,7 +132,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the external etcd image
 
@@ -147,7 +147,7 @@ ImagePullPolicy is the pull policy for the external etcd image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-env}
+#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-env}
 
 Env are extra environment variables
 
@@ -162,7 +162,7 @@ Env are extra environment variables
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-extraArgs}
 
 ExtraArgs are appended to the etcd command.
 
@@ -177,7 +177,7 @@ ExtraArgs are appended to the etcd command.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources}
 
 Resources the etcd can consume
 
@@ -189,7 +189,7 @@ Resources the etcd can consume
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -204,7 +204,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:150Mi&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -222,7 +222,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-pods}
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods}
 
 Pods defines extra metadata for the etcd pods.
 
@@ -234,7 +234,7 @@ Pods defines extra metadata for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -249,7 +249,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -267,7 +267,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-highAvailability}
+#### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-highAvailability}
 
 HighAvailability are high availability options
 
@@ -279,7 +279,7 @@ HighAvailability are high availability options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-highAvailability-replicas}
+##### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#deploy-statefulSet-highAvailability-replicas}
 
 Replicas are the amount of pods to use.
 
@@ -297,7 +297,7 @@ Replicas are the amount of pods to use.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling}
+#### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling}
 
 Scheduling options for the etcd pods.
 
@@ -309,7 +309,7 @@ Scheduling options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-nodeSelector}
+##### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -324,7 +324,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-affinity}
+##### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -339,7 +339,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-tolerations}
+##### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -354,7 +354,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -369,7 +369,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-podManagementPolicy}
+##### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -384,7 +384,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-scheduling-topologySpreadConstraints}
+##### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -402,7 +402,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-security}
+#### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-security}
 
 Security options for the etcd pods.
 
@@ -414,7 +414,7 @@ Security options for the etcd pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-security-podSecurityContext}
+##### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -429,7 +429,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-security-containerSecurityContext}
+##### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -447,7 +447,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence}
+#### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence}
 
 Persistence options for the etcd pods.
 
@@ -459,7 +459,7 @@ Persistence options for the etcd pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim}
+##### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -471,7 +471,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim.
 
@@ -486,7 +486,7 @@ Enabled enables deploying a persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -501,7 +501,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -516,7 +516,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -531,7 +531,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -549,7 +549,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-volumeClaimTemplates}
+##### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -564,7 +564,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumes}
+##### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -579,7 +579,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts}
+##### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -591,7 +591,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -606,7 +606,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -622,7 +622,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -638,7 +638,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -654,7 +654,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -672,7 +672,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -696,7 +696,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -711,7 +711,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-statefulSet-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -729,7 +729,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-service}
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-service}
 
 Service holds options for the external etcd service.
 
@@ -741,7 +741,7 @@ Service holds options for the external etcd service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-service-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deploy-service-enabled}
 
 Enabled defines if the etcd service should be deployed
 
@@ -756,7 +756,7 @@ Enabled defines if the etcd service should be deployed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-service-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-service-annotations}
 
 Annotations are extra annotations for the external etcd service
 
@@ -774,7 +774,7 @@ Annotations are extra annotations for the external etcd service
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-headlessService}
+### `headlessService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-headlessService}
 
 HeadlessService holds options for the external etcd headless service.
 
@@ -786,7 +786,7 @@ HeadlessService holds options for the external etcd headless service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-headlessService-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#deploy-headlessService-annotations}
 
 Annotations are extra annotations for the external etcd headless service
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/backingStore/etcd/embedded.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/backingStore/etcd/embedded.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded}
+## `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded}
 
 Embedded defines to use embedded etcd as a storage backend for the virtual cluster
 
@@ -14,7 +14,7 @@ Embedded defines to use embedded etcd as a storage backend for the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-enabled}
 
 Enabled defines if the embedded etcd should be used.
 
@@ -29,7 +29,7 @@ Enabled defines if the embedded etcd should be used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-migrateFromDeployedEtcd}
+### `migrateFromDeployedEtcd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#embedded-migrateFromDeployedEtcd}
 
 MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed external etcd to embedded etcd.
 
@@ -44,7 +44,7 @@ MigrateFromDeployedEtcd signals that vCluster should migrate from the deployed e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-snapshotCount}
+### `snapshotCount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#embedded-snapshotCount}
 
 SnapshotCount defines the number of snapshots to keep for the embedded etcd. Defaults to 10000 if less than 1.
 
@@ -59,7 +59,7 @@ SnapshotCount defines the number of snapshots to keep for the embedded etcd. Def
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#embedded-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#embedded-extraArgs}
 
 ExtraArgs are additional arguments to pass to the embedded etcd.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/coredns.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/coredns.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `coredns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns}
+## `coredns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns}
 
 CoreDNS defines everything related to the coredns that is deployed and used within the vCluster.
 
@@ -14,7 +14,7 @@ CoreDNS defines everything related to the coredns that is deployed and used with
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#coredns-enabled}
 
 Enabled defines if coredns is enabled
 
@@ -29,7 +29,7 @@ Enabled defines if coredns is enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-embedded}
+### `embedded` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#coredns-embedded}
 
 Embedded defines if vCluster will start the embedded coredns service within the control-plane and not as a separate deployment. This is a PRO feature.
 
@@ -44,7 +44,7 @@ Embedded defines if vCluster will start the embedded coredns service within the 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-security}
+### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-security}
 
 Security defines pod or container security context.
 
@@ -56,7 +56,7 @@ Security defines pod or container security context.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-security-podSecurityContext}
+#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -71,7 +71,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-security-containerSecurityContext}
+#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -89,7 +89,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-service}
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-service}
 
 Service holds extra options for the coredns service deployed within the virtual cluster
 
@@ -101,7 +101,7 @@ Service holds extra options for the coredns service deployed within the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-service-spec}
+#### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#coredns-service-spec}
 
 Spec holds extra options for the coredns service
 
@@ -116,7 +116,7 @@ Spec holds extra options for the coredns service
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-service-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -131,7 +131,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-service-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-service-labels}
 
 Labels are extra labels for this resource.
 
@@ -149,7 +149,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `deployment` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment}
+### `deployment` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment}
 
 Deployment holds extra options for the coredns deployment deployed within the virtual cluster
 
@@ -161,7 +161,7 @@ Deployment holds extra options for the coredns deployment deployed within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-image}
 
 Image is the coredns image to use
 
@@ -176,7 +176,7 @@ Image is the coredns image to use
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-replicas}
+#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#coredns-deployment-replicas}
 
 Replicas is the amount of coredns pods to run.
 
@@ -191,7 +191,7 @@ Replicas is the amount of coredns pods to run.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-nodeSelector}
+#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-nodeSelector}
 
 NodeSelector is the node selector to use for coredns.
 
@@ -206,7 +206,7 @@ NodeSelector is the node selector to use for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-affinity}
+#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -221,7 +221,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-tolerations}
+#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -236,7 +236,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-resources}
 
 Resources are the desired resources for coredns.
 
@@ -248,7 +248,7 @@ Resources are the desired resources for coredns.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1000m memory:170Mi&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-resources-limits}
 
 Limits are resource limits for the container
 
@@ -263,7 +263,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:20m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -281,7 +281,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-pods}
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-deployment-pods}
 
 Pods is additional metadata for the coredns pods.
 
@@ -293,7 +293,7 @@ Pods is additional metadata for the coredns pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-pods-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -308,7 +308,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-pods-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -326,7 +326,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -341,7 +341,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#coredns-deployment-labels}
 
 Labels are extra labels for this resource.
 
@@ -356,7 +356,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-deployment-topologySpreadConstraints}
+#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;labelSelector:map&#91;matchLabels:map&#91;k8s-app:vcluster-kube-dns&#93;&#93; maxSkew:1 topologyKey:kubernetes.io/hostname whenUnsatisfiable:DoNotSchedule&#93;&#93;</span> <span className="config-field-enum"></span> {#coredns-deployment-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the CoreDNS pod.
 
@@ -374,7 +374,7 @@ TopologySpreadConstraints are the topology spread constraints for the CoreDNS po
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `overwriteConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-overwriteConfig}
+### `overwriteConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-overwriteConfig}
 
 OverwriteConfig can be used to overwrite the coredns config
 
@@ -389,7 +389,7 @@ OverwriteConfig can be used to overwrite the coredns config
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `overwriteManifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-overwriteManifests}
+### `overwriteManifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-overwriteManifests}
 
 OverwriteManifests can be used to overwrite the coredns manifests used to deploy coredns
 
@@ -404,7 +404,7 @@ OverwriteManifests can be used to overwrite the coredns manifests used to deploy
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#coredns-priorityClassName}
+### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#coredns-priorityClassName}
 
 PriorityClassName specifies the priority class name for the CoreDNS pods.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/distro.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/distro.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro}
+## `distro` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro}
 
 Distro holds virtual cluster related distro options. A distro cannot be changed after vCluster is deployed.
 
@@ -14,7 +14,7 @@ Distro holds virtual cluster related distro options. A distro cannot be changed 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s}
+### `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s}
 
 K8S holds K8s relevant configuration.
 
@@ -26,7 +26,7 @@ K8S holds K8s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k8s-enabled}
 
 Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -41,7 +41,7 @@ Enabled specifies if the K8s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-version}
+#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-version}
 
 [Deprecated] Version field is deprecated.
 Use controlPlane.distro.k8s.image.tag to specify the Kubernetes version instead.
@@ -57,7 +57,7 @@ Use controlPlane.distro.k8s.image.tag to specify the Kubernetes version instead.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer}
+#### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-apiServer}
 
 APIServer holds configuration specific to starting the api server.
 
@@ -69,7 +69,7 @@ APIServer holds configuration specific to starting the api server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -84,7 +84,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -99,7 +99,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-apiServer-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-apiServer-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -117,7 +117,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager}
+#### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager}
 
 ControllerManager holds configuration specific to starting the controller manager.
 
@@ -129,7 +129,7 @@ ControllerManager holds configuration specific to starting the controller manage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -144,7 +144,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -159,7 +159,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-controllerManager-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-controllerManager-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -177,7 +177,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-scheduler}
+#### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-scheduler}
 
 Scheduler holds configuration specific to starting the scheduler. Enable this via controlPlane.advanced.virtualScheduler.enabled
 
@@ -189,7 +189,7 @@ Scheduler holds configuration specific to starting the scheduler. Enable this vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-scheduler-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -204,7 +204,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-scheduler-command}
+##### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -219,7 +219,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-scheduler-extraArgs}
+##### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-scheduler-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -237,7 +237,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-image}
 
 Image is the distro image
 
@@ -249,7 +249,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#distro-k8s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -265,7 +265,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#distro-k8s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -280,7 +280,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> {#distro-k8s-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -298,7 +298,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k8s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -313,7 +313,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-env}
+#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -328,7 +328,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#distro-k8s-resources}
 
 Resources for the distro init container
 
@@ -343,7 +343,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k8s-securityContext}
+#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#distro-k8s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -361,7 +361,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s}
+### `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s}
 
 [Deprecated] K3S holds K3s relevant configuration.
 
@@ -373,7 +373,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#distro-k3s-enabled}
 
 Enabled specifies if the K3s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -388,7 +388,7 @@ Enabled specifies if the K3s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-token}
+#### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-token}
 
 Token is the K3s token to use. If empty, vCluster will choose one.
 
@@ -403,7 +403,7 @@ Token is the K3s token to use. If empty, vCluster will choose one.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-image}
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-image}
 
 Image is the distro image
 
@@ -415,7 +415,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-image-registry}
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -431,7 +431,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-image-repository}
+##### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> {#distro-k3s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -446,7 +446,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1-k3s1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-image-tag}
+##### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1-k3s1</span> <span className="config-field-enum"></span> {#distro-k3s-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -464,7 +464,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-imagePullPolicy}
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -479,7 +479,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-env}
+#### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#distro-k3s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -494,7 +494,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#distro-k3s-resources}
 
 Resources for the distro init container
 
@@ -509,7 +509,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-securityContext}
+#### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#distro-k3s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -524,7 +524,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k3s-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -539,7 +539,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#distro-k3s-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#distro-k3s-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/distro/k0s.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/distro/k0s.mdx
@@ -1,3 +1,0 @@
-:::warning
-K0s distribution configuration options have been deprecated as of vCluster v0.25.0 and removed in v0.26.0.
-:::

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/distro/k3s.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/distro/k3s.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s}
+## `k3s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s}
 
 [Deprecated] K3S holds K3s relevant configuration.
 
@@ -14,7 +14,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k3s-enabled}
 
 Enabled specifies if the K3s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -29,7 +29,7 @@ Enabled specifies if the K3s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-token}
+### `token` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-token}
 
 Token is the K3s token to use. If empty, vCluster will choose one.
 
@@ -44,7 +44,7 @@ Token is the K3s token to use. If empty, vCluster will choose one.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-image}
+### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-image}
 
 Image is the distro image
 
@@ -56,7 +56,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-image-registry}
+#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -72,7 +72,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-image-repository}
+#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">rancher/k3s</span> <span className="config-field-enum"></span> {#k3s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -87,7 +87,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1-k3s1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-image-tag}
+#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1-k3s1</span> <span className="config-field-enum"></span> {#k3s-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -105,7 +105,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -120,7 +120,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-env}
+### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k3s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -135,7 +135,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#k3s-resources}
 
 Resources for the distro init container
 
@@ -150,7 +150,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-securityContext}
+### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#k3s-securityContext}
 
 Security options can be used for the distro init container
 
@@ -165,7 +165,7 @@ Security options can be used for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-command}
+### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k3s-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -180,7 +180,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k3s-extraArgs}
+### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k3s-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/distro/k8s.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/distro/k8s.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s}
+## `k8s` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s}
 
 K8S holds K8s relevant configuration.
 
@@ -14,7 +14,7 @@ K8S holds K8s relevant configuration.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k8s-enabled}
 
 Enabled specifies if the K8s distro should be enabled. Only one distro can be enabled at the same time.
 
@@ -29,7 +29,7 @@ Enabled specifies if the K8s distro should be enabled. Only one distro can be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-version}
+### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-version}
 
 [Deprecated] Version field is deprecated.
 Use controlPlane.distro.k8s.image.tag to specify the Kubernetes version instead.
@@ -45,7 +45,7 @@ Use controlPlane.distro.k8s.image.tag to specify the Kubernetes version instead.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer}
+### `apiServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-apiServer}
 
 APIServer holds configuration specific to starting the api server.
 
@@ -57,7 +57,7 @@ APIServer holds configuration specific to starting the api server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#k8s-apiServer-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -72,7 +72,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-apiServer-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -87,7 +87,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-apiServer-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-apiServer-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -105,7 +105,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager}
+### `controllerManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-controllerManager}
 
 ControllerManager holds configuration specific to starting the controller manager.
 
@@ -117,7 +117,7 @@ ControllerManager holds configuration specific to starting the controller manage
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#k8s-controllerManager-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -132,7 +132,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-controllerManager-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -147,7 +147,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-controllerManager-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-controllerManager-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -165,7 +165,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-scheduler}
+### `scheduler` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-scheduler}
 
 Scheduler holds configuration specific to starting the scheduler. Enable this via controlPlane.advanced.virtualScheduler.enabled
 
@@ -177,7 +177,7 @@ Scheduler holds configuration specific to starting the scheduler. Enable this vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-scheduler-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#k8s-scheduler-enabled}
 
 Enabled signals this container should be enabled.
 
@@ -192,7 +192,7 @@ Enabled signals this container should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-scheduler-command}
+#### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-scheduler-command}
 
 Command is the command to start the distro binary. This will override the existing command.
 
@@ -207,7 +207,7 @@ Command is the command to start the distro binary. This will override the existi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-scheduler-extraArgs}
+#### `extraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-scheduler-extraArgs}
 
 ExtraArgs are additional arguments to pass to the distro binary.
 
@@ -225,7 +225,7 @@ ExtraArgs are additional arguments to pass to the distro binary.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-image}
+### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-image}
 
 Image is the distro image
 
@@ -237,7 +237,7 @@ Image is the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-image-registry}
+#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#k8s-image-registry}
 
 Registry is the registry of the container image, e.g. my-registry.com or ghcr.io. This setting can be globally
 overridden via the controlPlane.advanced.defaultImageRegistry option. Empty means docker hub.
@@ -253,7 +253,7 @@ overridden via the controlPlane.advanced.defaultImageRegistry option. Empty mean
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-image-repository}
+#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/kubernetes</span> <span className="config-field-enum"></span> {#k8s-image-repository}
 
 Repository is the repository of the container image, e.g. my-repo/my-image
 
@@ -268,7 +268,7 @@ Repository is the repository of the container image, e.g. my-repo/my-image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-image-tag}
+#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">v1.32.1</span> <span className="config-field-enum"></span> {#k8s-image-tag}
 
 Tag is the tag of the container image, e.g. latest. If set to the default, it will use the host Kubernetes version.
 
@@ -286,7 +286,7 @@ Tag is the tag of the container image, e.g. latest. If set to the default, it wi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#k8s-imagePullPolicy}
 
 ImagePullPolicy is the pull policy for the distro image
 
@@ -301,7 +301,7 @@ ImagePullPolicy is the pull policy for the distro image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-env}
+### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#k8s-env}
 
 Env are extra environment variables to use for the main container and NOT the init container.
 
@@ -316,7 +316,7 @@ Env are extra environment variables to use for the main container and NOT the in
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;limits:map&#91;cpu:100m memory:256Mi&#93; requests:map&#91;cpu:40m memory:64Mi&#93;&#93;</span> <span className="config-field-enum"></span> {#k8s-resources}
 
 Resources for the distro init container
 
@@ -331,7 +331,7 @@ Resources for the distro init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#k8s-securityContext}
+### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#k8s-securityContext}
 
 Security options can be used for the distro init container
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/hostPathMapper.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/hostPathMapper.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `hostPathMapper` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#hostPathMapper}
+## `hostPathMapper` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper}
 
 HostPathMapper defines if vCluster should rewrite host paths.
 
@@ -14,7 +14,7 @@ HostPathMapper defines if vCluster should rewrite host paths.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#hostPathMapper-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper-enabled}
 
 Enabled specifies if the host path mapper will be used
 
@@ -29,7 +29,7 @@ Enabled specifies if the host path mapper will be used
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `central` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#hostPathMapper-central}
+### `central` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hostPathMapper-central}
 
 Central specifies if the central host path mapper will be used
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/ingress.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/ingress.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress}
+## `ingress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingress}
 
 Ingress defines options for vCluster ingress deployed by Helm.
 
@@ -14,7 +14,7 @@ Ingress defines options for vCluster ingress deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingress-enabled}
 
 Enabled defines if the control plane ingress should be enabled
 
@@ -29,7 +29,7 @@ Enabled defines if the control plane ingress should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-host}
+### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">my-host.com</span> <span className="config-field-enum"></span> {#ingress-host}
 
 Host is the host where vCluster will be reachable
 
@@ -44,7 +44,7 @@ Host is the host where vCluster will be reachable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `pathType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-pathType}
+### `pathType` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ImplementationSpecific</span> <span className="config-field-enum"></span> {#ingress-pathType}
 
 PathType is the path type of the ingress
 
@@ -59,7 +59,7 @@ PathType is the path type of the ingress
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-spec}
+### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;tls:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#ingress-spec}
 
 Spec allows you to configure extra ingress options.
 
@@ -74,7 +74,7 @@ Spec allows you to configure extra ingress options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;nginx.ingress.kubernetes.io/backend-protocol:HTTPS nginx.ingress.kubernetes.io/ssl-passthrough:true nginx.ingress.kubernetes.io/ssl-redirect:true&#93;</span> <span className="config-field-enum"></span> {#ingress-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingress-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#ingress-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/proxy.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/proxy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#proxy}
+## `proxy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#proxy}
 
 Proxy defines options for the virtual cluster control plane proxy that is used to do authentication and intercept requests.
 
@@ -14,7 +14,7 @@ Proxy defines options for the virtual cluster control plane proxy that is used t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `bindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#proxy-bindAddress}
+### `bindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0</span> <span className="config-field-enum"></span> {#proxy-bindAddress}
 
 BindAddress under which vCluster will expose the proxy.
 
@@ -29,7 +29,7 @@ BindAddress under which vCluster will expose the proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#proxy-port}
+### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">8443</span> <span className="config-field-enum"></span> {#proxy-port}
 
 Port under which vCluster will expose the proxy. Changing port is currently not supported.
 
@@ -44,7 +44,7 @@ Port under which vCluster will expose the proxy. Changing port is currently not 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraSANs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#proxy-extraSANs}
+### `extraSANs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#proxy-extraSANs}
 
 ExtraSANs are extra hostnames to sign the vCluster proxy certificate for.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/service.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/service.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service}
+## `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#service}
 
 Service defines options for vCluster service deployed by Helm.
 
@@ -14,7 +14,7 @@ Service defines options for vCluster service deployed by Helm.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#service-enabled}
 
 Enabled defines if the control plane service should be enabled
 
@@ -29,7 +29,7 @@ Enabled defines if the control plane service should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-spec}
+### `spec` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;type:ClusterIP&#93;</span> <span className="config-field-enum"></span> {#service-spec}
 
 Spec allows you to configure extra service options.
 
@@ -44,7 +44,7 @@ Spec allows you to configure extra service options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeletNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-kubeletNodePort}
+### `kubeletNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#service-kubeletNodePort}
 
 KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 0.
 
@@ -59,7 +59,7 @@ KubeletNodePort is the node port where the fake kubelet is exposed. Defaults to 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `httpsNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-httpsNodePort}
+### `httpsNodePort` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">0</span> <span className="config-field-enum"></span> {#service-httpsNodePort}
 
 HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 
@@ -74,7 +74,7 @@ HTTPSNodePort is the node port where https is exposed. Defaults to 0.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#service-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -89,7 +89,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#service-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#service-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/serviceMonitor.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/serviceMonitor.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `serviceMonitor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceMonitor}
+## `serviceMonitor` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceMonitor}
 
 ServiceMonitor can be used to automatically create a service monitor for vCluster deployment itself.
 
@@ -14,7 +14,7 @@ ServiceMonitor can be used to automatically create a service monitor for vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceMonitor-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#serviceMonitor-enabled}
 
 Enabled configures if Helm should create the service monitor.
 
@@ -29,7 +29,7 @@ Enabled configures if Helm should create the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceMonitor-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceMonitor-labels}
 
 Labels are the extra labels to add to the service monitor.
 
@@ -44,7 +44,7 @@ Labels are the extra labels to add to the service monitor.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceMonitor-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#serviceMonitor-annotations}
 
 Annotations are the extra annotations to add to the service monitor.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/statefulSet.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/controlPlane/statefulSet.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet}
+## `statefulSet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet}
 
 StatefulSet defines options for vCluster statefulSet deployed by Helm.
 
@@ -14,7 +14,7 @@ StatefulSet defines options for vCluster statefulSet deployed by Helm.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability}
+### `highAvailability` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-highAvailability}
 
 HighAvailability holds options related to high availability.
 
@@ -26,7 +26,7 @@ HighAvailability holds options related to high availability.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability-replicas}
+#### `replicas` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-replicas}
 
 Replicas is the amount of replicas to use for the statefulSet.
 
@@ -41,7 +41,7 @@ Replicas is the amount of replicas to use for the statefulSet.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `leaseDuration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability-leaseDuration}
+#### `leaseDuration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-leaseDuration}
 
 LeaseDuration is the time to lease for the leader.
 
@@ -56,7 +56,7 @@ LeaseDuration is the time to lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `renewDeadline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability-renewDeadline}
+#### `renewDeadline` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">40</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-renewDeadline}
 
 RenewDeadline is the deadline to renew a lease for the leader.
 
@@ -71,7 +71,7 @@ RenewDeadline is the deadline to renew a lease for the leader.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `retryPeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-highAvailability-retryPeriod}
+#### `retryPeriod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">15</span> <span className="config-field-enum"></span> {#statefulSet-highAvailability-retryPeriod}
 
 RetryPeriod is the time until a replica will retry to get a lease.
 
@@ -89,7 +89,7 @@ RetryPeriod is the time until a replica will retry to get a lease.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-resources}
 
 Resources are the resource requests and limits for the statefulSet container.
 
@@ -101,7 +101,7 @@ Resources are the resource requests and limits for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:8Gi memory:2Gi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-resources-limits}
+#### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;ephemeral-storage:8Gi memory:2Gi&#93;</span> <span className="config-field-enum"></span> {#statefulSet-resources-limits}
 
 Limits are resource limits for the container
 
@@ -116,7 +116,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:400Mi memory:256Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-resources-requests}
+#### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:200m ephemeral-storage:400Mi memory:256Mi&#93;</span> <span className="config-field-enum"></span> {#statefulSet-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -134,7 +134,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling}
+### `scheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-scheduling}
 
 Scheduling holds options related to scheduling.
 
@@ -146,7 +146,7 @@ Scheduling holds options related to scheduling.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-nodeSelector}
+#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-nodeSelector}
 
 NodeSelector is the node selector to apply to the pod.
 
@@ -161,7 +161,7 @@ NodeSelector is the node selector to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-affinity}
+#### `affinity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-affinity}
 
 Affinity is the affinity to apply to the pod.
 
@@ -176,7 +176,7 @@ Affinity is the affinity to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-tolerations}
+#### `tolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-tolerations}
 
 Tolerations are the tolerations to apply to the pod.
 
@@ -191,7 +191,7 @@ Tolerations are the tolerations to apply to the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-priorityClassName}
+#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-scheduling-priorityClassName}
 
 PriorityClassName is the priority class name for the the pod.
 
@@ -206,7 +206,7 @@ PriorityClassName is the priority class name for the the pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-podManagementPolicy}
+#### `podManagementPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Parallel</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-podManagementPolicy}
 
 PodManagementPolicy is the statefulSet pod management policy.
 
@@ -221,7 +221,7 @@ PodManagementPolicy is the statefulSet pod management policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-scheduling-topologySpreadConstraints}
+#### `topologySpreadConstraints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-scheduling-topologySpreadConstraints}
 
 TopologySpreadConstraints are the topology spread constraints for the pod.
 
@@ -239,7 +239,7 @@ TopologySpreadConstraints are the topology spread constraints for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-security}
+### `security` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-security}
 
 Security defines pod or container security context.
 
@@ -251,7 +251,7 @@ Security defines pod or container security context.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-security-podSecurityContext}
+#### `podSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-security-podSecurityContext}
 
 PodSecurityContext specifies security context options on the pod level.
 
@@ -266,7 +266,7 @@ PodSecurityContext specifies security context options on the pod level.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-security-containerSecurityContext}
+#### `containerSecurityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;allowPrivilegeEscalation:false runAsGroup:0 runAsUser:0&#93;</span> <span className="config-field-enum"></span> {#statefulSet-security-containerSecurityContext}
 
 ContainerSecurityContext specifies security context options on the container level.
 
@@ -284,7 +284,7 @@ ContainerSecurityContext specifies security context options on the container lev
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `probes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes}
+### `probes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes}
 
 Probes enables or disables the main container probes.
 
@@ -296,7 +296,7 @@ Probes enables or disables the main container probes.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `livenessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-livenessProbe}
+#### `livenessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe}
 
 LivenessProbe specifies if the liveness probe for the container should be enabled
 
@@ -308,7 +308,7 @@ LivenessProbe specifies if the liveness probe for the container should be enable
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-livenessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -323,7 +323,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-livenessProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-failureThreshold}
 
 Number of consecutive failures for the probe to be considered failed
 
@@ -338,7 +338,7 @@ Number of consecutive failures for the probe to be considered failed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `initialDelaySeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-livenessProbe-initialDelaySeconds}
+##### `initialDelaySeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-initialDelaySeconds}
 
 Time (in seconds) to wait before starting the liveness probe
 
@@ -353,7 +353,7 @@ Time (in seconds) to wait before starting the liveness probe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-livenessProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -368,7 +368,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-livenessProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#statefulSet-probes-livenessProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -386,7 +386,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `readinessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-readinessProbe}
+#### `readinessProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe}
 
 ReadinessProbe specifies if the readiness probe for the container should be enabled
 
@@ -398,7 +398,7 @@ ReadinessProbe specifies if the readiness probe for the container should be enab
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-readinessProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -413,7 +413,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-readinessProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">60</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-failureThreshold}
 
 Number of consecutive failures for the probe to be considered failed
 
@@ -428,7 +428,7 @@ Number of consecutive failures for the probe to be considered failed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-readinessProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -443,7 +443,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-readinessProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">2</span> <span className="config-field-enum"></span> {#statefulSet-probes-readinessProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -461,7 +461,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `startupProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-startupProbe}
+#### `startupProbe` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe}
 
 StartupProbe specifies if the startup probe for the container should be enabled
 
@@ -473,7 +473,7 @@ StartupProbe specifies if the startup probe for the container should be enabled
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-startupProbe-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -488,7 +488,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">300</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-startupProbe-failureThreshold}
+##### `failureThreshold` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">300</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-failureThreshold}
 
 Number of consecutive failures allowed before failing the pod
 
@@ -503,7 +503,7 @@ Number of consecutive failures allowed before failing the pod
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-startupProbe-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">3</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-timeoutSeconds}
 
 Maximum duration (in seconds) that the probe will wait for a response.
 
@@ -518,7 +518,7 @@ Maximum duration (in seconds) that the probe will wait for a response.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">6</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-probes-startupProbe-periodSeconds}
+##### `periodSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">6</span> <span className="config-field-enum"></span> {#statefulSet-probes-startupProbe-periodSeconds}
 
 Frequency (in seconds) to perform the probe
 
@@ -539,7 +539,7 @@ Frequency (in seconds) to perform the probe
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence}
+### `persistence` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence}
 
 Persistence defines options around persistence for the statefulSet.
 
@@ -551,7 +551,7 @@ Persistence defines options around persistence for the statefulSet.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim}
+#### `volumeClaim` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim}
 
 VolumeClaim can be used to configure the persistent volume claim.
 
@@ -563,7 +563,7 @@ VolumeClaim can be used to configure the persistent volume claim.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-enabled}
 
 Enabled enables deploying a persistent volume claim. If auto, vCluster will automatically determine
 based on the chosen distro and other options if this is required.
@@ -579,7 +579,7 @@ based on the chosen distro and other options if this is required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-accessModes}
+##### `accessModes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;ReadWriteOnce&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-accessModes}
 
 AccessModes are the persistent volume claim access modes.
 
@@ -594,7 +594,7 @@ AccessModes are the persistent volume claim access modes.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-retentionPolicy}
+##### `retentionPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">Retain</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-retentionPolicy}
 
 RetentionPolicy is the persistent volume claim retention policy.
 
@@ -609,7 +609,7 @@ RetentionPolicy is the persistent volume claim retention policy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-size}
+##### `size` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">5Gi</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-size}
 
 Size is the persistent volume claim storage size.
 
@@ -624,7 +624,7 @@ Size is the persistent volume claim storage size.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaim-storageClass}
+##### `storageClass` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaim-storageClass}
 
 StorageClass is the persistent volume claim storage class.
 
@@ -642,7 +642,7 @@ StorageClass is the persistent volume claim storage class.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-volumeClaimTemplates}
+#### `volumeClaimTemplates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-volumeClaimTemplates}
 
 VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 
@@ -657,7 +657,7 @@ VolumeClaimTemplates defines the volumeClaimTemplates for the statefulSet
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `dataVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-dataVolume}
+#### `dataVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-dataVolume}
 
 Allows you to override the dataVolume. Only works correctly if volumeClaim.enabled=false.
 
@@ -672,7 +672,7 @@ Allows you to override the dataVolume. Only works correctly if volumeClaim.enabl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `binariesVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-binariesVolume}
+#### `binariesVolume` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;map&#91;emptyDir:map&#91;&#93; name:binaries&#93;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-binariesVolume}
 
 BinariesVolume defines a binaries volume that is used to retrieve
 distro specific executables to be run by the syncer controller.
@@ -689,7 +689,7 @@ This volume doesn't need to be persistent.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumes}
+#### `addVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumes}
 
 AddVolumes defines extra volumes for the pod
 
@@ -704,7 +704,7 @@ AddVolumes defines extra volumes for the pod
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts}
+#### `addVolumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts}
 
 AddVolumeMounts defines extra volume mounts for the container
 
@@ -716,7 +716,7 @@ AddVolumeMounts defines extra volume mounts for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-name}
 
 This must match the Name of a Volume.
 
@@ -731,7 +731,7 @@ This must match the Name of a Volume.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-readOnly}
+##### `readOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-readOnly}
 
 Mounted read-only if true, read-write otherwise (false or unspecified).
 Defaults to false.
@@ -747,7 +747,7 @@ Defaults to false.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-mountPath}
+##### `mountPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-mountPath}
 
 Path within the container at which the volume should be mounted.  Must
 not contain ':'.
@@ -763,7 +763,7 @@ not contain ':'.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-subPath}
 
 Path within the volume from which the container's volume should be mounted.
 Defaults to "" (volume's root).
@@ -779,7 +779,7 @@ Defaults to "" (volume's root).
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-mountPropagation}
+##### `mountPropagation` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-mountPropagation}
 
 mountPropagation determines how mounts are propagated from the host
 to container and the other way around.
@@ -797,7 +797,7 @@ This field is beta in 1.10.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-persistence-addVolumeMounts-subPathExpr}
+##### `subPathExpr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-persistence-addVolumeMounts-subPathExpr}
 
 Expanded path within the volume from which the container's volume should be mounted.
 Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
@@ -821,7 +821,7 @@ SubPathExpr and SubPath are mutually exclusive.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-enableServiceLinks}
+### `enableServiceLinks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#statefulSet-enableServiceLinks}
 
 EnableServiceLinks for the StatefulSet pod
 
@@ -836,7 +836,7 @@ EnableServiceLinks for the StatefulSet pod
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -851,7 +851,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-labels}
 
 Labels are extra labels for this resource.
 
@@ -866,7 +866,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-pods}
+### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-pods}
 
 Additional labels or annotations for the statefulSet pods.
 
@@ -878,7 +878,7 @@ Additional labels or annotations for the statefulSet pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-pods-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-pods-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -893,7 +893,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-pods-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#statefulSet-pods-labels}
 
 Labels are extra labels for this resource.
 
@@ -911,7 +911,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-image}
+### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-image}
 
 Image is the image for the controlPlane statefulSet container
 
@@ -923,7 +923,7 @@ Image is the image for the controlPlane statefulSet container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-image-registry}
+#### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">ghcr.io</span> <span className="config-field-enum"></span> {#statefulSet-image-registry}
 
 Configure the registry of the container image, e.g. my-registry.com or ghcr.io
 It defaults to ghcr.io and can be overriding either by using this field or controlPlane.advanced.defaultImageRegistry
@@ -939,7 +939,7 @@ It defaults to ghcr.io and can be overriding either by using this field or contr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-image-repository}
+#### `repository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">loft-sh/vcluster-pro</span> <span className="config-field-enum"></span> {#statefulSet-image-repository}
 
 Configure the repository of the container image, e.g. my-repo/my-image.
 It defaults to the vCluster pro repository that includes the optional pro modules that are turned off by default.
@@ -956,7 +956,7 @@ If you still want to use the pure OSS build, use 'loft-sh/vcluster-oss' instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-image-tag}
+#### `tag` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-image-tag}
 
 Tag is the tag of the container image, e.g. latest
 
@@ -974,7 +974,7 @@ Tag is the tag of the container image, e.g. latest
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-imagePullPolicy}
 
 ImagePullPolicy is the policy how to pull the image.
 
@@ -989,7 +989,7 @@ ImagePullPolicy is the policy how to pull the image.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `workingDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-workingDir}
+### `workingDir` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-workingDir}
 
 WorkingDir specifies in what folder the main process should get started.
 
@@ -1004,7 +1004,7 @@ WorkingDir specifies in what folder the main process should get started.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-command}
+### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-command}
 
 Command allows you to override the main command.
 
@@ -1019,7 +1019,7 @@ Command allows you to override the main command.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-args}
+### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-args}
 
 Args allows you to override the main arguments.
 
@@ -1034,7 +1034,7 @@ Args allows you to override the main arguments.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-env}
+### `env` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#statefulSet-env}
 
 Env are additional environment variables for the statefulSet container.
 
@@ -1049,7 +1049,7 @@ Env are additional environment variables for the statefulSet container.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `dnsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsPolicy}
+### `dnsPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsPolicy}
 
 Set DNS policy for the pod.
 
@@ -1064,7 +1064,7 @@ Set DNS policy for the pod.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `dnsConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig}
+### `dnsConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig}
 
 Specifies the DNS parameters of a pod.
 
@@ -1076,7 +1076,7 @@ Specifies the DNS parameters of a pod.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nameservers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-nameservers}
+#### `nameservers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-nameservers}
 
 A list of DNS name server IP addresses.
 This will be appended to the base nameservers generated from DNSPolicy.
@@ -1093,7 +1093,7 @@ Duplicated nameservers will be removed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `searches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-searches}
+#### `searches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-searches}
 
 A list of DNS search domains for host-name lookup.
 This will be appended to the base search paths generated from DNSPolicy.
@@ -1110,7 +1110,7 @@ Duplicated search paths will be removed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-options}
+#### `options` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options}
 
 A list of DNS resolver options.
 This will be merged with the base options generated from DNSPolicy.
@@ -1125,7 +1125,7 @@ will override those that appear in the base DNSPolicy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-options-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options-name}
 
 Required.
 
@@ -1140,7 +1140,7 @@ Required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#statefulSet-dnsConfig-options-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#statefulSet-dnsConfig-options-value}
 
 
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/experimental.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/experimental.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `experimental` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental}
+## `experimental` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental}
 
 Experimental features for vCluster. Configuration here might change, so be careful with this.
 
@@ -14,7 +14,7 @@ Experimental features for vCluster. Configuration here might change, so be caref
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy}
+### `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy}
 
 Deploy allows you to configure manifests and Helm charts to deploy within the host or virtual cluster.
 
@@ -26,7 +26,7 @@ Deploy allows you to configure manifests and Helm charts to deploy within the ho
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-host}
+#### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host}
 
 Host defines what manifests to deploy into the host cluster
 
@@ -38,7 +38,7 @@ Host defines what manifests to deploy into the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-host-manifests}
+##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the host cluster.
 
@@ -53,7 +53,7 @@ Manifests are raw Kubernetes manifests that should get applied within the host c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-host-manifestsTemplate}
+##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-host-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the host cluster.
 
@@ -71,7 +71,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster}
+#### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster}
 
 VCluster defines what manifests and charts to deploy into the vCluster
 
@@ -83,7 +83,7 @@ VCluster defines what manifests and charts to deploy into the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-manifests}
+##### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the virtual cluster.
 
@@ -98,7 +98,7 @@ Manifests are raw Kubernetes manifests that should get applied within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-manifestsTemplate}
+##### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the virtual cluster.
 
@@ -113,7 +113,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm}
+##### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm}
 
 Helm are Helm charts that should get deployed into the virtual cluster
 
@@ -125,7 +125,7 @@ Helm are Helm charts that should get deployed into the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart}
+##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart}
 
 Chart defines what chart should get deployed.
 
@@ -137,7 +137,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-name}
 
 
 
@@ -152,7 +152,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-repo}
 
 
 
@@ -167,7 +167,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-insecure}
+##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-insecure}
 
 
 
@@ -182,7 +182,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-version}
+##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-version}
 
 
 
@@ -197,7 +197,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-username}
+##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-username}
 
 
 
@@ -212,7 +212,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-chart-password}
+##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-chart-password}
 
 
 
@@ -230,7 +230,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-release}
+##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release}
 
 Release defines what release should get deployed.
 
@@ -242,7 +242,7 @@ Release defines what release should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-release-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release-name}
 
 Name of the release
 
@@ -257,7 +257,7 @@ Name of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-release-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-release-namespace}
 
 Namespace of the release
 
@@ -275,7 +275,7 @@ Namespace of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-values}
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-values}
 
 Values defines what values should get used.
 
@@ -290,7 +290,7 @@ Values defines what values should get used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-timeout}
+##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-timeout}
 
 Timeout defines the timeout for Helm
 
@@ -305,7 +305,7 @@ Timeout defines the timeout for Helm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-deploy-vcluster-helm-bundle}
+##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-deploy-vcluster-helm-bundle}
 
 Bundle allows to compress the Helm chart and specify this instead of an online chart
 
@@ -329,7 +329,7 @@ Bundle allows to compress the Helm chart and specify this instead of an online c
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings}
+### `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings}
 
 SyncSettings are advanced settings for the syncer controller.
 
@@ -341,7 +341,7 @@ SyncSettings are advanced settings for the syncer controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `targetNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-targetNamespace}
+#### `targetNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-targetNamespace}
 
 TargetNamespace is the namespace where the workloads should get synced to.
 
@@ -356,7 +356,7 @@ TargetNamespace is the namespace where the workloads should get synced to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-setOwner}
+#### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#experimental-syncSettings-setOwner}
 
 SetOwner specifies if vCluster should set an owner reference on the synced objects to the vCluster service. This allows for easy garbage collection.
 
@@ -371,7 +371,7 @@ SetOwner specifies if vCluster should set an owner reference on the synced objec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-hostMetricsBindAddress}
+#### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-hostMetricsBindAddress}
 
 HostMetricsBindAddress is the bind address for the local manager
 
@@ -386,7 +386,7 @@ HostMetricsBindAddress is the bind address for the local manager
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-syncSettings-virtualMetricsBindAddress}
+#### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-syncSettings-virtualMetricsBindAddress}
 
 VirtualMetricsBindAddress is the bind address for the virtual manager
 
@@ -404,7 +404,7 @@ VirtualMetricsBindAddress is the bind address for the virtual manager
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `genericSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync}
+### `genericSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync}
 
 GenericSync holds options to generically sync resources from virtual cluster to host.
 
@@ -416,7 +416,7 @@ GenericSync holds options to generically sync resources from virtual cluster to 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-version}
+#### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-version}
 
 Version is the config version
 
@@ -431,7 +431,7 @@ Version is the config version
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `export` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export}
+#### `export` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export}
 
 Exports syncs a resource from the virtual cluster to the host
 
@@ -443,7 +443,7 @@ Exports syncs a resource from the virtual cluster to the host
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-apiVersion}
 
 APIVersion of the object to sync
 
@@ -458,7 +458,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-kind}
 
 Kind of the object to sync
 
@@ -473,7 +473,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-optional}
+##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-optional}
 
 
 
@@ -488,7 +488,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-replaceOnConflict}
+##### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-replaceOnConflict}
 
 ReplaceWhenInvalid determines if the controller should try to recreate the object
 if there is a problem applying
@@ -504,7 +504,7 @@ if there is a problem applying
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches}
 
 Patches are the patches to apply on the virtual cluster objects
 when syncing them from the host cluster
@@ -517,7 +517,7 @@ when syncing them from the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-op}
 
 Operation is the type of the patch
 
@@ -532,7 +532,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -547,7 +547,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-path}
 
 Path is the path of the patch
 
@@ -562,7 +562,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -577,7 +577,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -592,7 +592,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-value}
 
 Value is the new value to be set to the path
 
@@ -607,7 +607,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -624,7 +624,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -637,7 +637,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -652,7 +652,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -667,7 +667,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -682,7 +682,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -697,7 +697,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -715,7 +715,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -730,7 +730,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -743,7 +743,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-sync-secret}
 
 
 
@@ -758,7 +758,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-patches-sync-configmap}
 
 
 
@@ -779,7 +779,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches}
+##### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches}
 
 ReversePatches are the patches to apply to host cluster objects
 after it has been synced to the virtual cluster
@@ -792,7 +792,7 @@ after it has been synced to the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-op}
 
 Operation is the type of the patch
 
@@ -807,7 +807,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-fromPath}
 
 FromPath is the path from the other object
 
@@ -822,7 +822,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-path}
 
 Path is the path of the patch
 
@@ -837,7 +837,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -852,7 +852,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -867,7 +867,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-value}
 
 Value is the new value to be set to the path
 
@@ -882,7 +882,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -899,7 +899,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -912,7 +912,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-path}
 
 Path is the path within the object to select
 
@@ -927,7 +927,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -942,7 +942,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -957,7 +957,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -972,7 +972,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -990,7 +990,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1005,7 +1005,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1018,7 +1018,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-sync-secret}
 
 
 
@@ -1033,7 +1033,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-reversePatches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-reversePatches-sync-configmap}
 
 
 
@@ -1054,7 +1054,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-selector}
 
 Selector is a label selector to select the synced objects in the virtual cluster.
 If empty, all objects will be synced.
@@ -1067,7 +1067,7 @@ If empty, all objects will be synced.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labelSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-export-selector-labelSelector}
+##### `labelSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-export-selector-labelSelector}
 
 LabelSelector are the labels to select the object from
 
@@ -1088,7 +1088,7 @@ LabelSelector are the labels to select the object from
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `import` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import}
+#### `import` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import}
 
 Imports syncs a resource from the host cluster to virtual cluster
 
@@ -1100,7 +1100,7 @@ Imports syncs a resource from the host cluster to virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-apiVersion}
 
 APIVersion of the object to sync
 
@@ -1115,7 +1115,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-kind}
 
 Kind of the object to sync
 
@@ -1130,7 +1130,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-optional}
+##### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-optional}
 
 
 
@@ -1145,7 +1145,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-replaceOnConflict}
+##### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-replaceOnConflict}
 
 ReplaceWhenInvalid determines if the controller should try to recreate the object
 if there is a problem applying
@@ -1161,7 +1161,7 @@ if there is a problem applying
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches}
 
 Patches are the patches to apply on the virtual cluster objects
 when syncing them from the host cluster
@@ -1174,7 +1174,7 @@ when syncing them from the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-op}
 
 Operation is the type of the patch
 
@@ -1189,7 +1189,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1204,7 +1204,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-path}
 
 Path is the path of the patch
 
@@ -1219,7 +1219,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1234,7 +1234,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1249,7 +1249,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-value}
 
 Value is the new value to be set to the path
 
@@ -1264,7 +1264,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1281,7 +1281,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1294,7 +1294,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1309,7 +1309,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1324,7 +1324,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1339,7 +1339,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1354,7 +1354,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1372,7 +1372,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1387,7 +1387,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1400,7 +1400,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-sync-secret}
 
 
 
@@ -1415,7 +1415,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-patches-sync-configmap}
 
 
 
@@ -1436,7 +1436,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches}
+##### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches}
 
 ReversePatches are the patches to apply to host cluster objects
 after it has been synced to the virtual cluster
@@ -1449,7 +1449,7 @@ after it has been synced to the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-op}
 
 Operation is the type of the patch
 
@@ -1464,7 +1464,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1479,7 +1479,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-path}
 
 Path is the path of the patch
 
@@ -1494,7 +1494,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1509,7 +1509,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1524,7 +1524,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-value}
 
 Value is the new value to be set to the path
 
@@ -1539,7 +1539,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1556,7 +1556,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1569,7 +1569,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1584,7 +1584,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1599,7 +1599,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1614,7 +1614,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1629,7 +1629,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1647,7 +1647,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1662,7 +1662,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1675,7 +1675,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-sync-secret}
 
 
 
@@ -1690,7 +1690,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-import-reversePatches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-import-reversePatches-sync-configmap}
 
 
 
@@ -1714,7 +1714,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `hooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks}
+#### `hooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks}
 
 Hooks are hooks that can be used to inject custom patches before syncing
 
@@ -1726,7 +1726,7 @@ Hooks are hooks that can be used to inject custom patches before syncing
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `hostToVirtual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual}
+##### `hostToVirtual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual}
 
 HostToVirtual is a hook that is executed before syncing from the host to the virtual cluster
 
@@ -1738,7 +1738,7 @@ HostToVirtual is a hook that is executed before syncing from the host to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-apiVersion}
 
 APIVersion of the object to sync
 
@@ -1753,7 +1753,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-kind}
 
 Kind of the object to sync
 
@@ -1768,7 +1768,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-verbs}
 
 Verbs are the verbs that the hook should mutate
 
@@ -1783,7 +1783,7 @@ Verbs are the verbs that the hook should mutate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches}
 
 Patches are the patches to apply on the object to be synced
 
@@ -1795,7 +1795,7 @@ Patches are the patches to apply on the object to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-op}
 
 Operation is the type of the patch
 
@@ -1810,7 +1810,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1825,7 +1825,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-path}
 
 Path is the path of the patch
 
@@ -1840,7 +1840,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1855,7 +1855,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1870,7 +1870,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-value}
 
 Value is the new value to be set to the path
 
@@ -1885,7 +1885,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1902,7 +1902,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1915,7 +1915,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1930,7 +1930,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1945,7 +1945,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1960,7 +1960,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1975,7 +1975,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1993,7 +1993,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -2008,7 +2008,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -2021,7 +2021,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync-secret}
 
 
 
@@ -2036,7 +2036,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-hostToVirtual-patches-sync-configmap}
 
 
 
@@ -2060,7 +2060,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualToHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost}
+##### `virtualToHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost}
 
 VirtualToHost is a hook that is executed before syncing from the virtual to the host cluster
 
@@ -2072,7 +2072,7 @@ VirtualToHost is a hook that is executed before syncing from the virtual to the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-apiVersion}
 
 APIVersion of the object to sync
 
@@ -2087,7 +2087,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-kind}
 
 Kind of the object to sync
 
@@ -2102,7 +2102,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-verbs}
 
 Verbs are the verbs that the hook should mutate
 
@@ -2117,7 +2117,7 @@ Verbs are the verbs that the hook should mutate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches}
 
 Patches are the patches to apply on the object to be synced
 
@@ -2129,7 +2129,7 @@ Patches are the patches to apply on the object to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-op}
 
 Operation is the type of the patch
 
@@ -2144,7 +2144,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -2159,7 +2159,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-path}
 
 Path is the path of the patch
 
@@ -2174,7 +2174,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -2189,7 +2189,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -2204,7 +2204,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-value}
 
 Value is the new value to be set to the path
 
@@ -2219,7 +2219,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -2236,7 +2236,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -2249,7 +2249,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -2264,7 +2264,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -2279,7 +2279,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -2294,7 +2294,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -2309,7 +2309,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -2327,7 +2327,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -2342,7 +2342,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -2355,7 +2355,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-sync-secret}
 
 
 
@@ -2370,7 +2370,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-hooks-virtualToHost-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-hooks-virtualToHost-patches-sync-configmap}
 
 
 
@@ -2397,7 +2397,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-clusterRole}
 
 
 
@@ -2409,7 +2409,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-clusterRole-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#experimental-genericSync-clusterRole-extraRules}
 
 
 
@@ -2427,7 +2427,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-role}
+#### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-genericSync-role}
 
 
 
@@ -2439,7 +2439,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-genericSync-role-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#experimental-genericSync-role-extraRules}
 
 
 
@@ -2460,7 +2460,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `isolatedControlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane}
+### `isolatedControlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane}
 
 IsolatedControlPlane is a feature to run the vCluster control plane in a different Kubernetes cluster than the workloads themselves.
 
@@ -2472,7 +2472,7 @@ IsolatedControlPlane is a feature to run the vCluster control plane in a differe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-enabled}
 
 Enabled specifies if the isolated control plane feature should be enabled.
 
@@ -2487,7 +2487,7 @@ Enabled specifies if the isolated control plane feature should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `headless` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-headless}
+#### `headless` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-headless}
 
 Headless states that Helm should deploy the vCluster in headless mode for the isolated control plane.
 
@@ -2502,7 +2502,7 @@ Headless states that Helm should deploy the vCluster in headless mode for the is
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-kubeConfig}
+#### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-kubeConfig}
 
 KubeConfig is the path where to find the remote workload cluster kubeconfig.
 
@@ -2517,7 +2517,7 @@ KubeConfig is the path where to find the remote workload cluster kubeconfig.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-namespace}
 
 Namespace is the namespace where to sync the workloads into.
 
@@ -2532,7 +2532,7 @@ Namespace is the namespace where to sync the workloads into.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-isolatedControlPlane-service}
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-isolatedControlPlane-service}
 
 Service is the vCluster service in the remote cluster.
 
@@ -2550,7 +2550,7 @@ Service is the vCluster service in the remote cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig}
+### `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig}
 
 VirtualClusterKubeConfig allows you to override distro specifics and specify where vCluster will find the required certificates and vCluster config.
 
@@ -2562,7 +2562,7 @@ VirtualClusterKubeConfig allows you to override distro specifics and specify whe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-kubeConfig}
+#### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-kubeConfig}
 
 KubeConfig is the virtual cluster kubeconfig path.
 
@@ -2577,7 +2577,7 @@ KubeConfig is the virtual cluster kubeconfig path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-serverCAKey}
+#### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-serverCAKey}
 
 ServerCAKey is the server ca key path.
 
@@ -2592,7 +2592,7 @@ ServerCAKey is the server ca key path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-serverCACert}
+#### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-serverCACert}
 
 ServerCAKey is the server ca cert path.
 
@@ -2607,7 +2607,7 @@ ServerCAKey is the server ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-clientCACert}
+#### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-clientCACert}
 
 ServerCAKey is the client ca cert path.
 
@@ -2622,7 +2622,7 @@ ServerCAKey is the client ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-virtualClusterKubeConfig-requestHeaderCACert}
+#### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-virtualClusterKubeConfig-requestHeaderCACert}
 
 RequestHeaderCACert is the request header ca cert path.
 
@@ -2640,7 +2640,7 @@ RequestHeaderCACert is the request header ca cert path.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests}
+### `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests}
 
 DenyProxyRequests denies certain requests in the vCluster proxy.
 
@@ -2652,7 +2652,7 @@ DenyProxyRequests denies certain requests in the vCluster proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-name}
 
 The name of the check.
 
@@ -2667,7 +2667,7 @@ The name of the check.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-namespaces}
+#### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-namespaces}
 
 Namespace describe a list of namespaces that will be affected by the check.
 An empty list means that all namespaces will be affected.
@@ -2684,7 +2684,7 @@ In case of ClusterScoped rules, only the Namespace resource is affected.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules}
+#### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules}
 
 Rules describes on which verbs and on what resources/subresources the webhook is enforced.
 The webhook is enforced if it matches any Rule.
@@ -2698,7 +2698,7 @@ The version of the request must match the rule version exactly. Equivalent match
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-apiGroups}
 
 APIGroups is the API groups the resources belong to. '*' is all groups.
 
@@ -2713,7 +2713,7 @@ APIGroups is the API groups the resources belong to. '*' is all groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-apiVersions}
+##### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-apiVersions}
 
 APIVersions is the API versions the resources belong to. '*' is all versions.
 
@@ -2728,7 +2728,7 @@ APIVersions is the API versions the resources belong to. '*' is all versions.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -2743,7 +2743,7 @@ Resources is a list of resources this rule applies to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-scope}
+##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-scope}
 
 Scope specifies the scope of this rule.
 
@@ -2758,7 +2758,7 @@ Scope specifies the scope of this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-rules-operations}
+##### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-rules-operations}
 
 Verb is the kube verb associated with the request for API requests, not the http verb. This includes things like list and watch.
 For non-resource requests, this is the lowercase http verb.
@@ -2778,7 +2778,7 @@ If '*' is present, the length of the slice must be one.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#experimental-denyProxyRequests-excludedUsers}
+#### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#experimental-denyProxyRequests-excludedUsers}
 
 ExcludedUsers describe a list of users for which the checks will be skipped.
 Impersonation attempts on these users will still be subjected to the checks.

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/experimental/denyProxyRequests.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/experimental/denyProxyRequests.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests}
+## `denyProxyRequests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests}
 
 DenyProxyRequests denies certain requests in the vCluster proxy.
 
@@ -14,7 +14,7 @@ DenyProxyRequests denies certain requests in the vCluster proxy.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-name}
 
 The name of the check.
 
@@ -29,7 +29,7 @@ The name of the check.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-namespaces}
+### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-namespaces}
 
 Namespace describe a list of namespaces that will be affected by the check.
 An empty list means that all namespaces will be affected.
@@ -46,7 +46,7 @@ In case of ClusterScoped rules, only the Namespace resource is affected.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules}
+### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules}
 
 Rules describes on which verbs and on what resources/subresources the webhook is enforced.
 The webhook is enforced if it matches any Rule.
@@ -60,7 +60,7 @@ The version of the request must match the rule version exactly. Equivalent match
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-apiGroups}
+#### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-apiGroups}
 
 APIGroups is the API groups the resources belong to. '*' is all groups.
 
@@ -75,7 +75,7 @@ APIGroups is the API groups the resources belong to. '*' is all groups.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-apiVersions}
+#### `apiVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-apiVersions}
 
 APIVersions is the API versions the resources belong to. '*' is all versions.
 
@@ -90,7 +90,7 @@ APIVersions is the API versions the resources belong to. '*' is all versions.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-resources}
+#### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-resources}
 
 Resources is a list of resources this rule applies to.
 
@@ -105,7 +105,7 @@ Resources is a list of resources this rule applies to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-scope}
+#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-scope}
 
 Scope specifies the scope of this rule.
 
@@ -120,7 +120,7 @@ Scope specifies the scope of this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-rules-operations}
+#### `operations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-rules-operations}
 
 Verb is the kube verb associated with the request for API requests, not the http verb. This includes things like list and watch.
 For non-resource requests, this is the lowercase http verb.
@@ -140,7 +140,7 @@ If '*' is present, the length of the slice must be one.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#denyProxyRequests-excludedUsers}
+### `excludedUsers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#denyProxyRequests-excludedUsers}
 
 ExcludedUsers describe a list of users for which the checks will be skipped.
 Impersonation attempts on these users will still be subjected to the checks.

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/experimental/deploy.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/experimental/deploy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy}
+## `deploy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy}
 
 Deploy allows you to configure manifests and Helm charts to deploy within the host or virtual cluster.
 
@@ -14,7 +14,7 @@ Deploy allows you to configure manifests and Helm charts to deploy within the ho
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-host}
+### `host` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host}
 
 Host defines what manifests to deploy into the host cluster
 
@@ -26,7 +26,7 @@ Host defines what manifests to deploy into the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-host-manifests}
+#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the host cluster.
 
@@ -41,7 +41,7 @@ Manifests are raw Kubernetes manifests that should get applied within the host c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-host-manifestsTemplate}
+#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-host-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the host cluster.
 
@@ -59,7 +59,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster}
+### `vcluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster}
 
 VCluster defines what manifests and charts to deploy into the vCluster
 
@@ -71,7 +71,7 @@ VCluster defines what manifests and charts to deploy into the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-manifests}
+#### `manifests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-manifests}
 
 Manifests are raw Kubernetes manifests that should get applied within the virtual cluster.
 
@@ -86,7 +86,7 @@ Manifests are raw Kubernetes manifests that should get applied within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-manifestsTemplate}
+#### `manifestsTemplate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-manifestsTemplate}
 
 ManifestsTemplate is a Kubernetes manifest template that will be rendered with vCluster values before applying it within the virtual cluster.
 
@@ -101,7 +101,7 @@ ManifestsTemplate is a Kubernetes manifest template that will be rendered with v
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm}
+#### `helm` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm}
 
 Helm are Helm charts that should get deployed into the virtual cluster
 
@@ -113,7 +113,7 @@ Helm are Helm charts that should get deployed into the virtual cluster
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart}
+##### `chart` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart}
 
 Chart defines what chart should get deployed.
 
@@ -125,7 +125,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-name}
 
 
 
@@ -140,7 +140,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-repo}
+##### `repo` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-repo}
 
 
 
@@ -155,7 +155,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-insecure}
+##### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-insecure}
 
 
 
@@ -170,7 +170,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-version}
+##### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-version}
 
 
 
@@ -185,7 +185,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-username}
+##### `username` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-username}
 
 
 
@@ -200,7 +200,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-chart-password}
+##### `password` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-chart-password}
 
 
 
@@ -218,7 +218,7 @@ Chart defines what chart should get deployed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-release}
+##### `release` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release}
 
 Release defines what release should get deployed.
 
@@ -230,7 +230,7 @@ Release defines what release should get deployed.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-release-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release-name}
 
 Name of the release
 
@@ -245,7 +245,7 @@ Name of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-release-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-release-namespace}
 
 Namespace of the release
 
@@ -263,7 +263,7 @@ Namespace of the release
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-values}
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-values}
 
 Values defines what values should get used.
 
@@ -278,7 +278,7 @@ Values defines what values should get used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-timeout}
+##### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-timeout}
 
 Timeout defines the timeout for Helm
 
@@ -293,7 +293,7 @@ Timeout defines the timeout for Helm
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#deploy-vcluster-helm-bundle}
+##### `bundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deploy-vcluster-helm-bundle}
 
 Bundle allows to compress the Helm chart and specify this instead of an online chart
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/experimental/genericSync.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/experimental/genericSync.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `genericSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync}
+## `genericSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync}
 
 GenericSync holds options to generically sync resources from virtual cluster to host.
 
@@ -14,7 +14,7 @@ GenericSync holds options to generically sync resources from virtual cluster to 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-version}
+### `version` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-version}
 
 Version is the config version
 
@@ -29,7 +29,7 @@ Version is the config version
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `export` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export}
+### `export` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export}
 
 Exports syncs a resource from the virtual cluster to the host
 
@@ -41,7 +41,7 @@ Exports syncs a resource from the virtual cluster to the host
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-apiVersion}
 
 APIVersion of the object to sync
 
@@ -56,7 +56,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-kind}
 
 Kind of the object to sync
 
@@ -71,7 +71,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-optional}
+#### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-optional}
 
 
 
@@ -86,7 +86,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-replaceOnConflict}
+#### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-replaceOnConflict}
 
 ReplaceWhenInvalid determines if the controller should try to recreate the object
 if there is a problem applying
@@ -102,7 +102,7 @@ if there is a problem applying
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches}
 
 Patches are the patches to apply on the virtual cluster objects
 when syncing them from the host cluster
@@ -115,7 +115,7 @@ when syncing them from the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-op}
 
 Operation is the type of the patch
 
@@ -130,7 +130,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -145,7 +145,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-path}
 
 Path is the path of the patch
 
@@ -160,7 +160,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -175,7 +175,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -190,7 +190,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-value}
 
 Value is the new value to be set to the path
 
@@ -205,7 +205,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -222,7 +222,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -235,7 +235,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -250,7 +250,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -265,7 +265,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -280,7 +280,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -295,7 +295,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -313,7 +313,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -328,7 +328,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -341,7 +341,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-sync-secret}
 
 
 
@@ -356,7 +356,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-patches-sync-configmap}
 
 
 
@@ -377,7 +377,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches}
+#### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches}
 
 ReversePatches are the patches to apply to host cluster objects
 after it has been synced to the virtual cluster
@@ -390,7 +390,7 @@ after it has been synced to the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-op}
 
 Operation is the type of the patch
 
@@ -405,7 +405,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-fromPath}
 
 FromPath is the path from the other object
 
@@ -420,7 +420,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-path}
 
 Path is the path of the patch
 
@@ -435,7 +435,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -450,7 +450,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -465,7 +465,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-value}
 
 Value is the new value to be set to the path
 
@@ -480,7 +480,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -497,7 +497,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -510,7 +510,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-path}
 
 Path is the path within the object to select
 
@@ -525,7 +525,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -540,7 +540,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -555,7 +555,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -570,7 +570,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -588,7 +588,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -603,7 +603,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -616,7 +616,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-sync-secret}
 
 
 
@@ -631,7 +631,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-reversePatches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-reversePatches-sync-configmap}
 
 
 
@@ -652,7 +652,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-selector}
+#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-selector}
 
 Selector is a label selector to select the synced objects in the virtual cluster.
 If empty, all objects will be synced.
@@ -665,7 +665,7 @@ If empty, all objects will be synced.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labelSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-export-selector-labelSelector}
+##### `labelSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-export-selector-labelSelector}
 
 LabelSelector are the labels to select the object from
 
@@ -686,7 +686,7 @@ LabelSelector are the labels to select the object from
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `import` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import}
+### `import` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import}
 
 Imports syncs a resource from the host cluster to virtual cluster
 
@@ -698,7 +698,7 @@ Imports syncs a resource from the host cluster to virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-apiVersion}
 
 APIVersion of the object to sync
 
@@ -713,7 +713,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-kind}
 
 Kind of the object to sync
 
@@ -728,7 +728,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-optional}
+#### `optional` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-optional}
 
 
 
@@ -743,7 +743,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-replaceOnConflict}
+#### `replaceOnConflict` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-replaceOnConflict}
 
 ReplaceWhenInvalid determines if the controller should try to recreate the object
 if there is a problem applying
@@ -759,7 +759,7 @@ if there is a problem applying
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches}
 
 Patches are the patches to apply on the virtual cluster objects
 when syncing them from the host cluster
@@ -772,7 +772,7 @@ when syncing them from the host cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-op}
 
 Operation is the type of the patch
 
@@ -787,7 +787,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -802,7 +802,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-path}
 
 Path is the path of the patch
 
@@ -817,7 +817,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -832,7 +832,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -847,7 +847,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-value}
 
 Value is the new value to be set to the path
 
@@ -862,7 +862,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -879,7 +879,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -892,7 +892,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -907,7 +907,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -922,7 +922,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -937,7 +937,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -952,7 +952,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -970,7 +970,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -985,7 +985,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -998,7 +998,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-sync-secret}
 
 
 
@@ -1013,7 +1013,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-patches-sync-configmap}
 
 
 
@@ -1034,7 +1034,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches}
+#### `reversePatches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches}
 
 ReversePatches are the patches to apply to host cluster objects
 after it has been synced to the virtual cluster
@@ -1047,7 +1047,7 @@ after it has been synced to the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-op}
 
 Operation is the type of the patch
 
@@ -1062,7 +1062,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1077,7 +1077,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-path}
 
 Path is the path of the patch
 
@@ -1092,7 +1092,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1107,7 +1107,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1122,7 +1122,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-value}
 
 Value is the new value to be set to the path
 
@@ -1137,7 +1137,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1154,7 +1154,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1167,7 +1167,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1182,7 +1182,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1197,7 +1197,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1212,7 +1212,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1227,7 +1227,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1245,7 +1245,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1260,7 +1260,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1273,7 +1273,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-sync-secret}
 
 
 
@@ -1288,7 +1288,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-import-reversePatches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-import-reversePatches-sync-configmap}
 
 
 
@@ -1312,7 +1312,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `hooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks}
+### `hooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks}
 
 Hooks are hooks that can be used to inject custom patches before syncing
 
@@ -1324,7 +1324,7 @@ Hooks are hooks that can be used to inject custom patches before syncing
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `hostToVirtual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual}
+#### `hostToVirtual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual}
 
 HostToVirtual is a hook that is executed before syncing from the host to the virtual cluster
 
@@ -1336,7 +1336,7 @@ HostToVirtual is a hook that is executed before syncing from the host to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-apiVersion}
 
 APIVersion of the object to sync
 
@@ -1351,7 +1351,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-kind}
 
 Kind of the object to sync
 
@@ -1366,7 +1366,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-verbs}
 
 Verbs are the verbs that the hook should mutate
 
@@ -1381,7 +1381,7 @@ Verbs are the verbs that the hook should mutate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches}
 
 Patches are the patches to apply on the object to be synced
 
@@ -1393,7 +1393,7 @@ Patches are the patches to apply on the object to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-op}
 
 Operation is the type of the patch
 
@@ -1408,7 +1408,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1423,7 +1423,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-path}
 
 Path is the path of the patch
 
@@ -1438,7 +1438,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1453,7 +1453,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1468,7 +1468,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-value}
 
 Value is the new value to be set to the path
 
@@ -1483,7 +1483,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1500,7 +1500,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1513,7 +1513,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1528,7 +1528,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1543,7 +1543,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1558,7 +1558,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1573,7 +1573,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1591,7 +1591,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1606,7 +1606,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1619,7 +1619,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-sync-secret}
 
 
 
@@ -1634,7 +1634,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-hostToVirtual-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-hostToVirtual-patches-sync-configmap}
 
 
 
@@ -1658,7 +1658,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualToHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost}
+#### `virtualToHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost}
 
 VirtualToHost is a hook that is executed before syncing from the virtual to the host cluster
 
@@ -1670,7 +1670,7 @@ VirtualToHost is a hook that is executed before syncing from the virtual to the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-apiVersion}
 
 APIVersion of the object to sync
 
@@ -1685,7 +1685,7 @@ APIVersion of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-kind}
 
 Kind of the object to sync
 
@@ -1700,7 +1700,7 @@ Kind of the object to sync
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-verbs}
 
 Verbs are the verbs that the hook should mutate
 
@@ -1715,7 +1715,7 @@ Verbs are the verbs that the hook should mutate
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches}
 
 Patches are the patches to apply on the object to be synced
 
@@ -1727,7 +1727,7 @@ Patches are the patches to apply on the object to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-op}
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-op}
 
 Operation is the type of the patch
 
@@ -1742,7 +1742,7 @@ Operation is the type of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-fromPath}
+##### `fromPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-fromPath}
 
 FromPath is the path from the other object
 
@@ -1757,7 +1757,7 @@ FromPath is the path from the other object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-path}
 
 Path is the path of the patch
 
@@ -1772,7 +1772,7 @@ Path is the path of the patch
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-namePath}
 
 NamePath is the path to the name of a child resource within Path
 
@@ -1787,7 +1787,7 @@ NamePath is the path to the name of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-namespacePath}
 
 NamespacePath is path to the namespace of a child resource within Path
 
@@ -1802,7 +1802,7 @@ NamespacePath is path to the namespace of a child resource within Path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-value}
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-value}
 
 Value is the new value to be set to the path
 
@@ -1817,7 +1817,7 @@ Value is the new value to be set to the path
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-regex}
+##### `regex` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-regex}
 
 Regex - is regular expresion used to identify the Name,
 and optionally Namespace, parts of the field value that
@@ -1834,7 +1834,7 @@ will be replaced with the rewritten Name and/or Namespace
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions}
+##### `conditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions}
 
 Conditions are conditions that must be true for
 the patch to get executed
@@ -1847,7 +1847,7 @@ the patch to get executed
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-path}
 
 Path is the path within the object to select
 
@@ -1862,7 +1862,7 @@ Path is the path within the object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-subPath}
+##### `subPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-subPath}
 
 SubPath is the path below the selected object to select
 
@@ -1877,7 +1877,7 @@ SubPath is the path below the selected object to select
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-equal}
+##### `equal` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-equal}
 
 Equal is the value the path should be equal to
 
@@ -1892,7 +1892,7 @@ Equal is the value the path should be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-notEqual}
+##### `notEqual` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-notEqual}
 
 NotEqual is the value the path should not be equal to
 
@@ -1907,7 +1907,7 @@ NotEqual is the value the path should not be equal to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-conditions-empty}
+##### `empty` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-conditions-empty}
 
 Empty means that the path value should be empty or unset
 
@@ -1925,7 +1925,7 @@ Empty means that the path value should be empty or unset
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-ignore}
+##### `ignore` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-ignore}
 
 Ignore determines if the path should be ignored if handled as a reverse patch
 
@@ -1940,7 +1940,7 @@ Ignore determines if the path should be ignored if handled as a reverse patch
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-sync}
+##### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-sync}
 
 Sync defines if a specialized syncer should be initialized using values
 from the rewriteName operation as Secret/Configmap names to be synced
@@ -1953,7 +1953,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-sync-secret}
+##### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-sync-secret}
 
 
 
@@ -1968,7 +1968,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-hooks-virtualToHost-patches-sync-configmap}
+##### `configmap` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-hooks-virtualToHost-patches-sync-configmap}
 
 
 
@@ -1995,7 +1995,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-clusterRole}
+### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-clusterRole}
 
 
 
@@ -2007,7 +2007,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-clusterRole-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#genericSync-clusterRole-extraRules}
 
 
 
@@ -2025,7 +2025,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-role}
+### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#genericSync-role}
 
 
 
@@ -2037,7 +2037,7 @@ from the rewriteName operation as Secret/Configmap names to be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#genericSync-role-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#genericSync-role-extraRules}
 
 
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/experimental/isolatedControlPlane.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/experimental/isolatedControlPlane.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `isolatedControlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane}
+## `isolatedControlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane}
 
 IsolatedControlPlane is a feature to run the vCluster control plane in a different Kubernetes cluster than the workloads themselves.
 
@@ -14,7 +14,7 @@ IsolatedControlPlane is a feature to run the vCluster control plane in a differe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane-enabled}
 
 Enabled specifies if the isolated control plane feature should be enabled.
 
@@ -29,7 +29,7 @@ Enabled specifies if the isolated control plane feature should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `headless` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-headless}
+### `headless` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#isolatedControlPlane-headless}
 
 Headless states that Helm should deploy the vCluster in headless mode for the isolated control plane.
 
@@ -44,7 +44,7 @@ Headless states that Helm should deploy the vCluster in headless mode for the is
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-kubeConfig}
+### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane-kubeConfig}
 
 KubeConfig is the path where to find the remote workload cluster kubeconfig.
 
@@ -59,7 +59,7 @@ KubeConfig is the path where to find the remote workload cluster kubeconfig.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-namespace}
+### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane-namespace}
 
 Namespace is the namespace where to sync the workloads into.
 
@@ -74,7 +74,7 @@ Namespace is the namespace where to sync the workloads into.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#isolatedControlPlane-service}
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#isolatedControlPlane-service}
 
 Service is the vCluster service in the remote cluster.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/experimental/syncSettings.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/experimental/syncSettings.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings}
+## `syncSettings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings}
 
 SyncSettings are advanced settings for the syncer controller.
 
@@ -14,7 +14,7 @@ SyncSettings are advanced settings for the syncer controller.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `targetNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-targetNamespace}
+### `targetNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-targetNamespace}
 
 TargetNamespace is the namespace where the workloads should get synced to.
 
@@ -29,7 +29,7 @@ TargetNamespace is the namespace where the workloads should get synced to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-setOwner}
+### `setOwner` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#syncSettings-setOwner}
 
 SetOwner specifies if vCluster should set an owner reference on the synced objects to the vCluster service. This allows for easy garbage collection.
 
@@ -44,7 +44,7 @@ SetOwner specifies if vCluster should set an owner reference on the synced objec
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-hostMetricsBindAddress}
+### `hostMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-hostMetricsBindAddress}
 
 HostMetricsBindAddress is the bind address for the local manager
 
@@ -59,7 +59,7 @@ HostMetricsBindAddress is the bind address for the local manager
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#syncSettings-virtualMetricsBindAddress}
+### `virtualMetricsBindAddress` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#syncSettings-virtualMetricsBindAddress}
 
 VirtualMetricsBindAddress is the bind address for the virtual manager
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/experimental/virtualClusterKubeConfig.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/experimental/virtualClusterKubeConfig.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig}
+## `virtualClusterKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig}
 
 VirtualClusterKubeConfig allows you to override distro specifics and specify where vCluster will find the required certificates and vCluster config.
 
@@ -14,7 +14,7 @@ VirtualClusterKubeConfig allows you to override distro specifics and specify whe
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-kubeConfig}
+### `kubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-kubeConfig}
 
 KubeConfig is the virtual cluster kubeconfig path.
 
@@ -29,7 +29,7 @@ KubeConfig is the virtual cluster kubeconfig path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-serverCAKey}
+### `serverCAKey` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-serverCAKey}
 
 ServerCAKey is the server ca key path.
 
@@ -44,7 +44,7 @@ ServerCAKey is the server ca key path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-serverCACert}
+### `serverCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-serverCACert}
 
 ServerCAKey is the server ca cert path.
 
@@ -59,7 +59,7 @@ ServerCAKey is the server ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-clientCACert}
+### `clientCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-clientCACert}
 
 ServerCAKey is the client ca cert path.
 
@@ -74,7 +74,7 @@ ServerCAKey is the client ca cert path.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#virtualClusterKubeConfig-requestHeaderCACert}
+### `requestHeaderCACert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#virtualClusterKubeConfig-requestHeaderCACert}
 
 RequestHeaderCACert is the request header ca cert path.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/exportKubeConfig.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/exportKubeConfig.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `exportKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig}
+## `exportKubeConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig}
 
 ExportKubeConfig describes how vCluster should export the vCluster kubeConfig file.
 
@@ -14,7 +14,7 @@ ExportKubeConfig describes how vCluster should export the vCluster kubeConfig fi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-context}
+### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-context}
 
 Context is the name of the context within the generated kubeconfig to use.
 
@@ -29,7 +29,7 @@ Context is the name of the context within the generated kubeconfig to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-server}
+### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-server}
 
 Override the default https://localhost:8443 and specify a custom hostname for the generated kubeconfig.
 
@@ -44,7 +44,7 @@ Override the default https://localhost:8443 and specify a custom hostname for th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-insecure}
+### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#exportKubeConfig-insecure}
 
 If tls should get skipped for the server
 
@@ -59,7 +59,7 @@ If tls should get skipped for the server
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-serviceAccount}
+### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount}
 
 ServiceAccount can be used to generate a service account token instead of the default certificates.
 
@@ -71,7 +71,7 @@ ServiceAccount can be used to generate a service account token instead of the de
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-serviceAccount-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-name}
 
 Name of the service account to be used to generate a service account token instead of the default certificates.
 
@@ -86,7 +86,7 @@ Name of the service account to be used to generate a service account token inste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-serviceAccount-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-namespace}
 
 Namespace of the service account to be used to generate a service account token instead of the default certificates.
 If omitted, will use the kube-system namespace.
@@ -102,7 +102,7 @@ If omitted, will use the kube-system namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-serviceAccount-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-serviceAccount-clusterRole}
 
 ClusterRole to assign to the service account.
 
@@ -120,7 +120,7 @@ ClusterRole to assign to the service account.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-secret}
+### `secret` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret}
 
 Declare in which host cluster secret vCluster should store the generated virtual cluster kubeconfig.
 If this is not defined, vCluster will create it with `vc-NAME`. If you specify another name,
@@ -136,7 +136,7 @@ Deprecated: Use AdditionalSecrets instead.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-secret-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret-name}
 
 Name is the name of the secret where the kubeconfig should get stored.
 
@@ -151,7 +151,7 @@ Name is the name of the secret where the kubeconfig should get stored.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-secret-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-secret-namespace}
 
 Namespace where vCluster should store the kubeconfig secret. If this is not equal to the namespace
 where you deployed vCluster, you need to make sure vCluster has access to this other namespace.
@@ -170,7 +170,7 @@ where you deployed vCluster, you need to make sure vCluster has access to this o
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `additionalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets}
+### `additionalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets}
 
 AdditionalSecrets specifies the additional host cluster secrets in which vCluster will store the
 generated virtual cluster kubeconfigs.
@@ -183,7 +183,7 @@ generated virtual cluster kubeconfigs.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-context}
+#### `context` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-context}
 
 Context is the name of the context within the generated kubeconfig to use.
 
@@ -198,7 +198,7 @@ Context is the name of the context within the generated kubeconfig to use.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-server}
+#### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-server}
 
 Override the default https://localhost:8443 and specify a custom hostname for the generated kubeconfig.
 
@@ -213,7 +213,7 @@ Override the default https://localhost:8443 and specify a custom hostname for th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-insecure}
+#### `insecure` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-insecure}
 
 If tls should get skipped for the server
 
@@ -228,7 +228,7 @@ If tls should get skipped for the server
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-serviceAccount}
+#### `serviceAccount` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount}
 
 ServiceAccount can be used to generate a service account token instead of the default certificates.
 
@@ -240,7 +240,7 @@ ServiceAccount can be used to generate a service account token instead of the de
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-serviceAccount-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-name}
 
 Name of the service account to be used to generate a service account token instead of the default certificates.
 
@@ -255,7 +255,7 @@ Name of the service account to be used to generate a service account token inste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-serviceAccount-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-namespace}
 
 Namespace of the service account to be used to generate a service account token instead of the default certificates.
 If omitted, will use the kube-system namespace.
@@ -271,7 +271,7 @@ If omitted, will use the kube-system namespace.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-serviceAccount-clusterRole}
+##### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-serviceAccount-clusterRole}
 
 ClusterRole to assign to the service account.
 
@@ -289,7 +289,7 @@ ClusterRole to assign to the service account.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-name}
+#### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-name}
 
 Name is the name of the secret where the kubeconfig is stored.
 
@@ -304,7 +304,7 @@ Name is the name of the secret where the kubeconfig is stored.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#exportKubeConfig-additionalSecrets-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#exportKubeConfig-additionalSecrets-namespace}
 
 Namespace where vCluster stores the kubeconfig secret. If this is not equal to the namespace
 where you deployed vCluster, you need to make sure vCluster has access to this other namespace.

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/integrations.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/integrations.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `integrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations}
+## `integrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations}
 
 Integrations holds config for vCluster integrations with other operators or tools running on the host cluster
 
@@ -14,7 +14,7 @@ Integrations holds config for vCluster integrations with other operators or tool
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer}
+### `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer}
 
 MetricsServer reuses the metrics server from the host cluster within the vCluster.
 
@@ -26,7 +26,7 @@ MetricsServer reuses the metrics server from the host cluster within the vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-metricsServer-enabled}
 
 Enabled signals the metrics server integration should be enabled.
 
@@ -41,7 +41,7 @@ Enabled signals the metrics server integration should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService}
+#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService}
 
 APIService holds information about where to find the metrics-server service. Defaults to metrics-server/kube-system.
 
@@ -53,7 +53,7 @@ APIService holds information about where to find the metrics-server service. Def
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -65,7 +65,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -80,7 +80,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -95,7 +95,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-metricsServer-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -116,7 +116,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-nodes}
+#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-metricsServer-nodes}
 
 Nodes defines if metrics-server nodes api should get proxied from host to virtual cluster.
 
@@ -131,7 +131,7 @@ Nodes defines if metrics-server nodes api should get proxied from host to virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-metricsServer-pods}
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-metricsServer-pods}
 
 Pods defines if metrics-server pods api should get proxied from host to virtual cluster.
 
@@ -149,7 +149,7 @@ Pods defines if metrics-server pods api should get proxied from host to virtual 
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt}
+### `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt}
 
 KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside the vCluster
 
@@ -161,7 +161,7 @@ KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-enabled}
 
 Enabled signals if the integration should be enabled
 
@@ -176,7 +176,7 @@ Enabled signals if the integration should be enabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService}
+#### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService}
 
 APIService holds information about where to find the virt-api service. Defaults to virt-api/kubevirt.
 
@@ -188,7 +188,7 @@ APIService holds information about where to find the virt-api service. Defaults 
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -200,7 +200,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -215,7 +215,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -230,7 +230,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -251,7 +251,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-webhook}
+#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-webhook}
 
 Webhook holds configuration for enabling the webhook within the vCluster
 
@@ -263,7 +263,7 @@ Webhook holds configuration for enabling the webhook within the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-webhook-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -281,7 +281,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync}
+#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync}
 
 Sync holds configuration on what resources to sync
 
@@ -293,7 +293,7 @@ Sync holds configuration on what resources to sync
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-dataVolumes}
+##### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-dataVolumes}
 
 If DataVolumes should get synced
 
@@ -305,7 +305,7 @@ If DataVolumes should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-dataVolumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-dataVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -323,7 +323,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations}
+##### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations}
 
 If VirtualMachineInstanceMigrations should get synced
 
@@ -335,7 +335,7 @@ If VirtualMachineInstanceMigrations should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -353,7 +353,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineInstances}
+##### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstances}
 
 If VirtualMachineInstances should get synced
 
@@ -365,7 +365,7 @@ If VirtualMachineInstances should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineInstances-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineInstances-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -383,7 +383,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachines}
+##### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachines}
 
 If VirtualMachines should get synced
 
@@ -395,7 +395,7 @@ If VirtualMachines should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachines-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachines-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -413,7 +413,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineClones}
+##### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineClones}
 
 If VirtualMachineClones should get synced
 
@@ -425,7 +425,7 @@ If VirtualMachineClones should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachineClones-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachineClones-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -443,7 +443,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachinePools}
+##### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachinePools}
 
 If VirtualMachinePools should get synced
 
@@ -455,7 +455,7 @@ If VirtualMachinePools should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-kubeVirt-sync-virtualMachinePools-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-kubeVirt-sync-virtualMachinePools-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -479,7 +479,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets}
+### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets}
 
 ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster.
 - ExternalSecrets will be synced from the virtual cluster to the host cluster.
@@ -494,7 +494,7 @@ ExternalSecrets reuses a host external secret operator and makes certain CRDs fr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-enabled}
 
 Enabled defines whether the external secret integration is enabled or not
 
@@ -509,7 +509,7 @@ Enabled defines whether the external secret integration is enabled or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-webhook}
+#### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-webhook}
 
 Webhook defines whether the host webhooks are reused or not
 
@@ -521,7 +521,7 @@ Webhook defines whether the host webhooks are reused or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-webhook-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -539,7 +539,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync}
+#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync}
 
 Sync defines the syncing behavior for the integration
 
@@ -551,7 +551,7 @@ Sync defines the syncing behavior for the integration
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-externalSecrets}
+##### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-externalSecrets}
 
 ExternalSecrets defines if external secrets should get synced from the virtual cluster to the host cluster.
 
@@ -563,7 +563,7 @@ ExternalSecrets defines if external secrets should get synced from the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-externalSecrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-externalSecrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -581,7 +581,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-stores}
+##### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-stores}
 
 Stores defines if secret stores should get synced from the virtual cluster to the host cluster and then bi-directionally.
 
@@ -593,7 +593,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-stores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-stores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -611,7 +611,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-clusterStores}
+##### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-clusterStores}
 
 ClusterStores defines if cluster secrets stores should get synced from the host cluster to the virtual cluster.
 
@@ -623,7 +623,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-clusterStores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-clusterStores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -638,7 +638,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-clusterStores-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-clusterStores-selector}
 
 Selector defines what cluster stores should be synced
 
@@ -650,7 +650,7 @@ Selector defines what cluster stores should be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-externalSecrets-sync-clusterStores-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-externalSecrets-sync-clusterStores-selector-labels}
 
 Labels defines what labels should be looked for
 
@@ -677,7 +677,7 @@ Labels defines what labels should be looked for
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager}
+### `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager}
 
 CertManager reuses a host cert-manager and makes its CRDs from it available inside the vCluster.
 - Certificates and Issuers will be synced from the virtual cluster to the host cluster.
@@ -691,7 +691,7 @@ CertManager reuses a host cert-manager and makes its CRDs from it available insi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-certManager-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -706,7 +706,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync}
+#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync}
 
 Sync contains advanced configuration for syncing cert-manager resources.
 
@@ -718,7 +718,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost}
+##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost}
 
 
 
@@ -730,7 +730,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost-certificates}
+##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-certificates}
 
 Certificates defines if certificates should get synced from the virtual cluster to the host cluster.
 
@@ -742,7 +742,7 @@ Certificates defines if certificates should get synced from the virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost-certificates-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-certificates-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -760,7 +760,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost-issuers}
+##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-issuers}
 
 Issuers defines if issuers should get synced from the virtual cluster to the host cluster.
 
@@ -772,7 +772,7 @@ Issuers defines if issuers should get synced from the virtual cluster to the hos
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-toHost-issuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-toHost-issuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -793,7 +793,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost}
+##### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost}
 
 
 
@@ -805,7 +805,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost-clusterIssuers}
+##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers}
 
 ClusterIssuers defines if (and which) cluster issuers should get synced from the host cluster to the virtual cluster.
 
@@ -817,7 +817,7 @@ ClusterIssuers defines if (and which) cluster issuers should get synced from the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost-clusterIssuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -832,7 +832,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector}
 
 Selector defines what cluster issuers should be imported.
 
@@ -844,7 +844,7 @@ Selector defines what cluster issuers should be imported.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#integrations-certManager-sync-fromHost-clusterIssuers-selector-labels}
 
 Labels defines what labels should be looked for
 
@@ -874,7 +874,7 @@ Labels defines what labels should be looked for
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `istio` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio}
+### `istio` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio}
 
 Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster to the host.
 
@@ -886,7 +886,7 @@ Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#integrations-istio-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -901,7 +901,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync}
+#### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync}
 
 
 
@@ -913,7 +913,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost}
+##### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost}
 
 
 
@@ -925,7 +925,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `destinationRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost-destinationRules}
+##### `destinationRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-destinationRules}
 
 
 
@@ -937,37 +937,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost-destinationRules-enabled}
-
-Enabled defines if this option should be enabled.
-
-</summary>
-
-
-
-</details>
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost-gateways}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost-gateways-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-destinationRules-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -985,7 +955,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost-virtualServices}
+##### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-gateways}
 
 
 
@@ -997,7 +967,37 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#integrations-istio-sync-toHost-virtualServices-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-gateways-enabled}
+
+Enabled defines if this option should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `virtualServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-virtualServices}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#integrations-istio-sync-toHost-virtualServices-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/integrations/certManager.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/integrations/certManager.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager}
+## `certManager` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager}
 
 CertManager reuses a host cert-manager and makes its CRDs from it available inside the vCluster.
 - Certificates and Issuers will be synced from the virtual cluster to the host cluster.
@@ -16,7 +16,7 @@ CertManager reuses a host cert-manager and makes its CRDs from it available insi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#certManager-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -31,7 +31,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync}
+### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync}
 
 Sync contains advanced configuration for syncing cert-manager resources.
 
@@ -43,7 +43,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost}
+#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost}
 
 
 
@@ -55,7 +55,7 @@ Sync contains advanced configuration for syncing cert-manager resources.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-certificates}
+##### `certificates` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost-certificates}
 
 Certificates defines if certificates should get synced from the virtual cluster to the host cluster.
 
@@ -67,7 +67,7 @@ Certificates defines if certificates should get synced from the virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-certificates-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-toHost-certificates-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -85,7 +85,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-issuers}
+##### `issuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-toHost-issuers}
 
 Issuers defines if issuers should get synced from the virtual cluster to the host cluster.
 
@@ -97,7 +97,7 @@ Issuers defines if issuers should get synced from the virtual cluster to the hos
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-toHost-issuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-toHost-issuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -118,7 +118,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost}
+#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost}
 
 
 
@@ -130,7 +130,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers}
+##### `clusterIssuers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers}
 
 ClusterIssuers defines if (and which) cluster issuers should get synced from the host cluster to the virtual cluster.
 
@@ -142,7 +142,7 @@ ClusterIssuers defines if (and which) cluster issuers should get synced from the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -157,7 +157,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-selector}
 
 Selector defines what cluster issuers should be imported.
 
@@ -169,7 +169,7 @@ Selector defines what cluster issuers should be imported.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#certManager-sync-fromHost-clusterIssuers-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#certManager-sync-fromHost-clusterIssuers-selector-labels}
 
 Labels defines what labels should be looked for
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/integrations/externalSecrets.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/integrations/externalSecrets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets}
+## `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets}
 
 ExternalSecrets reuses a host external secret operator and makes certain CRDs from it available inside the vCluster.
 - ExternalSecrets will be synced from the virtual cluster to the host cluster.
@@ -17,7 +17,7 @@ ExternalSecrets reuses a host external secret operator and makes certain CRDs fr
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-enabled}
 
 Enabled defines whether the external secret integration is enabled or not
 
@@ -32,7 +32,7 @@ Enabled defines whether the external secret integration is enabled or not
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-webhook}
+### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-webhook}
 
 Webhook defines whether the host webhooks are reused or not
 
@@ -44,7 +44,7 @@ Webhook defines whether the host webhooks are reused or not
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-webhook-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -62,7 +62,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync}
+### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync}
 
 Sync defines the syncing behavior for the integration
 
@@ -74,7 +74,7 @@ Sync defines the syncing behavior for the integration
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-externalSecrets}
+#### `externalSecrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-externalSecrets}
 
 ExternalSecrets defines if external secrets should get synced from the virtual cluster to the host cluster.
 
@@ -86,7 +86,7 @@ ExternalSecrets defines if external secrets should get synced from the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-externalSecrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#externalSecrets-sync-externalSecrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -104,7 +104,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-stores}
+#### `stores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-stores}
 
 Stores defines if secret stores should get synced from the virtual cluster to the host cluster and then bi-directionally.
 
@@ -116,7 +116,7 @@ Stores defines if secret stores should get synced from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-stores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-sync-stores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -134,7 +134,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-clusterStores}
+#### `clusterStores` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-clusterStores}
 
 ClusterStores defines if cluster secrets stores should get synced from the host cluster to the virtual cluster.
 
@@ -146,7 +146,7 @@ ClusterStores defines if cluster secrets stores should get synced from the host 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-clusterStores-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#externalSecrets-sync-clusterStores-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -161,7 +161,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-clusterStores-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#externalSecrets-sync-clusterStores-selector}
 
 Selector defines what cluster stores should be synced
 
@@ -173,7 +173,7 @@ Selector defines what cluster stores should be synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#externalSecrets-sync-clusterStores-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#externalSecrets-sync-clusterStores-selector-labels}
 
 Labels defines what labels should be looked for
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/integrations/istio.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/integrations/istio.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `istio` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio}
+## `istio` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio}
 
 Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster to the host.
 
@@ -14,7 +14,7 @@ Istio syncs DestinationRules, Gateways and VirtualServices from virtual cluster 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#istio-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync}
+### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync}
 
 
 
@@ -41,7 +41,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost}
+#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost}
 
 
 
@@ -53,7 +53,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `destinationRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost-destinationRules}
+##### `destinationRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-destinationRules}
 
 
 
@@ -65,37 +65,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost-destinationRules-enabled}
-
-Enabled defines if this option should be enabled.
-
-</summary>
-
-
-
-</details>
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="true">
-<summary>
-
-##### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost-gateways}
-
-
-
-</summary>
-
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost-gateways-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-destinationRules-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -113,7 +83,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `virtualServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost-virtualServices}
+##### `gateways` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-gateways}
 
 
 
@@ -125,7 +95,37 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#istio-sync-toHost-virtualServices-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-gateways-enabled}
+
+Enabled defines if this option should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `virtualServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#istio-sync-toHost-virtualServices}
+
+
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#istio-sync-toHost-virtualServices-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/integrations/kubeVirt.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/integrations/kubeVirt.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt}
+## `kubeVirt` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt}
 
 KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside the vCluster
 
@@ -14,7 +14,7 @@ KubeVirt reuses a host kubevirt and makes certain CRDs from it available inside 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVirt-enabled}
 
 Enabled signals if the integration should be enabled
 
@@ -29,7 +29,7 @@ Enabled signals if the integration should be enabled
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService}
+### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService}
 
 APIService holds information about where to find the virt-api service. Defaults to virt-api/kubevirt.
 
@@ -41,7 +41,7 @@ APIService holds information about where to find the virt-api service. Defaults 
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService-service}
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -53,7 +53,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -68,7 +68,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -83,7 +83,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -104,7 +104,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-webhook}
+### `webhook` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-webhook}
 
 Webhook holds configuration for enabling the webhook within the vCluster
 
@@ -116,7 +116,7 @@ Webhook holds configuration for enabling the webhook within the vCluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-webhook-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-webhook-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -134,7 +134,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync}
+### `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync}
 
 Sync holds configuration on what resources to sync
 
@@ -146,7 +146,7 @@ Sync holds configuration on what resources to sync
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-dataVolumes}
+#### `dataVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-dataVolumes}
 
 If DataVolumes should get synced
 
@@ -158,7 +158,7 @@ If DataVolumes should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-dataVolumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#kubeVirt-sync-dataVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -176,7 +176,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineInstanceMigrations}
+#### `virtualMachineInstanceMigrations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstanceMigrations}
 
 If VirtualMachineInstanceMigrations should get synced
 
@@ -188,7 +188,7 @@ If VirtualMachineInstanceMigrations should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstanceMigrations-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -206,7 +206,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineInstances}
+#### `virtualMachineInstances` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstances}
 
 If VirtualMachineInstances should get synced
 
@@ -218,7 +218,7 @@ If VirtualMachineInstances should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineInstances-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineInstances-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -236,7 +236,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachines}
+#### `virtualMachines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachines}
 
 If VirtualMachines should get synced
 
@@ -248,7 +248,7 @@ If VirtualMachines should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachines-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachines-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -266,7 +266,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineClones}
+#### `virtualMachineClones` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineClones}
 
 If VirtualMachineClones should get synced
 
@@ -278,7 +278,7 @@ If VirtualMachineClones should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachineClones-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachineClones-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -296,7 +296,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachinePools}
+#### `virtualMachinePools` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachinePools}
 
 If VirtualMachinePools should get synced
 
@@ -308,7 +308,7 @@ If VirtualMachinePools should get synced
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#kubeVirt-sync-virtualMachinePools-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#kubeVirt-sync-virtualMachinePools-enabled}
 
 Enabled defines if this option should be enabled.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/integrations/metricsServer.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/integrations/metricsServer.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer}
+## `metricsServer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer}
 
 MetricsServer reuses the metrics server from the host cluster within the vCluster.
 
@@ -14,7 +14,7 @@ MetricsServer reuses the metrics server from the host cluster within the vCluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#metricsServer-enabled}
 
 Enabled signals the metrics server integration should be enabled.
 
@@ -29,7 +29,7 @@ Enabled signals the metrics server integration should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService}
+### `apiService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService}
 
 APIService holds information about where to find the metrics-server service. Defaults to metrics-server/kube-system.
 
@@ -41,7 +41,7 @@ APIService holds information about where to find the metrics-server service. Def
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService-service}
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service}
 
 Service is a reference to the service for the API server.
 
@@ -53,7 +53,7 @@ Service is a reference to the service for the API server.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-name}
 
 Name is the name of the host service of the apiservice.
 
@@ -68,7 +68,7 @@ Name is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-namespace}
 
 Namespace is the name of the host service of the apiservice.
 
@@ -83,7 +83,7 @@ Namespace is the name of the host service of the apiservice.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-apiService-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#metricsServer-apiService-service-port}
 
 Port is the target port on the host service to connect to.
 
@@ -104,7 +104,7 @@ Port is the target port on the host service to connect to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-nodes}
+### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#metricsServer-nodes}
 
 Nodes defines if metrics-server nodes api should get proxied from host to virtual cluster.
 
@@ -119,7 +119,7 @@ Nodes defines if metrics-server nodes api should get proxied from host to virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#metricsServer-pods}
+### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#metricsServer-pods}
 
 Pods defines if metrics-server pods api should get proxied from host to virtual cluster.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/logging.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/logging.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `logging` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#logging}
+## `logging` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#logging}
 
 Logging provides structured logging options
 
@@ -14,7 +14,7 @@ Logging provides structured logging options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `encoding` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">console</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#logging-encoding}
+### `encoding` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">console</span> <span className="config-field-enum"></span> {#logging-encoding}
 
 Encoding specifies the format of vCluster logs, it can either be json or console.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/networking.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/networking.mdx
@@ -2,16 +2,49 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `networking` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking}
+## `networking` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking}
 
 Networking options related to the virtual cluster.
 
 </summary>
 
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `serviceCIDR` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-serviceCIDR}
+
+ServiceCIDR holds the service cidr for the virtual cluster. This should only be set if privateNodes.enabled is true or vCluster cannot detect the host service cidr.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `podCIDR` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">10.244.0.0/16</span> <span className="config-field-enum"></span> {#networking-podCIDR}
+
+PodCIDR holds the pod cidr for the virtual cluster. This should only be set if privateNodes.enabled is true.
+
+</summary>
+
+
+
+</details>
+
+
+
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices}
+### `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices}
 
 ReplicateServices allows replicating services from the host within the virtual cluster or the other way around.
 
@@ -23,7 +56,7 @@ ReplicateServices allows replicating services from the host within the virtual c
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-toHost}
+#### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost}
 
 ToHost defines the services that should get synced from virtual cluster to the host cluster. If services are
 synced to a different namespace than the virtual cluster is in, additional permissions for the other namespace
@@ -37,7 +70,7 @@ are required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-toHost-from}
+##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -52,7 +85,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-toHost-to}
+##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-toHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 
@@ -70,7 +103,7 @@ To is the target service that it should get synced to. Can be either in the form
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-fromHost}
+#### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost}
 
 FromHost defines the services that should get synced from the host to the virtual cluster.
 
@@ -82,7 +115,7 @@ FromHost defines the services that should get synced from the host to the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-fromHost-from}
+##### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -97,7 +130,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-replicateServices-fromHost-to}
+##### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-replicateServices-fromHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 
@@ -118,7 +151,7 @@ To is the target service that it should get synced to. Can be either in the form
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS}
+### `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS}
 
 ResolveDNS allows to define extra DNS rules. This only works if embedded coredns is configured.
 
@@ -130,7 +163,7 @@ ResolveDNS allows to define extra DNS rules. This only works if embedded coredns
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-hostname}
+#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-hostname}
 
 Hostname is the hostname within the vCluster that should be resolved from.
 
@@ -145,7 +178,7 @@ Hostname is the hostname within the vCluster that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-service}
+#### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-service}
 
 Service is the virtual cluster service that should be resolved from.
 
@@ -160,7 +193,7 @@ Service is the virtual cluster service that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-namespace}
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-namespace}
 
 Namespace is the virtual cluster namespace that should be resolved from.
 
@@ -175,7 +208,7 @@ Namespace is the virtual cluster namespace that should be resolved from.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target}
+#### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target}
 
 Target is the DNS target that should get mapped to
 
@@ -187,7 +220,7 @@ Target is the DNS target that should get mapped to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-hostname}
+##### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostname}
 
 Hostname to use as a DNS target
 
@@ -202,7 +235,7 @@ Hostname to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-ip}
+##### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-ip}
 
 IP to use as a DNS target
 
@@ -217,7 +250,7 @@ IP to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-hostService}
+##### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostService}
 
 HostService to target, format is hostNamespace/hostService
 
@@ -232,7 +265,7 @@ HostService to target, format is hostNamespace/hostService
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-hostNamespace}
+##### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-hostNamespace}
 
 HostNamespace to target
 
@@ -247,7 +280,7 @@ HostNamespace to target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-resolveDNS-target-vClusterService}
+##### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-resolveDNS-target-vClusterService}
 
 VClusterService format is hostNamespace/vClusterName/vClusterNamespace/vClusterService
 
@@ -268,7 +301,7 @@ VClusterService format is hostNamespace/vClusterName/vClusterNamespace/vClusterS
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced}
+### `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-advanced}
 
 Advanced holds advanced network options.
 
@@ -280,7 +313,7 @@ Advanced holds advanced network options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-clusterDomain}
+#### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> {#networking-advanced-clusterDomain}
 
 ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster.
 
@@ -295,7 +328,7 @@ ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-fallbackHostCluster}
+#### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networking-advanced-fallbackHostCluster}
 
 FallbackHostCluster allows to fallback dns to the host cluster. This is useful if you want to reach host services without
 any other modification. You will need to provide a namespace for the service, e.g. my-other-service.my-other-namespace
@@ -311,7 +344,7 @@ any other modification. You will need to provide a namespace for the service, e.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-proxyKubelets}
+#### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets}
 
 ProxyKubelets allows rewriting certain metrics and stats from the Kubelet to "fake" this for applications such as
 prometheus or other node exporters.
@@ -324,7 +357,7 @@ prometheus or other node exporters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-proxyKubelets-byHostname}
+##### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets-byHostname}
 
 ByHostname will add a special vCluster hostname to the nodes where the node can be reached at. This doesn't work
 for all applications, e.g. Prometheus requires a node IP.
@@ -340,7 +373,7 @@ for all applications, e.g. Prometheus requires a node IP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networking-advanced-proxyKubelets-byIP}
+##### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networking-advanced-proxyKubelets-byIP}
 
 ByIP will create a separate service in the host cluster for every node that will point to virtual cluster and will be used to
 route traffic.

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/networking/advanced.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/networking/advanced.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced}
+## `advanced` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced}
 
 Advanced holds advanced network options.
 
@@ -14,7 +14,7 @@ Advanced holds advanced network options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-clusterDomain}
+### `clusterDomain` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">cluster.local</span> <span className="config-field-enum"></span> {#advanced-clusterDomain}
 
 ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster.
 
@@ -29,7 +29,7 @@ ClusterDomain is the Kubernetes cluster domain to use within the virtual cluster
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-fallbackHostCluster}
+### `fallbackHostCluster` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#advanced-fallbackHostCluster}
 
 FallbackHostCluster allows to fallback dns to the host cluster. This is useful if you want to reach host services without
 any other modification. You will need to provide a namespace for the service, e.g. my-other-service.my-other-namespace
@@ -45,7 +45,7 @@ any other modification. You will need to provide a namespace for the service, e.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-proxyKubelets}
+### `proxyKubelets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#advanced-proxyKubelets}
 
 ProxyKubelets allows rewriting certain metrics and stats from the Kubelet to "fake" this for applications such as
 prometheus or other node exporters.
@@ -58,7 +58,7 @@ prometheus or other node exporters.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-proxyKubelets-byHostname}
+#### `byHostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-proxyKubelets-byHostname}
 
 ByHostname will add a special vCluster hostname to the nodes where the node can be reached at. This doesn't work
 for all applications, e.g. Prometheus requires a node IP.
@@ -74,7 +74,7 @@ for all applications, e.g. Prometheus requires a node IP.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#advanced-proxyKubelets-byIP}
+#### `byIP` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#advanced-proxyKubelets-byIP}
 
 ByIP will create a separate service in the host cluster for every node that will point to virtual cluster and will be used to
 route traffic.

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/networking/replicateServices.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/networking/replicateServices.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices}
+## `replicateServices` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices}
 
 ReplicateServices allows replicating services from the host within the virtual cluster or the other way around.
 
@@ -14,7 +14,7 @@ ReplicateServices allows replicating services from the host within the virtual c
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-toHost}
+### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost}
 
 ToHost defines the services that should get synced from virtual cluster to the host cluster. If services are
 synced to a different namespace than the virtual cluster is in, additional permissions for the other namespace
@@ -28,7 +28,7 @@ are required.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-toHost-from}
+#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -43,7 +43,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-toHost-to}
+#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-toHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 
@@ -61,7 +61,7 @@ To is the target service that it should get synced to. Can be either in the form
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-fromHost}
+### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost}
 
 FromHost defines the services that should get synced from the host to the virtual cluster.
 
@@ -73,7 +73,7 @@ FromHost defines the services that should get synced from the host to the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-fromHost-from}
+#### `from` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost-from}
 
 From is the service that should get synced. Can be either in the form name or namespace/name.
 
@@ -88,7 +88,7 @@ From is the service that should get synced. Can be either in the form name or na
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#replicateServices-fromHost-to}
+#### `to` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#replicateServices-fromHost-to}
 
 To is the target service that it should get synced to. Can be either in the form name or namespace/name.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/networking/resolveDNS.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/networking/resolveDNS.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS}
+## `resolveDNS` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS}
 
 ResolveDNS allows to define extra DNS rules. This only works if embedded coredns is configured.
 
@@ -14,7 +14,7 @@ ResolveDNS allows to define extra DNS rules. This only works if embedded coredns
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-hostname}
+### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-hostname}
 
 Hostname is the hostname within the vCluster that should be resolved from.
 
@@ -29,7 +29,7 @@ Hostname is the hostname within the vCluster that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-service}
+### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-service}
 
 Service is the virtual cluster service that should be resolved from.
 
@@ -44,7 +44,7 @@ Service is the virtual cluster service that should be resolved from.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-namespace}
+### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-namespace}
 
 Namespace is the virtual cluster namespace that should be resolved from.
 
@@ -59,7 +59,7 @@ Namespace is the virtual cluster namespace that should be resolved from.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target}
+### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target}
 
 Target is the DNS target that should get mapped to
 
@@ -71,7 +71,7 @@ Target is the DNS target that should get mapped to
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-hostname}
+#### `hostname` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostname}
 
 Hostname to use as a DNS target
 
@@ -86,7 +86,7 @@ Hostname to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-ip}
+#### `ip` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-ip}
 
 IP to use as a DNS target
 
@@ -101,7 +101,7 @@ IP to use as a DNS target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-hostService}
+#### `hostService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostService}
 
 HostService to target, format is hostNamespace/hostService
 
@@ -116,7 +116,7 @@ HostService to target, format is hostNamespace/hostService
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-hostNamespace}
+#### `hostNamespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-hostNamespace}
 
 HostNamespace to target
 
@@ -131,7 +131,7 @@ HostNamespace to target
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resolveDNS-target-vClusterService}
+#### `vClusterService` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resolveDNS-target-vClusterService}
 
 VClusterService format is hostNamespace/vClusterName/vClusterNamespace/vClusterService
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/plugins.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/plugins.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `plugins` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins}
+## `plugins` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins}
 
 Define which vCluster plugins to load.
 
@@ -14,7 +14,7 @@ Define which vCluster plugins to load.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-name}
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-name}
 
 Name is the name of the init-container and NOT the plugin name
 
@@ -29,7 +29,7 @@ Name is the name of the init-container and NOT the plugin name
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-image}
+### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-image}
 
 Image is the container image that should be used for the plugin
 
@@ -44,7 +44,7 @@ Image is the container image that should be used for the plugin
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-imagePullPolicy}
+### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-imagePullPolicy}
 
 ImagePullPolicy is the pull policy to use for the container image
 
@@ -59,7 +59,7 @@ ImagePullPolicy is the pull policy to use for the container image
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-config}
+### `config` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-config}
 
 Config is the plugin config to use. This can be arbitrary config used for the plugin.
 
@@ -74,7 +74,7 @@ Config is the plugin config to use. This can be arbitrary config used for the pl
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac}
+### `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac}
 
 RBAC holds additional rbac configuration for the plugin
 
@@ -86,7 +86,7 @@ RBAC holds additional rbac configuration for the plugin
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role}
+#### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role}
 
 Role holds extra virtual cluster role permissions for the plugin
 
@@ -98,7 +98,7 @@ Role holds extra virtual cluster role permissions for the plugin
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules}
 
 ExtraRules are extra rbac permissions roles that will be added to role or cluster role
 
@@ -110,7 +110,7 @@ ExtraRules are extra rbac permissions roles that will be added to role or cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-verbs}
 
 Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 
@@ -125,7 +125,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this r
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-apiGroups}
 
 APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
@@ -141,7 +141,7 @@ the enumerated resources in any API group will be allowed. "" represents the cor
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-resources}
 
 Resources is a list of resources this rule applies to. '*' represents all resources.
 
@@ -156,7 +156,7 @@ Resources is a list of resources this rule applies to. '*' represents all resour
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-resourceNames}
 
 ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 
@@ -171,7 +171,7 @@ ResourceNames is an optional white list of names that the rule applies to.  An e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-role-extraRules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-role-extraRules-nonResourceURLs}
 
 NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
@@ -194,7 +194,7 @@ Rules can either apply to API resources (such as "pods" or "secrets") or non-res
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole}
+#### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole}
 
 ClusterRole holds extra virtual cluster cluster role permissions required for the plugin
 
@@ -206,7 +206,7 @@ ClusterRole holds extra virtual cluster cluster role permissions required for th
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules}
+##### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules}
 
 ExtraRules are extra rbac permissions roles that will be added to role or cluster role
 
@@ -218,7 +218,7 @@ ExtraRules are extra rbac permissions roles that will be added to role or cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-verbs}
+##### `verbs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-verbs}
 
 Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this rule. '*' represents all verbs.
 
@@ -233,7 +233,7 @@ Verbs is a list of Verbs that apply to ALL the ResourceKinds contained in this r
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-apiGroups}
+##### `apiGroups` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-apiGroups}
 
 APIGroups is the name of the APIGroup that contains the resources.  If multiple API groups are specified, any action requested against one of
 the enumerated resources in any API group will be allowed. "" represents the core API group and "*" represents all API groups.
@@ -249,7 +249,7 @@ the enumerated resources in any API group will be allowed. "" represents the cor
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-resources}
 
 Resources is a list of resources this rule applies to. '*' represents all resources.
 
@@ -264,7 +264,7 @@ Resources is a list of resources this rule applies to. '*' represents all resour
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-resourceNames}
+##### `resourceNames` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-resourceNames}
 
 ResourceNames is an optional white list of names that the rule applies to.  An empty set means that everything is allowed.
 
@@ -279,7 +279,7 @@ ResourceNames is an optional white list of names that the rule applies to.  An e
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-rbac-clusterRole-extraRules-nonResourceURLs}
+##### `nonResourceURLs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-rbac-clusterRole-extraRules-nonResourceURLs}
 
 NonResourceURLs is a set of partial urls that a user should have access to.  *s are allowed, but only as the full, final step in the path
 Since non-resource URLs are not namespaced, this field is only applicable for ClusterRoles referenced from a ClusterRoleBinding.
@@ -305,7 +305,7 @@ Rules can either apply to API resources (such as "pods" or "secrets") or non-res
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-command}
+### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-command}
 
 Command is the command that should be used for the init container
 
@@ -320,7 +320,7 @@ Command is the command that should be used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-args}
+### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-args}
 
 Args are the arguments that should be used for the init container
 
@@ -335,7 +335,7 @@ Args are the arguments that should be used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-securityContext}
+### `securityContext` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-securityContext}
 
 SecurityContext is the container security context used for the init container
 
@@ -350,7 +350,7 @@ SecurityContext is the container security context used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-resources}
+### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-resources}
 
 Resources are the container resources used for the init container
 
@@ -365,7 +365,7 @@ Resources are the container resources used for the init container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `volumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#plugins-volumeMounts}
+### `volumeMounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#plugins-volumeMounts}
 
 VolumeMounts are extra volume mounts for the init container
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/policies.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/policies.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `policies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies}
+## `policies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies}
 
 Policies to enforce for the virtual cluster deployment as well as within the virtual cluster.
 
@@ -14,7 +14,7 @@ Policies to enforce for the virtual cluster deployment as well as within the vir
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy}
+### `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy}
 
 NetworkPolicy specifies network policy options.
 
@@ -26,7 +26,7 @@ NetworkPolicy specifies network policy options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#policies-networkPolicy-enabled}
 
 Enabled defines if the network policy should be deployed by vCluster.
 
@@ -41,7 +41,7 @@ Enabled defines if the network policy should be deployed by vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-fallbackDns}
+#### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> {#policies-networkPolicy-fallbackDns}
 
 FallbackDNS is the fallback DNS server to use if the virtual cluster does not have a DNS server.
 
@@ -56,7 +56,7 @@ FallbackDNS is the fallback DNS server to use if the virtual cluster does not ha
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `outgoingConnections` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections}
+#### `outgoingConnections` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections}
 
 OutgoingConnections are the outgoing connections options for the vCluster workloads.
 
@@ -68,7 +68,7 @@ OutgoingConnections are the outgoing connections options for the vCluster worklo
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections-ipBlock}
+##### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections-ipBlock}
 
 IPBlock describes a particular CIDR (Ex. "192.168.1.0/24","2001:db8::/64") that is allowed
 to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs
@@ -82,7 +82,7 @@ that should not be included within this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections-ipBlock-cidr}
 
 cidr is a string representing the IPBlock
 Valid examples are "192.168.1.0/24" or "2001:db8::/64"
@@ -98,7 +98,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections-ipBlock-except}
 
 except is a slice of CIDRs that should not be included within an IPBlock
 Valid examples are "192.168.1.0/24" or "2001:db8::/64"
@@ -118,7 +118,7 @@ Except values will be rejected if they are outside the cidr range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-outgoingConnections-platform}
+##### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#policies-networkPolicy-outgoingConnections-platform}
 
 Platform enables egress access towards loft platform
 
@@ -136,7 +136,7 @@ Platform enables egress access towards loft platform
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraControlPlaneRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-extraControlPlaneRules}
+#### `extraControlPlaneRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-extraControlPlaneRules}
 
 ExtraControlPlaneRules are extra allowed rules for the vCluster control plane.
 
@@ -151,7 +151,7 @@ ExtraControlPlaneRules are extra allowed rules for the vCluster control plane.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraWorkloadRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-extraWorkloadRules}
+#### `extraWorkloadRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-extraWorkloadRules}
 
 ExtraWorkloadRules are extra allowed rules for the vCluster workloads.
 
@@ -166,7 +166,7 @@ ExtraWorkloadRules are extra allowed rules for the vCluster workloads.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -181,7 +181,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-networkPolicy-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-networkPolicy-labels}
 
 Labels are extra labels for this resource.
 
@@ -199,7 +199,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-podSecurityStandard}
+### `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-podSecurityStandard}
 
 PodSecurityStandard that can be enforced can be one of: empty (""), baseline, restricted or privileged
 
@@ -214,7 +214,7 @@ PodSecurityStandard that can be enforced can be one of: empty (""), baseline, re
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota}
+### `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-resourceQuota}
 
 ResourceQuota specifies resource quota options.
 
@@ -226,7 +226,7 @@ ResourceQuota specifies resource quota options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#policies-resourceQuota-enabled}
 
 Enabled defines if the resource quota should be enabled. "auto" means that if limitRange is enabled,
 the resourceQuota will be enabled as well.
@@ -242,7 +242,7 @@ the resourceQuota will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-quota}
+#### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-quota}
 
 Quota are the quota options
 
@@ -257,7 +257,7 @@ Quota are the quota options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-scopeSelector}
+#### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-scopeSelector}
 
 ScopeSelector is the resource quota scope selector
 
@@ -272,7 +272,7 @@ ScopeSelector is the resource quota scope selector
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-scopes}
+#### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-scopes}
 
 Scopes are the resource quota scopes
 
@@ -287,7 +287,7 @@ Scopes are the resource quota scopes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -302,7 +302,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-resourceQuota-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-resourceQuota-labels}
 
 Labels are extra labels for this resource.
 
@@ -320,7 +320,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange}
+### `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-limitRange}
 
 LimitRange specifies limit range options.
 
@@ -332,7 +332,7 @@ LimitRange specifies limit range options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#policies-limitRange-enabled}
 
 Enabled defines if the limit range should be deployed by vCluster. "auto" means that if resourceQuota is enabled,
 the limitRange will be enabled as well.
@@ -348,7 +348,7 @@ the limitRange will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-default}
+#### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> {#policies-limitRange-default}
 
 Default are the default limits for the limit range
 
@@ -363,7 +363,7 @@ Default are the default limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-defaultRequest}
+#### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> {#policies-limitRange-defaultRequest}
 
 DefaultRequest are the default request options for the limit range
 
@@ -378,7 +378,7 @@ DefaultRequest are the default request options for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-max}
+#### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-max}
 
 Max are the max limits for the limit range
 
@@ -393,7 +393,7 @@ Max are the max limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-min}
+#### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-min}
 
 Min are the min limits for the limit range
 
@@ -408,7 +408,7 @@ Min are the min limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-annotations}
+#### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -423,7 +423,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-limitRange-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#policies-limitRange-labels}
 
 Labels are extra labels for this resource.
 
@@ -441,7 +441,7 @@ Labels are extra labels for this resource.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission}
+### `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission}
 
 CentralAdmission defines what validating or mutating webhooks should be enforced within the virtual cluster.
 
@@ -453,7 +453,7 @@ CentralAdmission defines what validating or mutating webhooks should be enforced
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks}
+#### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks}
 
 ValidatingWebhooks are validating webhooks that should be enforced in the virtual cluster
 
@@ -465,7 +465,7 @@ ValidatingWebhooks are validating webhooks that should be enforced in the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -481,7 +481,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -498,7 +498,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -510,7 +510,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -528,7 +528,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -545,7 +545,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -564,7 +564,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks}
+##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -576,7 +576,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -594,7 +594,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -606,7 +606,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -623,7 +623,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -638,7 +638,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -653,7 +653,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -668,7 +668,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -684,7 +684,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -704,7 +704,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -723,7 +723,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -739,7 +739,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -755,7 +755,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -771,7 +771,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -790,7 +790,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -808,7 +808,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -823,7 +823,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -838,7 +838,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -854,7 +854,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-validatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,
@@ -878,7 +878,7 @@ There are a maximum of 64 match conditions allowed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks}
+#### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks}
 
 MutatingWebhooks are mutating webhooks that should be enforced in the virtual cluster
 
@@ -890,7 +890,7 @@ MutatingWebhooks are mutating webhooks that should be enforced in the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -906,7 +906,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -923,7 +923,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-metadata}
+##### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -935,7 +935,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -953,7 +953,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -970,7 +970,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -989,7 +989,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks}
+##### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -1001,7 +1001,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
+##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
 
 reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation.
 Allowed values are "Never" and "IfNeeded".
@@ -1017,7 +1017,7 @@ Allowed values are "Never" and "IfNeeded".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -1035,7 +1035,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -1047,7 +1047,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -1064,7 +1064,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -1079,7 +1079,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -1094,7 +1094,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -1109,7 +1109,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -1125,7 +1125,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -1145,7 +1145,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -1164,7 +1164,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -1180,7 +1180,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -1196,7 +1196,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -1212,7 +1212,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -1231,7 +1231,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -1249,7 +1249,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -1264,7 +1264,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -1279,7 +1279,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -1295,7 +1295,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#policies-centralAdmission-mutatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/policies/centralAdmission.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/policies/centralAdmission.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission}
+## `centralAdmission` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission}
 
 CentralAdmission defines what validating or mutating webhooks should be enforced within the virtual cluster.
 
@@ -14,7 +14,7 @@ CentralAdmission defines what validating or mutating webhooks should be enforced
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks}
+### `validatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks}
 
 ValidatingWebhooks are validating webhooks that should be enforced in the virtual cluster
 
@@ -26,7 +26,7 @@ ValidatingWebhooks are validating webhooks that should be enforced in the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -42,7 +42,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -59,7 +59,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -71,7 +71,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -89,7 +89,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -106,7 +106,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -125,7 +125,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks}
+#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -137,7 +137,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -155,7 +155,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -167,7 +167,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -184,7 +184,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -199,7 +199,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -214,7 +214,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -229,7 +229,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -245,7 +245,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -265,7 +265,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -284,7 +284,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -300,7 +300,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -316,7 +316,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -332,7 +332,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -351,7 +351,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -369,7 +369,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -384,7 +384,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -399,7 +399,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -415,7 +415,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-validatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-validatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,
@@ -439,7 +439,7 @@ There are a maximum of 64 match conditions allowed.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks}
+### `mutatingWebhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks}
 
 MutatingWebhooks are mutating webhooks that should be enforced in the virtual cluster
 
@@ -451,7 +451,7 @@ MutatingWebhooks are mutating webhooks that should be enforced in the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-kind}
+#### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-kind}
 
 Kind is a string value representing the REST resource this object represents.
 Servers may infer this from the endpoint the client submits requests to.
@@ -467,7 +467,7 @@ Servers may infer this from the endpoint the client submits requests to.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-apiVersion}
+#### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-apiVersion}
 
 APIVersion defines the versioned schema of this representation of an object.
 Servers should convert recognized schemas to the latest internal value, and
@@ -484,7 +484,7 @@ may reject unrecognized values.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-metadata}
+#### `metadata` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata}
 
 Standard object metadata; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata.
 
@@ -496,7 +496,7 @@ Standard object metadata; More info: https://git.k8s.io/community/contributors/d
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-metadata-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-name}
 
 Name must be unique within a namespace. Is required when creating resources, although
 some resources may allow a client to request the generation of an appropriate name
@@ -514,7 +514,7 @@ definition.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-metadata-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-labels}
 
 Map of string keys and values that can be used to organize and categorize
 (scope and select) objects. May match selectors of replication controllers
@@ -531,7 +531,7 @@ and services.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-metadata-annotations}
+##### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-metadata-annotations}
 
 Annotations is an unstructured key value map stored with a resource that may be
 set by external tools to store and retrieve arbitrary metadata.
@@ -550,7 +550,7 @@ set by external tools to store and retrieve arbitrary metadata.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks}
+#### `webhooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks}
 
 Webhooks is a list of webhooks and the affected resources and operations.
 
@@ -562,7 +562,7 @@ Webhooks is a list of webhooks and the affected resources and operations.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
+##### `reinvocationPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-reinvocationPolicy}
 
 reinvocationPolicy indicates whether this webhook should be called multiple times as part of a single admission evaluation.
 Allowed values are "Never" and "IfNeeded".
@@ -578,7 +578,7 @@ Allowed values are "Never" and "IfNeeded".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-name}
 
 The name of the admission webhook.
 Name should be fully qualified, e.g., imagepolicy.kubernetes.io, where
@@ -596,7 +596,7 @@ of the organization.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig}
+##### `clientConfig` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig}
 
 ClientConfig defines how to communicate with the hook.
 
@@ -608,7 +608,7 @@ ClientConfig defines how to communicate with the hook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
+##### `url` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-url}
 
 URL gives the location of the webhook, in standard URL form
 (`scheme://host:port/path`). Exactly one of `url` or `service`
@@ -625,7 +625,7 @@ must be specified.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
+##### `service` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service}
 
 Service is a reference to the service for this webhook. Either
 `service` or `url` must be specified.
@@ -640,7 +640,7 @@ If the webhook is running within the cluster, then you should use `service`.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
+##### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-namespace}
 
 Namespace is the namespace of the service.
 
@@ -655,7 +655,7 @@ Namespace is the namespace of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-name}
 
 Name is the name of the service.
 
@@ -670,7 +670,7 @@ Name is the name of the service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-path}
 
 Path is an optional URL path which will be sent in any request to
 this service.
@@ -686,7 +686,7 @@ this service.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
+##### `port` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-service-port}
 
 If specified, the port on the service that hosting webhook.
 Default to 443 for backward compatibility.
@@ -706,7 +706,7 @@ Default to 443 for backward compatibility.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
+##### `caBundle` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-clientConfig-caBundle}
 
 CABundle is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
 If unspecified, system trust roots on the apiserver are used.
@@ -725,7 +725,7 @@ If unspecified, system trust roots on the apiserver are used.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-rules}
+##### `rules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-rules}
 
 Rules describes what operations on what resources/subresources the webhook cares about.
 The webhook cares about an operation if it matches _any_ Rule.
@@ -741,7 +741,7 @@ The webhook cares about an operation if it matches _any_ Rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
+##### `failurePolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-failurePolicy}
 
 FailurePolicy defines how unrecognized errors from the admission endpoint are handled -
 allowed values are Ignore or Fail. Defaults to Fail.
@@ -757,7 +757,7 @@ allowed values are Ignore or Fail. Defaults to Fail.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
+##### `matchPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-matchPolicy}
 
 matchPolicy defines how the "rules" list is used to match incoming requests.
 Allowed values are "Exact" or "Equivalent".
@@ -773,7 +773,7 @@ Allowed values are "Exact" or "Equivalent".
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
+##### `namespaceSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-namespaceSelector}
 
 NamespaceSelector decides whether to run the webhook on an object based
 on whether the namespace for that object matches the selector. If the
@@ -792,7 +792,7 @@ it never skips the webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-objectSelector}
+##### `objectSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-objectSelector}
 
 ObjectSelector decides whether to run the webhook based on if the
 object has matching labels. objectSelector is evaluated against both
@@ -810,7 +810,7 @@ is considered to match if either object matches the selector.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-sideEffects}
+##### `sideEffects` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-sideEffects}
 
 SideEffects states whether this webhook has side effects.
 
@@ -825,7 +825,7 @@ SideEffects states whether this webhook has side effects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
+##### `timeoutSeconds` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-timeoutSeconds}
 
 TimeoutSeconds specifies the timeout for this webhook.
 
@@ -840,7 +840,7 @@ TimeoutSeconds specifies the timeout for this webhook.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
+##### `admissionReviewVersions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-admissionReviewVersions}
 
 AdmissionReviewVersions is an ordered list of preferred `AdmissionReview`
 versions the Webhook expects.
@@ -856,7 +856,7 @@ versions the Webhook expects.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#centralAdmission-mutatingWebhooks-webhooks-matchConditions}
+##### `matchConditions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#centralAdmission-mutatingWebhooks-webhooks-matchConditions}
 
 MatchConditions is a list of conditions that must be met for a request to be sent to this
 webhook. Match conditions filter requests that have already been matched by the rules,

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/policies/limitRange.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/policies/limitRange.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange}
+## `limitRange` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#limitRange}
 
 LimitRange specifies limit range options.
 
@@ -14,7 +14,7 @@ LimitRange specifies limit range options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#limitRange-enabled}
 
 Enabled defines if the limit range should be deployed by vCluster. "auto" means that if resourceQuota is enabled,
 the limitRange will be enabled as well.
@@ -30,7 +30,7 @@ the limitRange will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-default}
+### `default` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:1 ephemeral-storage:8Gi memory:512Mi&#93;</span> <span className="config-field-enum"></span> {#limitRange-default}
 
 Default are the default limits for the limit range
 
@@ -45,7 +45,7 @@ Default are the default limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-defaultRequest}
+### `defaultRequest` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:100m ephemeral-storage:3Gi memory:128Mi&#93;</span> <span className="config-field-enum"></span> {#limitRange-defaultRequest}
 
 DefaultRequest are the default request options for the limit range
 
@@ -60,7 +60,7 @@ DefaultRequest are the default request options for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-max}
+### `max` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-max}
 
 Max are the max limits for the limit range
 
@@ -75,7 +75,7 @@ Max are the max limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-min}
+### `min` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-min}
 
 Min are the min limits for the limit range
 
@@ -90,7 +90,7 @@ Min are the min limits for the limit range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -105,7 +105,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#limitRange-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#limitRange-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/policies/networkPolicy.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/policies/networkPolicy.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy}
+## `networkPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy}
 
 NetworkPolicy specifies network policy options.
 
@@ -14,7 +14,7 @@ NetworkPolicy specifies network policy options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networkPolicy-enabled}
 
 Enabled defines if the network policy should be deployed by vCluster.
 
@@ -29,7 +29,7 @@ Enabled defines if the network policy should be deployed by vCluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-fallbackDns}
+### `fallbackDns` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">8.8.8.8</span> <span className="config-field-enum"></span> {#networkPolicy-fallbackDns}
 
 FallbackDNS is the fallback DNS server to use if the virtual cluster does not have a DNS server.
 
@@ -44,7 +44,7 @@ FallbackDNS is the fallback DNS server to use if the virtual cluster does not ha
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `outgoingConnections` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections}
+### `outgoingConnections` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections}
 
 OutgoingConnections are the outgoing connections options for the vCluster workloads.
 
@@ -56,7 +56,7 @@ OutgoingConnections are the outgoing connections options for the vCluster worklo
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections-ipBlock}
+#### `ipBlock` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections-ipBlock}
 
 IPBlock describes a particular CIDR (Ex. "192.168.1.0/24","2001:db8::/64") that is allowed
 to the pods matched by a NetworkPolicySpec's podSelector. The except entry describes CIDRs
@@ -70,7 +70,7 @@ that should not be included within this rule.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections-ipBlock-cidr}
+##### `cidr` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">0.0.0.0/0</span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections-ipBlock-cidr}
 
 cidr is a string representing the IPBlock
 Valid examples are "192.168.1.0/24" or "2001:db8::/64"
@@ -86,7 +86,7 @@ Valid examples are "192.168.1.0/24" or "2001:db8::/64"
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections-ipBlock-except}
+##### `except` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;100.64.0.0/10 127.0.0.0/8 10.0.0.0/8 172.16.0.0/12 192.168.0.0/16&#93;</span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections-ipBlock-except}
 
 except is a slice of CIDRs that should not be included within an IPBlock
 Valid examples are "192.168.1.0/24" or "2001:db8::/64"
@@ -106,7 +106,7 @@ Except values will be rejected if they are outside the cidr range
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-outgoingConnections-platform}
+#### `platform` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#networkPolicy-outgoingConnections-platform}
 
 Platform enables egress access towards loft platform
 
@@ -124,7 +124,7 @@ Platform enables egress access towards loft platform
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraControlPlaneRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-extraControlPlaneRules}
+### `extraControlPlaneRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#networkPolicy-extraControlPlaneRules}
 
 ExtraControlPlaneRules are extra allowed rules for the vCluster control plane.
 
@@ -139,7 +139,7 @@ ExtraControlPlaneRules are extra allowed rules for the vCluster control plane.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `extraWorkloadRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-extraWorkloadRules}
+### `extraWorkloadRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#networkPolicy-extraWorkloadRules}
 
 ExtraWorkloadRules are extra allowed rules for the vCluster workloads.
 
@@ -154,7 +154,7 @@ ExtraWorkloadRules are extra allowed rules for the vCluster workloads.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#networkPolicy-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -169,7 +169,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicy-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#networkPolicy-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/policies/podSecurityStandard.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/policies/podSecurityStandard.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podSecurityStandard}
+## `podSecurityStandard` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podSecurityStandard}
 
 PodSecurityStandard that can be enforced can be one of: empty (""), baseline, restricted or privileged
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/policies/resourceQuota.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/policies/resourceQuota.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota}
+## `resourceQuota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#resourceQuota}
 
 ResourceQuota specifies resource quota options.
 
@@ -14,7 +14,7 @@ ResourceQuota specifies resource quota options.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#resourceQuota-enabled}
 
 Enabled defines if the resource quota should be enabled. "auto" means that if limitRange is enabled,
 the resourceQuota will be enabled as well.
@@ -30,7 +30,7 @@ the resourceQuota will be enabled as well.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-quota}
+### `quota` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;count/configmaps:100 count/endpoints:40 count/persistentvolumeclaims:20 count/pods:20 count/secrets:100 count/services:20 limits.cpu:20 limits.ephemeral-storage:160Gi limits.memory:40Gi requests.cpu:10 requests.ephemeral-storage:60Gi requests.memory:20Gi requests.storage:100Gi services.loadbalancers:1 services.nodeports:0&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-quota}
 
 Quota are the quota options
 
@@ -45,7 +45,7 @@ Quota are the quota options
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-scopeSelector}
+### `scopeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;matchExpressions:&#91;&#93;&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-scopeSelector}
 
 ScopeSelector is the resource quota scope selector
 
@@ -60,7 +60,7 @@ ScopeSelector is the resource quota scope selector
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-scopes}
+### `scopes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#resourceQuota-scopes}
 
 Scopes are the resource quota scopes
 
@@ -75,7 +75,7 @@ Scopes are the resource quota scopes
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-annotations}
+### `annotations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#resourceQuota-annotations}
 
 Annotations are extra annotations for this resource.
 
@@ -90,7 +90,7 @@ Annotations are extra annotations for this resource.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#resourceQuota-labels}
+### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#resourceQuota-labels}
 
 Labels are extra labels for this resource.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/privateNodes.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/privateNodes.mdx
@@ -1,0 +1,701 @@
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `privateNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes}
+
+PrivateNodes holds configuration for vCluster private nodes mode.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#privateNodes-enabled}
+
+Enabled defines if dedicated nodes should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `importNodeBinaries` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-importNodeBinaries}
+
+ImportNodeBinaries defines to use the loft-sh/kubernetes:VERSION-full image to also copy the node binaries to the control plane. This allows upgrades and
+joining new nodes into the cluster without having to download the binaries from the internet.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `kubelet` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-kubelet}
+
+Kubelet holds kubelet configuration that is used for all nodes.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `cgroupDriver` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-kubelet-cgroupDriver}
+
+CgroupDriver defines the cgroup driver to use for the kubelet.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `autoUpgrade` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade}
+
+AutoUpgrade holds configuration for auto upgrade.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-enabled}
+
+Enabled defines if auto upgrade should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-image}
+
+Image is the image for the auto upgrade pod started by vCluster. If empty defaults to the controlPlane.statefulSet.image.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-imagePullPolicy}
+
+ImagePullPolicy is the policy how to pull the image.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-nodeSelector}
+
+NodeSelector is the node selector for the auto upgrade. If empty will select all worker nodes.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `bundleRepository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-bundleRepository}
+
+BundleRepository is the repository to use for downloading the Kubernetes bundle. Defaults to https://github.com/loft-sh/kubernetes/releases/download
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `binariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-binariesPath}
+
+BinariesPath is the base path for the kubeadm binaries. Defaults to /usr/local/bin
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `cniBinariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-cniBinariesPath}
+
+CNIBinariesPath is the base path for the CNI binaries. Defaults to /opt/cni/bin
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `concurrency` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#privateNodes-autoUpgrade-concurrency}
+
+Concurrency is the number of nodes that can be upgraded at the same time.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `joinNode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode}
+
+JoinNode holds configuration specifically used during joining the node (see "kubeadm join").
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `preJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-preJoinCommands}
+
+PreJoinCommands are commands that will be executed before the join process starts.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `postJoinCommands` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-postJoinCommands}
+
+PostJoinCommands are commands that will be executed after the join process starts.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `containerd` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd}
+
+Containerd holds configuration for the containerd join process.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-enabled}
+
+Enabled defines if containerd should be installed and configured by vCluster.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `registry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry}
+
+Registry holds configuration for how containerd should be configured to use a registries.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `configPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-configPath}
+
+ConfigPath is the path to the containerd registry config.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `mirrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors}
+
+Mirrors holds configuration for the containerd registry mirrors. E.g. myregistry.io:5000 or docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-server}
+
+Server is the fallback server to use for the containerd registry mirror. E.g. https://registry-1.docker.io. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-caCert}
+
+CACert are paths to CA certificates to use for the containerd registry mirror.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-skipVerify}
+
+SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-capabilities}
+
+Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `hosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts}
+
+Hosts holds configuration for the containerd registry mirror hosts. See https://github.com/containerd/containerd/blob/main/docs/hosts.md for more details.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `server` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-server}
+
+Server is the server to use for the containerd registry mirror host. E.g. http://192.168.31.250:5000.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `caCert` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-caCert}
+
+CACert are paths to CA certificates to use for the containerd registry mirror host.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `skipVerify` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-skipVerify}
+
+SkipVerify is a boolean to skip the certificate verification for the containerd registry mirror and allows http connections.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `capabilities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-registry-mirrors-hosts-capabilities}
+
+Capabilities is a list of capabilities to enable for the containerd registry mirror. If empty, will use pull and resolve capabilities.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `importImages` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-importImages}
+
+ImportImages is a list of images to import into the containerd registry from local files. If the path is a folder, all files that end with .tar or .tar.gz in the folder will be imported.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `pauseImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-containerd-pauseImage}
+
+PauseImage is the image for the pause container.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `caCertPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-caCertPath}
+
+CACertPath is the path to the SSL certificate authority used to
+secure communications between node and control-plane.
+Defaults to "/etc/kubernetes/pki/ca.crt".
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `skipPhases` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-skipPhases}
+
+SkipPhases is a list of phases to skip during command execution.
+The list of phases can be obtained with the "kubeadm join --help" command.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `nodeRegistration` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration}
+
+NodeRegistration holds configuration for the node registration similar to the kubeadm node registration.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `criSocket` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-criSocket}
+
+CRI socket is the socket for the CRI.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `kubeletExtraArgs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs}
+
+KubeletExtraArgs passes through extra arguments to the kubelet. The arguments here are passed to the kubelet command line via the environment file
+kubeadm writes at runtime for the kubelet to source. This overrides the generic base-level configuration in the kubelet-config ConfigMap
+Flags have higher priority when parsing. These values are local and specific to the node kubeadm is executing on.
+An argument name in this list is the flag name as it appears on the command line except without leading dash(es).
+Extra arguments will override existing default arguments. Duplicate extra arguments are allowed.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs-name}
+
+Name is the name of the argument.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-kubeletExtraArgs-value}
+
+Value is the value of the argument.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `taints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints}
+
+Taints are additional taints to set for the kubelet.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints-key}
+
+Required. The taint key to be applied to a node.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints-value}
+
+The taint value corresponding to the taint key.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `effect` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-taints-effect}
+
+Required. The effect of the taint on pods
+that do not tolerate the taint.
+Valid effects are NoSchedule, PreferNoSchedule and NoExecute.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `ignorePreflightErrors` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-ignorePreflightErrors}
+
+IgnorePreflightErrors provides a slice of pre-flight errors to be ignored when the current node is registered, e.g. 'IsPrivilegedUser,Swap'.
+Value 'all' ignores errors from all checks.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#privateNodes-joinNode-nodeRegistration-imagePullPolicy}
+
+ImagePullPolicy specifies the policy for image pulling during kubeadm "init" and "join" operations.
+The value of this field must be one of "Always", "IfNotPresent" or "Never".
+If this field is unset kubeadm will default it to "IfNotPresent", or pull the required images if not present on the host.
+
+</summary>
+
+
+
+</details>
+
+
+</details>
+
+
+</details>
+
+
+</details>

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/privateNodes/autoUpgrade.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/privateNodes/autoUpgrade.mdx
@@ -1,0 +1,133 @@
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `autoUpgrade` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade}
+
+AutoUpgrade holds configuration for auto upgrade.
+
+</summary>
+
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#autoUpgrade-enabled}
+
+Enabled defines if auto upgrade should be enabled.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-image}
+
+Image is the image for the auto upgrade pod started by vCluster. If empty defaults to the controlPlane.statefulSet.image.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `imagePullPolicy` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-imagePullPolicy}
+
+ImagePullPolicy is the policy how to pull the image.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `nodeSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-nodeSelector}
+
+NodeSelector is the node selector for the auto upgrade. If empty will select all worker nodes.
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `bundleRepository` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-bundleRepository}
+
+BundleRepository is the repository to use for downloading the Kubernetes bundle. Defaults to https://github.com/loft-sh/kubernetes/releases/download
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `binariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-binariesPath}
+
+BinariesPath is the base path for the kubeadm binaries. Defaults to /usr/local/bin
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `cniBinariesPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#autoUpgrade-cniBinariesPath}
+
+CNIBinariesPath is the base path for the CNI binaries. Defaults to /opt/cni/bin
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `concurrency` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">1</span> <span className="config-field-enum"></span> {#autoUpgrade-concurrency}
+
+Concurrency is the number of nodes that can be upgraded at the same time.
+
+</summary>
+
+
+
+</details>
+
+
+</details>

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/rbac.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/rbac.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac}
+## `rbac` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac}
 
 RBAC options for the virtual cluster.
 
@@ -14,7 +14,7 @@ RBAC options for the virtual cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-role}
+### `role` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-role}
 
 Role holds virtual cluster role configuration
 
@@ -26,7 +26,7 @@ Role holds virtual cluster role configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-role-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#rbac-role-enabled}
 
 Enabled defines if the role should be enabled or disabled.
 
@@ -41,7 +41,7 @@ Enabled defines if the role should be enabled or disabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-role-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-role-extraRules}
 
 ExtraRules will add rules to the role.
 
@@ -56,7 +56,7 @@ ExtraRules will add rules to the role.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-role-overwriteRules}
+#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-role-overwriteRules}
 
 OverwriteRules will overwrite the role rules completely.
 
@@ -74,7 +74,7 @@ OverwriteRules will overwrite the role rules completely.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-clusterRole}
+### `clusterRole` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#rbac-clusterRole}
 
 ClusterRole holds virtual cluster cluster role configuration
 
@@ -86,7 +86,7 @@ ClusterRole holds virtual cluster cluster role configuration
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-clusterRole-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#rbac-clusterRole-enabled}
 
 Enabled defines if the cluster role should be enabled or disabled. If auto, vCluster automatically determines whether the virtual cluster requires a cluster role.
 
@@ -101,7 +101,7 @@ Enabled defines if the cluster role should be enabled or disabled. If auto, vClu
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-clusterRole-extraRules}
+#### `extraRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-clusterRole-extraRules}
 
 ExtraRules will add rules to the cluster role.
 
@@ -116,7 +116,7 @@ ExtraRules will add rules to the cluster role.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#rbac-clusterRole-overwriteRules}
+#### `overwriteRules` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#rbac-clusterRole-overwriteRules}
 
 OverwriteRules will overwrite the cluster role rules completely.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sleepMode.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sleepMode.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `sleepMode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode}
+## `sleepMode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode}
 
 SleepMode holds the native sleep mode configuration for Pro clusters
 
@@ -14,7 +14,7 @@ SleepMode holds the native sleep mode configuration for Pro clusters
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-enabled}
 
 Enabled toggles the sleep mode functionality, allowing for disabling sleep mode without removing other config
 
@@ -29,7 +29,7 @@ Enabled toggles the sleep mode functionality, allowing for disabling sleep mode 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `timeZone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-timeZone}
+### `timeZone` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-timeZone}
 
 Timezone represents the timezone a sleep schedule should run against, defaulting to UTC if unset
 
@@ -44,7 +44,7 @@ Timezone represents the timezone a sleep schedule should run against, defaulting
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep}
+### `autoSleep` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep}
 
 AutoSleep holds autoSleep details
 
@@ -56,7 +56,7 @@ AutoSleep holds autoSleep details
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-afterInactivity}
+#### `afterInactivity` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-afterInactivity}
 
 AfterInactivity represents how long a vCluster can be idle before workloads are automaticaly put to sleep
 
@@ -71,7 +71,7 @@ AfterInactivity represents how long a vCluster can be idle before workloads are 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-schedule}
+#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-schedule}
 
 Schedule represents a cron schedule for when to sleep workloads
 
@@ -86,7 +86,7 @@ Schedule represents a cron schedule for when to sleep workloads
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `exclude` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-exclude}
+#### `exclude` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-exclude}
 
 Exclude holds configuration for labels that, if present, will prevent a workload from going to sleep
 
@@ -98,7 +98,7 @@ Exclude holds configuration for labels that, if present, will prevent a workload
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-exclude-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-exclude-selector}
 
 
 
@@ -110,7 +110,7 @@ Exclude holds configuration for labels that, if present, will prevent a workload
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoSleep-exclude-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoSleep-exclude-selector-labels}
 
 Labels defines what labels should be looked for
 
@@ -134,7 +134,7 @@ Labels defines what labels should be looked for
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoWakeup}
+### `autoWakeup` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoWakeup}
 
 AutoWakeup holds configuration for waking the vCluster on a schedule rather than waiting for some activity.
 
@@ -146,7 +146,7 @@ AutoWakeup holds configuration for waking the vCluster on a schedule rather than
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sleepMode-autoWakeup-schedule}
+#### `schedule` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sleepMode-autoWakeup-schedule}
 
 
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync}
+## `sync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync}
 
 Sync describes how to sync resources from the virtual cluster to host cluster and back.
 
@@ -14,7 +14,7 @@ Sync describes how to sync resources from the virtual cluster to host cluster an
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost}
+### `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost}
 
 Configure resources to sync from the virtual cluster to the host cluster.
 
@@ -26,7 +26,7 @@ Configure resources to sync from the virtual cluster to the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods}
+#### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods}
 
 Pods defines if pods created within the virtual cluster should get synced to the host cluster.
 
@@ -38,7 +38,7 @@ Pods defines if pods created within the virtual cluster should get synced to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-pods-enabled}
 
 Enabled defines if pod syncing should be enabled.
 
@@ -53,7 +53,7 @@ Enabled defines if pod syncing should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-translateImage}
+##### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-translateImage}
 
 TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite
 a certain image that is used within the virtual cluster to be another image on the host cluster
@@ -69,7 +69,7 @@ a certain image that is used within the virtual cluster to be another image on t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-enforceTolerations}
+##### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-enforceTolerations}
 
 EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster.
 
@@ -84,7 +84,7 @@ EnforceTolerations will add the specified tolerations to all pods synced by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-useSecretsForSATokens}
+##### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-pods-useSecretsForSATokens}
 
 UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a
 pod annotation.
@@ -100,7 +100,7 @@ pod annotation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-runtimeClassName}
+##### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for synced pods.
 
@@ -115,7 +115,7 @@ RuntimeClassName is the runtime class to set for synced pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-priorityClassName}
+##### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-priorityClassName}
 
 PriorityClassName is the priority class to set for synced pods.
 
@@ -130,7 +130,7 @@ PriorityClassName is the priority class to set for synced pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts}
+##### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts}
 
 RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
 a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
@@ -144,7 +144,7 @@ the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-enabled}
 
 Enabled specifies if rewriting stateful set pods should be enabled.
 
@@ -159,7 +159,7 @@ Enabled specifies if rewriting stateful set pods should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer}
+##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer}
 
 InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
 
@@ -171,7 +171,7 @@ InitContainer holds extra options for the init container used by vCluster to rew
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine:3.20</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine:3.20</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-image}
 
 Image is the image virtual cluster should use to rewrite this FQDN.
 
@@ -186,7 +186,7 @@ Image is the image virtual cluster should use to rewrite this FQDN.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources}
 
 Resources are the resources that should be assigned to the init container for each stateful set init container.
 
@@ -198,7 +198,7 @@ Resources are the resources that should be assigned to the init container for ea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-limits}
 
 Limits are resource limits for the container
 
@@ -213,7 +213,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-rewriteHosts-initContainer-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -237,7 +237,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -249,7 +249,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -264,7 +264,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -279,7 +279,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -294,7 +294,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -308,7 +308,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -323,7 +323,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -338,7 +338,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -353,7 +353,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -368,7 +368,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -383,7 +383,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -402,7 +402,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -420,7 +420,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `hybridScheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-hybridScheduling}
+##### `hybridScheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-pods-hybridScheduling}
 
 HybridScheduling is used to enable and configure hybrid scheduling for pods in the virtual cluster.
 
@@ -432,7 +432,7 @@ HybridScheduling is used to enable and configure hybrid scheduling for pods in t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-hybridScheduling-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-pods-hybridScheduling-enabled}
 
 Enabled specifies if hybrid scheduling is enabled.
 
@@ -447,7 +447,7 @@ Enabled specifies if hybrid scheduling is enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostSchedulers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-pods-hybridScheduling-hostSchedulers}
+##### `hostSchedulers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#sync-toHost-pods-hybridScheduling-hostSchedulers}
 
 HostSchedulers is a list of schedulers that are deployed on the host cluster.
 
@@ -468,7 +468,7 @@ HostSchedulers is a list of schedulers that are deployed on the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets}
+#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets}
 
 Secrets defines if secrets created within the virtual cluster should get synced to the host cluster.
 
@@ -480,7 +480,7 @@ Secrets defines if secrets created within the virtual cluster should get synced 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -495,7 +495,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-all}
+##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-secrets-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -510,7 +510,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -522,7 +522,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -537,7 +537,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -552,7 +552,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -567,7 +567,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -581,7 +581,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -596,7 +596,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -611,7 +611,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -626,7 +626,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -641,7 +641,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -656,7 +656,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -675,7 +675,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -696,7 +696,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps}
+#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps}
 
 ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster.
 
@@ -708,7 +708,7 @@ ConfigMaps defines if config maps created within the virtual cluster should get 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -723,7 +723,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-all}
+##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -738,7 +738,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -750,7 +750,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -765,7 +765,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -780,7 +780,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -795,7 +795,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -809,7 +809,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -824,7 +824,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -839,7 +839,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -854,7 +854,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -869,7 +869,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -884,7 +884,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -903,7 +903,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -924,7 +924,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses}
+#### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses}
 
 Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster.
 
@@ -936,7 +936,7 @@ Ingresses defines if ingresses created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -951,7 +951,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -963,7 +963,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -978,7 +978,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -993,7 +993,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1008,7 +1008,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1022,7 +1022,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1037,7 +1037,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1052,7 +1052,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1067,7 +1067,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1082,7 +1082,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1097,7 +1097,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1116,7 +1116,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-ingresses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-ingresses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1137,7 +1137,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services}
+#### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services}
 
 Services defines if services created within the virtual cluster should get synced to the host cluster.
 
@@ -1149,7 +1149,7 @@ Services defines if services created within the virtual cluster should get synce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-services-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1164,7 +1164,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1176,7 +1176,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1191,7 +1191,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1206,7 +1206,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1221,7 +1221,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1235,7 +1235,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1250,7 +1250,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1265,7 +1265,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1280,7 +1280,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1295,7 +1295,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1310,7 +1310,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1329,7 +1329,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-services-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-services-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1350,7 +1350,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints}
+#### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints}
 
 Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
 
@@ -1362,7 +1362,7 @@ Endpoints defines if endpoints created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1377,7 +1377,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1389,7 +1389,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1404,7 +1404,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1419,7 +1419,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1434,7 +1434,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1448,7 +1448,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1463,7 +1463,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1478,7 +1478,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1493,7 +1493,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1508,7 +1508,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1523,7 +1523,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1542,7 +1542,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-endpoints-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-endpoints-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1563,7 +1563,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies}
+#### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies}
 
 NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster.
 
@@ -1575,7 +1575,7 @@ NetworkPolicies defines if network policies created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1590,7 +1590,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1602,7 +1602,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1617,7 +1617,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1632,7 +1632,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1647,7 +1647,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1661,7 +1661,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1676,7 +1676,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1691,7 +1691,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1706,7 +1706,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1721,7 +1721,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1736,7 +1736,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1755,7 +1755,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-networkPolicies-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-networkPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1776,7 +1776,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims}
+#### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims}
 
 PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster.
 
@@ -1788,7 +1788,7 @@ PersistentVolumeClaims defines if persistent volume claims created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1803,7 +1803,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1815,7 +1815,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1830,7 +1830,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1845,7 +1845,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1860,7 +1860,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1874,7 +1874,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1889,7 +1889,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1904,7 +1904,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1919,7 +1919,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1934,7 +1934,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1949,7 +1949,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1968,7 +1968,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumeClaims-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumeClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1989,7 +1989,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes}
+#### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes}
 
 PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster.
 
@@ -2001,7 +2001,7 @@ PersistentVolumes defines if persistent volumes created within the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2016,7 +2016,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2028,7 +2028,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2043,7 +2043,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2058,7 +2058,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2073,7 +2073,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2087,7 +2087,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2102,7 +2102,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2117,7 +2117,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2132,7 +2132,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2147,7 +2147,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2162,7 +2162,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2181,7 +2181,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-persistentVolumes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-persistentVolumes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2202,7 +2202,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots}
+#### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots}
 
 VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
 
@@ -2214,7 +2214,7 @@ VolumeSnapshots defines if volume snapshots created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2229,7 +2229,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2241,7 +2241,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2256,7 +2256,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2271,7 +2271,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2286,7 +2286,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2300,7 +2300,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2315,7 +2315,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2330,7 +2330,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2345,7 +2345,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2360,7 +2360,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2375,7 +2375,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2394,7 +2394,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshots-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshots-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2415,7 +2415,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents}
+#### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents}
 
 VolumeSnapshotContents defines if volume snapshot contents created within the virtual cluster should get synced to the host cluster.
 
@@ -2427,7 +2427,7 @@ VolumeSnapshotContents defines if volume snapshot contents created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2442,7 +2442,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2454,7 +2454,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2469,7 +2469,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2484,7 +2484,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2499,7 +2499,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2513,7 +2513,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2528,7 +2528,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2543,7 +2543,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2558,7 +2558,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2573,7 +2573,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2588,7 +2588,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2607,7 +2607,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-volumeSnapshotContents-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-volumeSnapshotContents-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2628,7 +2628,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses}
+#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses}
 
 StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
 
@@ -2640,7 +2640,7 @@ StorageClasses defines if storage classes created within the virtual cluster sho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2655,7 +2655,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2667,7 +2667,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2682,7 +2682,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2697,7 +2697,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2712,7 +2712,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2726,7 +2726,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2741,7 +2741,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2756,7 +2756,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2771,7 +2771,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2786,7 +2786,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2801,7 +2801,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2820,7 +2820,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2841,7 +2841,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts}
+#### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts}
 
 ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster.
 
@@ -2853,7 +2853,7 @@ ServiceAccounts defines if service accounts created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2868,7 +2868,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2880,7 +2880,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2895,7 +2895,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2910,7 +2910,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2925,7 +2925,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2939,7 +2939,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2954,7 +2954,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2969,7 +2969,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2984,7 +2984,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2999,7 +2999,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3014,7 +3014,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3033,7 +3033,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-serviceAccounts-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-serviceAccounts-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3054,7 +3054,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets}
+#### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets}
 
 PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster.
 
@@ -3066,7 +3066,7 @@ PodDisruptionBudgets defines if pod disruption budgets created within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3081,7 +3081,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3093,7 +3093,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3108,7 +3108,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3123,7 +3123,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3138,7 +3138,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3152,7 +3152,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3167,7 +3167,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3182,7 +3182,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3197,7 +3197,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3212,7 +3212,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3227,7 +3227,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3246,7 +3246,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-podDisruptionBudgets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-podDisruptionBudgets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3267,7 +3267,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses}
+#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses}
 
 PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster.
 
@@ -3279,7 +3279,7 @@ PriorityClasses defines if priority classes created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3294,7 +3294,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3306,7 +3306,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3321,7 +3321,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3336,7 +3336,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3351,7 +3351,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3365,7 +3365,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3380,7 +3380,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3395,7 +3395,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3410,7 +3410,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3425,7 +3425,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3440,7 +3440,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3459,7 +3459,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3480,7 +3480,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources}
+#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources}
 
 CustomResources defines what custom resources should get synced from the virtual cluster to the host cluster. vCluster will copy the definition automatically from host cluster to virtual cluster on startup.
 vCluster will also automatically add any required RBAC permissions to the vCluster role for this to work.
@@ -3493,7 +3493,7 @@ vCluster will also automatically add any required RBAC permissions to the vClust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3508,7 +3508,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-scope}
+##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-scope}
 
 Scope defines the scope of the resource. If undefined, will use Namespaced. Currently only Namespaced is supported.
 
@@ -3523,7 +3523,7 @@ Scope defines the scope of the resource. If undefined, will use Namespaced. Curr
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3535,7 +3535,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3550,7 +3550,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3565,7 +3565,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3580,7 +3580,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3594,7 +3594,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3609,7 +3609,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3624,7 +3624,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3639,7 +3639,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3654,7 +3654,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3669,7 +3669,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3688,7 +3688,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3709,7 +3709,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces}
+#### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces}
 
 Namespaces defines if namespaces created within the virtual cluster should get synced to the host cluster.
 
@@ -3721,7 +3721,7 @@ Namespaces defines if namespaces created within the virtual cluster should get s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3736,7 +3736,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3748,7 +3748,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3763,7 +3763,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3778,7 +3778,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3793,7 +3793,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3807,7 +3807,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3822,7 +3822,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3837,7 +3837,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3852,7 +3852,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3867,7 +3867,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3882,7 +3882,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3901,7 +3901,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3919,7 +3919,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-mappings}
+##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-mappings}
 
 Mappings for Namespace and Object
 
@@ -3931,7 +3931,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -3965,7 +3965,7 @@ byName:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `mappingsOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-mappingsOnly}
+##### `mappingsOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-mappingsOnly}
 
 MappingsOnly defines if creation of namespaces not matched by mappings should be allowed.
 
@@ -3980,7 +3980,7 @@ MappingsOnly defines if creation of namespaces not matched by mappings should be
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `extraLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-toHost-namespaces-extraLabels}
+##### `extraLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-toHost-namespaces-extraLabels}
 
 ExtraLabels are additional labels to add to the namespace in the host cluster.
 
@@ -4001,7 +4001,7 @@ ExtraLabels are additional labels to add to the namespace in the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost}
+### `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost}
 
 Configure what resources vCluster should sync from the host cluster to the virtual cluster.
 
@@ -4013,7 +4013,7 @@ Configure what resources vCluster should sync from the host cluster to the virtu
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes}
+#### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes}
 
 Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -4025,7 +4025,7 @@ Nodes defines if nodes should get synced from the host cluster to the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-enabled}
 
 Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead.
 
@@ -4040,7 +4040,7 @@ Enabled specifies if syncing real nodes should be enabled. If this is disabled, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-syncBackChanges}
+##### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-syncBackChanges}
 
 SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node.
 
@@ -4055,7 +4055,7 @@ SyncBackChanges enables syncing labels and taints from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-clearImageStatus}
+##### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-clearImageStatus}
 
 ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node.
 
@@ -4070,7 +4070,7 @@ ClearImageStatus will erase the image status when syncing a node. This allows to
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector}
 
 Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster.
 
@@ -4082,7 +4082,7 @@ Selector can be used to define more granular what nodes should get synced from t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-selector-all}
+##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector-all}
 
 All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to.
 
@@ -4097,7 +4097,7 @@ All specifies if all nodes should get synced by vCluster from the host to the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-selector-labels}
 
 Labels are the node labels used to sync nodes from host cluster to virtual cluster. This will also set the node selector when syncing a pod from virtual cluster to host cluster to the same value.
 
@@ -4115,7 +4115,7 @@ Labels are the node labels used to sync nodes from host cluster to virtual clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4127,7 +4127,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4142,7 +4142,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4157,7 +4157,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4172,7 +4172,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4186,7 +4186,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4201,7 +4201,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4216,7 +4216,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4231,7 +4231,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4246,7 +4246,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4261,7 +4261,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4280,7 +4280,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-nodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-nodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4301,7 +4301,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events}
+#### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events}
 
 Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -4313,7 +4313,7 @@ Events defines if events should get synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#sync-fromHost-events-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4328,7 +4328,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4340,7 +4340,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4355,7 +4355,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4370,7 +4370,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4385,7 +4385,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4399,7 +4399,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4414,7 +4414,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4429,7 +4429,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4444,7 +4444,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4459,7 +4459,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4474,7 +4474,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4493,7 +4493,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-events-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-events-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4514,7 +4514,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses}
+#### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses}
 
 IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -4526,7 +4526,7 @@ IngressClasses defines if ingress classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4541,7 +4541,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4553,7 +4553,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4568,7 +4568,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4583,7 +4583,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4598,7 +4598,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4612,7 +4612,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4627,7 +4627,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4642,7 +4642,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4657,7 +4657,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4672,7 +4672,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4687,7 +4687,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -4706,7 +4706,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -4724,7 +4724,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -4736,7 +4736,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchLabels}
 
 
 
@@ -4751,7 +4751,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions}
 
 
 
@@ -4763,22 +4763,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions-key}
 
 
 
@@ -4793,7 +4778,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-ingressClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-ingressClasses-selector-matchExpressions-values}
 
 
 
@@ -4817,7 +4817,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses}
+#### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses}
 
 RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -4829,7 +4829,7 @@ RuntimeClasses defines if runtime classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -4844,7 +4844,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -4856,7 +4856,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -4871,7 +4871,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -4886,7 +4886,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -4901,7 +4901,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -4915,7 +4915,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -4930,7 +4930,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -4945,7 +4945,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -4960,7 +4960,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -4975,7 +4975,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -4990,7 +4990,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5009,7 +5009,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5027,7 +5027,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -5039,7 +5039,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchLabels}
 
 
 
@@ -5054,7 +5054,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions}
 
 
 
@@ -5066,22 +5066,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-key}
 
 
 
@@ -5096,7 +5081,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-runtimeClasses-selector-matchExpressions-values}
 
 
 
@@ -5120,7 +5120,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses}
+#### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses}
 
 PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -5132,7 +5132,7 @@ PriorityClasses defines if priority classes classes should get synced from the h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5147,7 +5147,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5159,7 +5159,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5174,7 +5174,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5189,7 +5189,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5204,7 +5204,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5218,7 +5218,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5233,7 +5233,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5248,7 +5248,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5263,7 +5263,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5278,7 +5278,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5293,7 +5293,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5312,7 +5312,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5330,7 +5330,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -5342,7 +5342,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchLabels}
 
 
 
@@ -5357,7 +5357,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions}
 
 
 
@@ -5369,22 +5369,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions-key}
 
 
 
@@ -5399,7 +5384,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-priorityClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-priorityClasses-selector-matchExpressions-values}
 
 
 
@@ -5423,7 +5423,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses}
+#### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses}
 
 StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -5435,7 +5435,7 @@ StorageClasses defines if storage classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5450,7 +5450,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5462,7 +5462,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5477,7 +5477,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5492,7 +5492,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5507,7 +5507,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5521,7 +5521,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5536,7 +5536,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5551,7 +5551,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5566,7 +5566,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5581,7 +5581,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5596,7 +5596,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5615,7 +5615,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5633,7 +5633,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-selector}
+##### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -5645,7 +5645,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchLabels}
 
 
 
@@ -5660,7 +5660,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions}
 
 
 
@@ -5672,22 +5672,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions-key}
 
 
 
@@ -5702,7 +5687,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-storageClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-storageClasses-selector-matchExpressions-values}
 
 
 
@@ -5726,7 +5726,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes}
+#### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes}
 
 CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -5738,7 +5738,7 @@ CSINodes defines if csi nodes should get synced from the host cluster to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5753,7 +5753,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5765,7 +5765,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5780,7 +5780,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -5795,7 +5795,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -5810,7 +5810,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -5824,7 +5824,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -5839,7 +5839,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -5854,7 +5854,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -5869,7 +5869,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -5884,7 +5884,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -5899,7 +5899,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -5918,7 +5918,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiNodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiNodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -5939,7 +5939,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers}
+#### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers}
 
 CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -5951,7 +5951,7 @@ CSIDrivers defines if csi drivers should get synced from the host cluster to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -5966,7 +5966,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -5978,7 +5978,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -5993,7 +5993,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6008,7 +6008,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6023,7 +6023,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6037,7 +6037,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6052,7 +6052,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6067,7 +6067,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6082,7 +6082,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6097,7 +6097,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6112,7 +6112,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6131,7 +6131,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiDrivers-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiDrivers-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6152,7 +6152,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities}
+#### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities}
 
 CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -6164,7 +6164,7 @@ CSIStorageCapacities defines if csi storage capacities should get synced from th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -6179,7 +6179,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6191,7 +6191,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6206,7 +6206,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6221,7 +6221,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6236,7 +6236,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6250,7 +6250,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6265,7 +6265,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6280,7 +6280,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6295,7 +6295,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6310,7 +6310,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6325,7 +6325,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6344,7 +6344,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-csiStorageCapacities-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-csiStorageCapacities-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6365,7 +6365,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources}
+#### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources}
 
 CustomResources defines what custom resources should get synced read-only to the virtual cluster from the host cluster. vCluster will automatically add any required RBAC to the vCluster cluster role.
 
@@ -6377,7 +6377,7 @@ CustomResources defines what custom resources should get synced read-only to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -6392,7 +6392,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-scope}
+##### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-scope}
 
 Scope defines the scope of the resource
 
@@ -6407,7 +6407,7 @@ Scope defines the scope of the resource
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6419,7 +6419,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6434,7 +6434,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6449,7 +6449,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6464,7 +6464,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6478,7 +6478,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6493,7 +6493,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6508,7 +6508,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6523,7 +6523,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6538,7 +6538,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6553,7 +6553,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6572,7 +6572,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6590,7 +6590,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-mappings}
+##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-mappings}
 
 Mappings for Namespace and Object
 
@@ -6602,7 +6602,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-customResources-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-customResources-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -6639,7 +6639,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses}
+#### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses}
 
 VolumeSnapshotClasses defines if volume snapshot classes created within the virtual cluster should get synced to the host cluster.
 
@@ -6651,7 +6651,7 @@ VolumeSnapshotClasses defines if volume snapshot classes created within the virt
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -6666,7 +6666,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6678,7 +6678,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6693,7 +6693,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6708,7 +6708,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6723,7 +6723,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6737,7 +6737,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6752,7 +6752,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6767,7 +6767,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6782,7 +6782,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -6797,7 +6797,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -6812,7 +6812,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -6831,7 +6831,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-volumeSnapshotClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-volumeSnapshotClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -6852,7 +6852,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps}
+#### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps}
 
 ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
 
@@ -6864,7 +6864,7 @@ ConfigMaps defines if config maps in the host should get synced to the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -6879,7 +6879,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -6891,7 +6891,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -6906,7 +6906,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -6921,7 +6921,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -6936,7 +6936,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -6950,7 +6950,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -6965,7 +6965,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -6980,7 +6980,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -6995,7 +6995,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -7010,7 +7010,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -7025,7 +7025,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -7044,7 +7044,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -7062,7 +7062,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-mappings}
+##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-mappings}
 
 Mappings for Namespace and Object
 
@@ -7074,7 +7074,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-configMaps-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-configMaps-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -7111,7 +7111,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets}
+#### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets}
 
 Secrets defines if secrets in the host should get synced to the virtual cluster.
 
@@ -7123,7 +7123,7 @@ Secrets defines if secrets in the host should get synced to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -7138,7 +7138,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches}
+##### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -7150,7 +7150,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -7165,7 +7165,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -7180,7 +7180,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -7195,7 +7195,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -7209,7 +7209,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -7224,7 +7224,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -7239,7 +7239,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -7254,7 +7254,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -7269,7 +7269,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -7284,7 +7284,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -7303,7 +7303,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -7321,7 +7321,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-mappings}
+##### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-mappings}
 
 Mappings for Namespace and Object
 
@@ -7333,7 +7333,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#sync-fromHost-secrets-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#sync-fromHost-secrets-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost}
+## `fromHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost}
 
 Configure what resources vCluster should sync from the host cluster to the virtual cluster.
 
@@ -14,7 +14,7 @@ Configure what resources vCluster should sync from the host cluster to the virtu
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes}
+### `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes}
 
 Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -26,7 +26,7 @@ Nodes defines if nodes should get synced from the host cluster to the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-enabled}
 
 Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead.
 
@@ -41,7 +41,7 @@ Enabled specifies if syncing real nodes should be enabled. If this is disabled, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-syncBackChanges}
+#### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-syncBackChanges}
 
 SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node.
 
@@ -56,7 +56,7 @@ SyncBackChanges enables syncing labels and taints from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-clearImageStatus}
+#### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-clearImageStatus}
 
 ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node.
 
@@ -71,7 +71,7 @@ ClearImageStatus will erase the image status when syncing a node. This allows to
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-selector}
+#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-selector}
 
 Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster.
 
@@ -83,7 +83,7 @@ Selector can be used to define more granular what nodes should get synced from t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-selector-all}
+##### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-nodes-selector-all}
 
 All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to.
 
@@ -98,7 +98,7 @@ All specifies if all nodes should get synced by vCluster from the host to the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-selector-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-nodes-selector-labels}
 
 Labels are the node labels used to sync nodes from host cluster to virtual cluster. This will also set the node selector when syncing a pod from virtual cluster to host cluster to the same value.
 
@@ -116,7 +116,7 @@ Labels are the node labels used to sync nodes from host cluster to virtual clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -128,7 +128,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -143,7 +143,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -158,7 +158,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -173,7 +173,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -187,7 +187,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -202,7 +202,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -217,7 +217,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -232,7 +232,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -247,7 +247,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -262,7 +262,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -281,7 +281,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-nodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-nodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -302,7 +302,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events}
+### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events}
 
 Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -314,7 +314,7 @@ Events defines if events should get synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#fromHost-events-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -329,7 +329,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -341,7 +341,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -356,7 +356,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -371,7 +371,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -386,7 +386,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -400,7 +400,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -415,7 +415,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -430,7 +430,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -445,7 +445,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -460,7 +460,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -475,7 +475,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -494,7 +494,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-events-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-events-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -515,7 +515,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses}
+### `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses}
 
 IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -527,7 +527,7 @@ IngressClasses defines if ingress classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -542,7 +542,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -554,7 +554,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -569,7 +569,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -584,7 +584,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -599,7 +599,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -613,7 +613,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -628,7 +628,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -643,7 +643,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -658,7 +658,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -673,7 +673,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -688,7 +688,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -707,7 +707,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -725,7 +725,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -737,7 +737,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchLabels}
 
 
 
@@ -752,7 +752,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions}
 
 
 
@@ -764,22 +764,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions-key}
 
 
 
@@ -794,7 +779,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-ingressClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-ingressClasses-selector-matchExpressions-values}
 
 
 
@@ -818,7 +818,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses}
+### `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses}
 
 RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -830,7 +830,7 @@ RuntimeClasses defines if runtime classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -845,7 +845,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -857,7 +857,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -872,7 +872,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -887,7 +887,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -902,7 +902,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -916,7 +916,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -931,7 +931,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -946,7 +946,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -961,7 +961,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -976,7 +976,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -991,7 +991,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1010,7 +1010,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1028,7 +1028,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -1040,7 +1040,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchLabels}
 
 
 
@@ -1055,7 +1055,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions}
 
 
 
@@ -1067,22 +1067,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions-key}
 
 
 
@@ -1097,7 +1082,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-runtimeClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-runtimeClasses-selector-matchExpressions-values}
 
 
 
@@ -1121,7 +1121,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses}
+### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses}
 
 PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -1133,7 +1133,7 @@ PriorityClasses defines if priority classes classes should get synced from the h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1148,7 +1148,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1160,7 +1160,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1175,7 +1175,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1190,7 +1190,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1205,7 +1205,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1219,7 +1219,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1234,7 +1234,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1249,7 +1249,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1264,7 +1264,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1279,7 +1279,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1294,7 +1294,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1313,7 +1313,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1331,7 +1331,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -1343,7 +1343,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchLabels}
 
 
 
@@ -1358,7 +1358,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions}
 
 
 
@@ -1370,22 +1370,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions-key}
 
 
 
@@ -1400,7 +1385,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-priorityClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-priorityClasses-selector-matchExpressions-values}
 
 
 
@@ -1424,7 +1424,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses}
+### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses}
 
 StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -1436,7 +1436,7 @@ StorageClasses defines if storage classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1451,7 +1451,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1463,7 +1463,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1478,7 +1478,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1493,7 +1493,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1508,7 +1508,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1522,7 +1522,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1537,7 +1537,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1552,7 +1552,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1567,7 +1567,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1582,7 +1582,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1597,7 +1597,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1616,7 +1616,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1634,7 +1634,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-selector}
+#### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -1646,7 +1646,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-selector-matchLabels}
+##### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchLabels}
 
 
 
@@ -1661,7 +1661,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-selector-matchExpressions}
+##### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions}
 
 
 
@@ -1673,22 +1673,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions-key}
 
 
 
@@ -1703,7 +1688,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-storageClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-storageClasses-selector-matchExpressions-values}
 
 
 
@@ -1727,7 +1727,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes}
+### `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes}
 
 CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -1739,7 +1739,7 @@ CSINodes defines if csi nodes should get synced from the host cluster to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiNodes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1754,7 +1754,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1766,7 +1766,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1781,7 +1781,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1796,7 +1796,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1811,7 +1811,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1825,7 +1825,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1840,7 +1840,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1855,7 +1855,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1870,7 +1870,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1885,7 +1885,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1900,7 +1900,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1919,7 +1919,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiNodes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiNodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1940,7 +1940,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers}
+### `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers}
 
 CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -1952,7 +1952,7 @@ CSIDrivers defines if csi drivers should get synced from the host cluster to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1967,7 +1967,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1979,7 +1979,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1994,7 +1994,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2009,7 +2009,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2024,7 +2024,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2038,7 +2038,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2053,7 +2053,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2068,7 +2068,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2083,7 +2083,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2098,7 +2098,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2113,7 +2113,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2132,7 +2132,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiDrivers-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiDrivers-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2153,7 +2153,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities}
+### `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities}
 
 CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -2165,7 +2165,7 @@ CSIStorageCapacities defines if csi storage capacities should get synced from th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2180,7 +2180,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2192,7 +2192,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2207,7 +2207,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2222,7 +2222,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2237,7 +2237,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2251,7 +2251,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2266,7 +2266,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2281,7 +2281,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2296,7 +2296,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2311,7 +2311,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2326,7 +2326,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2345,7 +2345,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-csiStorageCapacities-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-csiStorageCapacities-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2366,7 +2366,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources}
+### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources}
 
 CustomResources defines what custom resources should get synced read-only to the virtual cluster from the host cluster. vCluster will automatically add any required RBAC to the vCluster cluster role.
 
@@ -2378,7 +2378,7 @@ CustomResources defines what custom resources should get synced read-only to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2393,7 +2393,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-scope}
+#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-scope}
 
 Scope defines the scope of the resource
 
@@ -2408,7 +2408,7 @@ Scope defines the scope of the resource
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2420,7 +2420,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2435,7 +2435,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2450,7 +2450,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2465,7 +2465,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2479,7 +2479,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2494,7 +2494,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2509,7 +2509,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2524,7 +2524,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2539,7 +2539,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2554,7 +2554,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2573,7 +2573,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2591,7 +2591,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-mappings}
+#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-mappings}
 
 Mappings for Namespace and Object
 
@@ -2603,7 +2603,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-customResources-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-customResources-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -2640,7 +2640,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses}
+### `volumeSnapshotClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses}
 
 VolumeSnapshotClasses defines if volume snapshot classes created within the virtual cluster should get synced to the host cluster.
 
@@ -2652,7 +2652,7 @@ VolumeSnapshotClasses defines if volume snapshot classes created within the virt
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2667,7 +2667,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2679,7 +2679,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2694,7 +2694,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2709,7 +2709,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2724,7 +2724,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2738,7 +2738,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2753,7 +2753,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2768,7 +2768,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2783,7 +2783,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2798,7 +2798,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2813,7 +2813,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2832,7 +2832,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-volumeSnapshotClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-volumeSnapshotClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2853,7 +2853,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps}
+### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps}
 
 ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
 
@@ -2865,7 +2865,7 @@ ConfigMaps defines if config maps in the host should get synced to the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2880,7 +2880,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2892,7 +2892,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2907,7 +2907,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2922,7 +2922,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2937,7 +2937,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2951,7 +2951,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2966,7 +2966,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2981,7 +2981,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2996,7 +2996,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3011,7 +3011,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3026,7 +3026,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3045,7 +3045,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3063,7 +3063,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-mappings}
+#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-configMaps-mappings}
 
 Mappings for Namespace and Object
 
@@ -3075,7 +3075,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-configMaps-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-configMaps-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -3112,7 +3112,7 @@ byName:
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets}
+### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets}
 
 Secrets defines if secrets in the host should get synced to the virtual cluster.
 
@@ -3124,7 +3124,7 @@ Secrets defines if secrets in the host should get synced to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#fromHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3139,7 +3139,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3151,7 +3151,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3166,7 +3166,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3181,7 +3181,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3196,7 +3196,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3210,7 +3210,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3225,7 +3225,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3240,7 +3240,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3255,7 +3255,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3270,7 +3270,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3285,7 +3285,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3304,7 +3304,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3322,7 +3322,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-mappings}
+#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#fromHost-secrets-mappings}
 
 Mappings for Namespace and Object
 
@@ -3334,7 +3334,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#fromHost-secrets-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#fromHost-secrets-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/configMaps.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/configMaps.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps}
+## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps}
 
 ConfigMaps defines if config maps in the host should get synced to the virtual cluster.
 
@@ -14,7 +14,7 @@ ConfigMaps defines if config maps in the host should get synced to the virtual c
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-mappings}
+### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-mappings}
 
 Mappings for Namespace and Object
 
@@ -224,7 +224,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-mappings-byName}
+#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#configMaps-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/csiDrivers.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/csiDrivers.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers}
+## `csiDrivers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers}
 
 CSIDrivers defines if csi drivers should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ CSIDrivers defines if csi drivers should get synced from the host cluster to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiDrivers-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiDrivers-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiDrivers-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/csiNodes.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/csiNodes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes}
+## `csiNodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes}
 
 CSINodes defines if csi nodes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ CSINodes defines if csi nodes should get synced from the host cluster to the vir
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiNodes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiNodes-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiNodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/csiStorageCapacities.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/csiStorageCapacities.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities}
+## `csiStorageCapacities` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities}
 
 CSIStorageCapacities defines if csi storage capacities should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ CSIStorageCapacities defines if csi storage capacities should get synced from th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#csiStorageCapacities-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#csiStorageCapacities-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#csiStorageCapacities-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/customResources.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/customResources.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources}
+## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources}
 
 CustomResources defines what custom resources should get synced read-only to the virtual cluster from the host cluster. vCluster will automatically add any required RBAC to the vCluster cluster role.
 
@@ -14,7 +14,7 @@ CustomResources defines what custom resources should get synced read-only to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-scope}
+### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-scope}
 
 Scope defines the scope of the resource
 
@@ -44,7 +44,7 @@ Scope defines the scope of the resource
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -56,7 +56,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -71,7 +71,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -101,7 +101,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -115,7 +115,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -130,7 +130,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -145,7 +145,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -160,7 +160,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -175,7 +175,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -190,7 +190,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -209,7 +209,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -227,7 +227,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-mappings}
+### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-mappings}
 
 Mappings for Namespace and Object
 
@@ -239,7 +239,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-mappings-byName}
+#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/events.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/events.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events}
+## `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events}
 
 Events defines if events should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ Events defines if events should get synced from the host cluster to the virtual 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#events-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#events-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#events-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/ingressClasses.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/ingressClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses}
+## `ingressClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses}
 
 IngressClasses defines if ingress classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ IngressClasses defines if ingress classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingressClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-selector}
+### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -224,7 +224,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-selector-matchLabels}
+#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchLabels}
 
 
 
@@ -239,7 +239,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-selector-matchExpressions}
+#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions}
 
 
 
@@ -251,22 +251,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions-key}
 
 
 
@@ -281,7 +266,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingressClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingressClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/nodes.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/nodes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes}
+## `nodes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes}
 
 Nodes defines if nodes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ Nodes defines if nodes should get synced from the host cluster to the virtual cl
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-enabled}
 
 Enabled specifies if syncing real nodes should be enabled. If this is disabled, vCluster will create fake nodes instead.
 
@@ -29,7 +29,7 @@ Enabled specifies if syncing real nodes should be enabled. If this is disabled, 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-syncBackChanges}
+### `syncBackChanges` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-syncBackChanges}
 
 SyncBackChanges enables syncing labels and taints from the virtual cluster to the host cluster. If this is enabled someone within the virtual cluster will be able to change the labels and taints of the host cluster node.
 
@@ -44,7 +44,7 @@ SyncBackChanges enables syncing labels and taints from the virtual cluster to th
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-clearImageStatus}
+### `clearImageStatus` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-clearImageStatus}
 
 ClearImageStatus will erase the image status when syncing a node. This allows to hide images that are pulled by the node.
 
@@ -59,7 +59,7 @@ ClearImageStatus will erase the image status when syncing a node. This allows to
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-selector}
+### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-selector}
 
 Selector can be used to define more granular what nodes should get synced from the host cluster to the virtual cluster.
 
@@ -71,7 +71,7 @@ Selector can be used to define more granular what nodes should get synced from t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-selector-all}
+#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#nodes-selector-all}
 
 All specifies if all nodes should get synced by vCluster from the host to the virtual cluster or only the ones where pods are assigned to.
 
@@ -86,7 +86,7 @@ All specifies if all nodes should get synced by vCluster from the host to the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-selector-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#nodes-selector-labels}
 
 Labels are the node labels used to sync nodes from host cluster to virtual cluster. This will also set the node selector when syncing a pod from virtual cluster to host cluster to the same value.
 
@@ -104,7 +104,7 @@ Labels are the node labels used to sync nodes from host cluster to virtual clust
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -116,7 +116,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -131,7 +131,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -146,7 +146,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -161,7 +161,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -175,7 +175,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -190,7 +190,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -205,7 +205,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -220,7 +220,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -235,7 +235,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -250,7 +250,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -269,7 +269,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#nodes-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#nodes-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/priorityClasses.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/priorityClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses}
+## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses}
 
 PriorityClasses defines if priority classes classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ PriorityClasses defines if priority classes classes should get synced from the h
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-selector}
+### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -224,7 +224,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-selector-matchLabels}
+#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchLabels}
 
 
 
@@ -239,7 +239,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-selector-matchExpressions}
+#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions}
 
 
 
@@ -251,22 +251,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions-key}
 
 
 
@@ -281,7 +266,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/runtimeClasses.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/runtimeClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses}
+## `runtimeClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses}
 
 RuntimeClasses defines if runtime classes should get synced from the host cluster to the virtual cluster, but not back.
 
@@ -14,7 +14,7 @@ RuntimeClasses defines if runtime classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#runtimeClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-selector}
+### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -224,7 +224,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-selector-matchLabels}
+#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchLabels}
 
 
 
@@ -239,7 +239,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-selector-matchExpressions}
+#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions}
 
 
 
@@ -251,22 +251,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions-key}
 
 
 
@@ -281,7 +266,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#runtimeClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#runtimeClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/secrets.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/secrets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets}
+## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets}
 
 Secrets defines if secrets in the host should get synced to the virtual cluster.
 
@@ -14,7 +14,7 @@ Secrets defines if secrets in the host should get synced to the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-mappings}
+### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-mappings}
 
 Mappings for Namespace and Object
 
@@ -224,7 +224,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-mappings-byName}
+#### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#secrets-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/storageClasses.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/fromHost/storageClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses}
+## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses}
 
 StorageClasses defines if storage classes should get synced from the host cluster to the virtual cluster, but not back. If auto, is automatically enabled when the virtual scheduler is enabled.
 
@@ -14,7 +14,7 @@ StorageClasses defines if storage classes should get synced from the host cluste
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string|boolean</span> <span className="config-field-default">auto</span> <span className="config-field-enum"></span> {#storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -212,7 +212,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-selector}
+### `selector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector}
 
 Selector defines the selector to use for the resource. If not set, all resources of that type will be synced.
 
@@ -224,7 +224,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-selector-matchLabels}
+#### `matchLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchLabels}
 
 
 
@@ -239,7 +239,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-selector-matchExpressions}
+#### `matchExpressions` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions}
 
 
 
@@ -251,22 +251,7 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-selector-matchExpressions-key}
-
-
-
-</summary>
-
-
-
-</details>
-
-
-
-<details className="config-field" data-expandable="false" open>
-<summary>
-
-##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-selector-matchExpressions-operator}
+##### `key` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions-key}
 
 
 
@@ -281,7 +266,22 @@ Selector defines the selector to use for the resource. If not set, all resources
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-selector-matchExpressions-values}
+##### `operator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions-operator}
+
+
+
+</summary>
+
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `values` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-selector-matchExpressions-values}
 
 
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost}
+## `toHost` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost}
 
 Configure resources to sync from the virtual cluster to the host cluster.
 
@@ -14,7 +14,7 @@ Configure resources to sync from the virtual cluster to the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods}
+### `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods}
 
 Pods defines if pods created within the virtual cluster should get synced to the host cluster.
 
@@ -26,7 +26,7 @@ Pods defines if pods created within the virtual cluster should get synced to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-pods-enabled}
 
 Enabled defines if pod syncing should be enabled.
 
@@ -41,7 +41,7 @@ Enabled defines if pod syncing should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-translateImage}
+#### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#toHost-pods-translateImage}
 
 TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite
 a certain image that is used within the virtual cluster to be another image on the host cluster
@@ -57,7 +57,7 @@ a certain image that is used within the virtual cluster to be another image on t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-enforceTolerations}
+#### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-enforceTolerations}
 
 EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster.
 
@@ -72,7 +72,7 @@ EnforceTolerations will add the specified tolerations to all pods synced by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-useSecretsForSATokens}
+#### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-pods-useSecretsForSATokens}
 
 UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a
 pod annotation.
@@ -88,7 +88,7 @@ pod annotation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-runtimeClassName}
+#### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for synced pods.
 
@@ -103,7 +103,7 @@ RuntimeClassName is the runtime class to set for synced pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-priorityClassName}
+#### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-priorityClassName}
 
 PriorityClassName is the priority class to set for synced pods.
 
@@ -118,7 +118,7 @@ PriorityClassName is the priority class to set for synced pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts}
+#### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts}
 
 RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
 a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
@@ -132,7 +132,7 @@ the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-enabled}
 
 Enabled specifies if rewriting stateful set pods should be enabled.
 
@@ -147,7 +147,7 @@ Enabled specifies if rewriting stateful set pods should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer}
+##### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer}
 
 InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
 
@@ -159,7 +159,7 @@ InitContainer holds extra options for the init container used by vCluster to rew
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine:3.20</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine:3.20</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-image}
 
 Image is the image virtual cluster should use to rewrite this FQDN.
 
@@ -174,7 +174,7 @@ Image is the image virtual cluster should use to rewrite this FQDN.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources}
 
 Resources are the resources that should be assigned to the init container for each stateful set init container.
 
@@ -186,7 +186,7 @@ Resources are the resources that should be assigned to the init container for ea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources-limits}
 
 Limits are resource limits for the container
 
@@ -201,7 +201,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-rewriteHosts-initContainer-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-rewriteHosts-initContainer-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -225,7 +225,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -237,7 +237,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -252,7 +252,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -267,7 +267,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -282,7 +282,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -296,7 +296,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -311,7 +311,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -326,7 +326,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -341,7 +341,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -356,7 +356,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -371,7 +371,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -390,7 +390,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -408,7 +408,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `hybridScheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-hybridScheduling}
+#### `hybridScheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-pods-hybridScheduling}
 
 HybridScheduling is used to enable and configure hybrid scheduling for pods in the virtual cluster.
 
@@ -420,7 +420,7 @@ HybridScheduling is used to enable and configure hybrid scheduling for pods in t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-hybridScheduling-enabled}
+##### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-pods-hybridScheduling-enabled}
 
 Enabled specifies if hybrid scheduling is enabled.
 
@@ -435,7 +435,7 @@ Enabled specifies if hybrid scheduling is enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `hostSchedulers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-pods-hybridScheduling-hostSchedulers}
+##### `hostSchedulers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#toHost-pods-hybridScheduling-hostSchedulers}
 
 HostSchedulers is a list of schedulers that are deployed on the host cluster.
 
@@ -456,7 +456,7 @@ HostSchedulers is a list of schedulers that are deployed on the host cluster.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets}
+### `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets}
 
 Secrets defines if secrets created within the virtual cluster should get synced to the host cluster.
 
@@ -468,7 +468,7 @@ Secrets defines if secrets created within the virtual cluster should get synced 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -483,7 +483,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-all}
+#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-secrets-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -498,7 +498,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -510,7 +510,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -525,7 +525,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -540,7 +540,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -555,7 +555,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -569,7 +569,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -584,7 +584,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -599,7 +599,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -614,7 +614,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -629,7 +629,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -644,7 +644,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -663,7 +663,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-secrets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -684,7 +684,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps}
+### `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps}
 
 ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster.
 
@@ -696,7 +696,7 @@ ConfigMaps defines if config maps created within the virtual cluster should get 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -711,7 +711,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-all}
+#### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-configMaps-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -726,7 +726,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -738,7 +738,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -753,7 +753,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -768,7 +768,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -783,7 +783,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -797,7 +797,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -812,7 +812,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -827,7 +827,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -842,7 +842,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -857,7 +857,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -872,7 +872,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -891,7 +891,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-configMaps-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -912,7 +912,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses}
+### `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses}
 
 Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster.
 
@@ -924,7 +924,7 @@ Ingresses defines if ingresses created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-ingresses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -939,7 +939,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -951,7 +951,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -966,7 +966,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -981,7 +981,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -996,7 +996,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1010,7 +1010,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1025,7 +1025,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1040,7 +1040,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1055,7 +1055,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1070,7 +1070,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1085,7 +1085,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1104,7 +1104,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-ingresses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-ingresses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1125,7 +1125,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services}
+### `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services}
 
 Services defines if services created within the virtual cluster should get synced to the host cluster.
 
@@ -1137,7 +1137,7 @@ Services defines if services created within the virtual cluster should get synce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-services-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1152,7 +1152,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1164,7 +1164,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1179,7 +1179,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1194,7 +1194,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1209,7 +1209,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1223,7 +1223,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1238,7 +1238,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1253,7 +1253,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1268,7 +1268,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1283,7 +1283,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1298,7 +1298,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1317,7 +1317,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-services-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-services-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1338,7 +1338,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints}
+### `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints}
 
 Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
 
@@ -1350,7 +1350,7 @@ Endpoints defines if endpoints created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-endpoints-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1365,7 +1365,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1377,7 +1377,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1392,7 +1392,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1407,7 +1407,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1422,7 +1422,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1436,7 +1436,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1451,7 +1451,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1466,7 +1466,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1481,7 +1481,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1496,7 +1496,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1511,7 +1511,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1530,7 +1530,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-endpoints-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-endpoints-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1551,7 +1551,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies}
+### `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies}
 
 NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster.
 
@@ -1563,7 +1563,7 @@ NetworkPolicies defines if network policies created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-networkPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1578,7 +1578,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1590,7 +1590,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1605,7 +1605,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1620,7 +1620,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1635,7 +1635,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1649,7 +1649,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1664,7 +1664,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1679,7 +1679,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1694,7 +1694,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1709,7 +1709,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1724,7 +1724,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1743,7 +1743,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-networkPolicies-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-networkPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1764,7 +1764,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims}
+### `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims}
 
 PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster.
 
@@ -1776,7 +1776,7 @@ PersistentVolumeClaims defines if persistent volume claims created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -1791,7 +1791,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -1803,7 +1803,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -1818,7 +1818,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -1833,7 +1833,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -1848,7 +1848,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -1862,7 +1862,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -1877,7 +1877,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -1892,7 +1892,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -1907,7 +1907,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -1922,7 +1922,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -1937,7 +1937,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -1956,7 +1956,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumeClaims-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumeClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -1977,7 +1977,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes}
+### `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes}
 
 PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster.
 
@@ -1989,7 +1989,7 @@ PersistentVolumes defines if persistent volumes created within the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2004,7 +2004,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2016,7 +2016,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2031,7 +2031,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2046,7 +2046,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2061,7 +2061,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2075,7 +2075,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2090,7 +2090,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2105,7 +2105,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2120,7 +2120,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2135,7 +2135,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2150,7 +2150,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2169,7 +2169,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-persistentVolumes-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-persistentVolumes-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2190,7 +2190,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots}
+### `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots}
 
 VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
 
@@ -2202,7 +2202,7 @@ VolumeSnapshots defines if volume snapshots created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2217,7 +2217,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2229,7 +2229,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2244,7 +2244,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2259,7 +2259,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2274,7 +2274,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2288,7 +2288,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2303,7 +2303,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2318,7 +2318,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2333,7 +2333,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2348,7 +2348,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2363,7 +2363,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2382,7 +2382,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshots-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshots-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2403,7 +2403,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents}
+### `volumeSnapshotContents` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents}
 
 VolumeSnapshotContents defines if volume snapshot contents created within the virtual cluster should get synced to the host cluster.
 
@@ -2415,7 +2415,7 @@ VolumeSnapshotContents defines if volume snapshot contents created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2430,7 +2430,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2442,7 +2442,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2457,7 +2457,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2472,7 +2472,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2487,7 +2487,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2501,7 +2501,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2516,7 +2516,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2531,7 +2531,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2546,7 +2546,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2561,7 +2561,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2576,7 +2576,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2595,7 +2595,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-volumeSnapshotContents-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-volumeSnapshotContents-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2616,7 +2616,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses}
+### `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses}
 
 StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
 
@@ -2628,7 +2628,7 @@ StorageClasses defines if storage classes created within the virtual cluster sho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2643,7 +2643,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2655,7 +2655,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2670,7 +2670,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2685,7 +2685,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2700,7 +2700,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2714,7 +2714,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2729,7 +2729,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2744,7 +2744,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2759,7 +2759,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2774,7 +2774,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -2789,7 +2789,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -2808,7 +2808,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-storageClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -2829,7 +2829,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts}
+### `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts}
 
 ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster.
 
@@ -2841,7 +2841,7 @@ ServiceAccounts defines if service accounts created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -2856,7 +2856,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -2868,7 +2868,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -2883,7 +2883,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -2898,7 +2898,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -2913,7 +2913,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -2927,7 +2927,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -2942,7 +2942,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -2957,7 +2957,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -2972,7 +2972,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -2987,7 +2987,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3002,7 +3002,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3021,7 +3021,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-serviceAccounts-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-serviceAccounts-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3042,7 +3042,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets}
+### `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets}
 
 PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster.
 
@@ -3054,7 +3054,7 @@ PodDisruptionBudgets defines if pod disruption budgets created within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3069,7 +3069,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3081,7 +3081,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3096,7 +3096,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3111,7 +3111,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3126,7 +3126,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3140,7 +3140,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3155,7 +3155,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3170,7 +3170,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3185,7 +3185,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3200,7 +3200,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3215,7 +3215,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3234,7 +3234,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-podDisruptionBudgets-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-podDisruptionBudgets-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3255,7 +3255,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses}
+### `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses}
 
 PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster.
 
@@ -3267,7 +3267,7 @@ PriorityClasses defines if priority classes created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3282,7 +3282,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3294,7 +3294,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3309,7 +3309,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3324,7 +3324,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3339,7 +3339,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3353,7 +3353,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3368,7 +3368,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3383,7 +3383,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3398,7 +3398,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3413,7 +3413,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3428,7 +3428,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3447,7 +3447,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-priorityClasses-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3468,7 +3468,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources}
+### `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources}
 
 CustomResources defines what custom resources should get synced from the virtual cluster to the host cluster. vCluster will copy the definition automatically from host cluster to virtual cluster on startup.
 vCluster will also automatically add any required RBAC permissions to the vCluster role for this to work.
@@ -3481,7 +3481,7 @@ vCluster will also automatically add any required RBAC permissions to the vClust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3496,7 +3496,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-scope}
+#### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-scope}
 
 Scope defines the scope of the resource. If undefined, will use Namespaced. Currently only Namespaced is supported.
 
@@ -3511,7 +3511,7 @@ Scope defines the scope of the resource. If undefined, will use Namespaced. Curr
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3523,7 +3523,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3538,7 +3538,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3553,7 +3553,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3568,7 +3568,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3582,7 +3582,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3597,7 +3597,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3612,7 +3612,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3627,7 +3627,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3642,7 +3642,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3657,7 +3657,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3676,7 +3676,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-customResources-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3697,7 +3697,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces}
+### `namespaces` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces}
 
 Namespaces defines if namespaces created within the virtual cluster should get synced to the host cluster.
 
@@ -3709,7 +3709,7 @@ Namespaces defines if namespaces created within the virtual cluster should get s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-namespaces-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -3724,7 +3724,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches}
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -3736,7 +3736,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-path}
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -3751,7 +3751,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-expression}
+##### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -3766,7 +3766,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-reverseExpression}
+##### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -3781,7 +3781,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-reference}
+##### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -3795,7 +3795,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -3810,7 +3810,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -3825,7 +3825,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -3840,7 +3840,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -3855,7 +3855,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -3870,7 +3870,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -3889,7 +3889,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-patches-labels}
+##### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -3907,7 +3907,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-mappings}
+#### `mappings` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-mappings}
 
 Mappings for Namespace and Object
 
@@ -3919,7 +3919,7 @@ Mappings for Namespace and Object
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-mappings-byName}
+##### `byName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-mappings-byName}
 
 ByName is a map of host-object-namespace/host-object-name: virtual-object-namespace/virtual-object-name.
 There are several wildcards supported:
@@ -3953,7 +3953,7 @@ byName:
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `mappingsOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-mappingsOnly}
+#### `mappingsOnly` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#toHost-namespaces-mappingsOnly}
 
 MappingsOnly defines if creation of namespaces not matched by mappings should be allowed.
 
@@ -3968,7 +3968,7 @@ MappingsOnly defines if creation of namespaces not matched by mappings should be
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `extraLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#toHost-namespaces-extraLabels}
+#### `extraLabels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#toHost-namespaces-extraLabels}
 
 ExtraLabels are additional labels to add to the namespace in the host cluster.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/configMaps.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/configMaps.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps}
+## `configMaps` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps}
 
 ConfigMaps defines if config maps created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ ConfigMaps defines if config maps created within the virtual cluster should get 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#configMaps-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-all}
+### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#configMaps-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -44,7 +44,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -56,7 +56,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -71,7 +71,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -101,7 +101,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -115,7 +115,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -130,7 +130,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -145,7 +145,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -160,7 +160,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -175,7 +175,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -190,7 +190,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -209,7 +209,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#configMaps-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#configMaps-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/customResources.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/customResources.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources}
+## `customResources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&#123;key: object&#125;</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources}
 
 CustomResources defines what custom resources should get synced from the virtual cluster to the host cluster. vCluster will copy the definition automatically from host cluster to virtual cluster on startup.
 vCluster will also automatically add any required RBAC permissions to the vCluster role for this to work.
@@ -15,7 +15,7 @@ vCluster will also automatically add any required RBAC permissions to the vClust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -30,7 +30,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-scope}
+### `scope` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-scope}
 
 Scope defines the scope of the resource. If undefined, will use Namespaced. Currently only Namespaced is supported.
 
@@ -45,7 +45,7 @@ Scope defines the scope of the resource. If undefined, will use Namespaced. Curr
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -57,7 +57,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -72,7 +72,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -87,7 +87,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -102,7 +102,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -116,7 +116,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -131,7 +131,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -146,7 +146,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -161,7 +161,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -176,7 +176,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -191,7 +191,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -210,7 +210,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#customResources-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#customResources-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/endpoints.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/endpoints.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints}
+## `endpoints` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints}
 
 Endpoints defines if endpoints created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Endpoints defines if endpoints created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#endpoints-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#endpoints-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#endpoints-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/ingresses.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/ingresses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses}
+## `ingresses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses}
 
 Ingresses defines if ingresses created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Ingresses defines if ingresses created within the virtual cluster should get syn
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#ingresses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#ingresses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#ingresses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/networkPolicies.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/networkPolicies.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies}
+## `networkPolicies` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies}
 
 NetworkPolicies defines if network policies created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ NetworkPolicies defines if network policies created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#networkPolicies-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#networkPolicies-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#networkPolicies-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/persistentVolumeClaims.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/persistentVolumeClaims.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims}
+## `persistentVolumeClaims` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims}
 
 PersistentVolumeClaims defines if persistent volume claims created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PersistentVolumeClaims defines if persistent volume claims created within the vi
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#persistentVolumeClaims-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumeClaims-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumeClaims-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/persistentVolumes.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/persistentVolumes.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes}
+## `persistentVolumes` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes}
 
 PersistentVolumes defines if persistent volumes created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PersistentVolumes defines if persistent volumes created within the virtual clust
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#persistentVolumes-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#persistentVolumes-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#persistentVolumes-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/podDisruptionBudgets.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/podDisruptionBudgets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets}
+## `podDisruptionBudgets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets}
 
 PodDisruptionBudgets defines if pod disruption budgets created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PodDisruptionBudgets defines if pod disruption budgets created within the virtua
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#podDisruptionBudgets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#podDisruptionBudgets-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#podDisruptionBudgets-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/pods.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/pods.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods}
+## `pods` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods}
 
 Pods defines if pods created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Pods defines if pods created within the virtual cluster should get synced to the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#pods-enabled}
 
 Enabled defines if pod syncing should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if pod syncing should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-translateImage}
+### `translateImage` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">&#123;&#125;</span> <span className="config-field-enum"></span> {#pods-translateImage}
 
 TranslateImage maps an image to another image that should be used instead. For example this can be used to rewrite
 a certain image that is used within the virtual cluster to be another image on the host cluster
@@ -45,7 +45,7 @@ a certain image that is used within the virtual cluster to be another image on t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-enforceTolerations}
+### `enforceTolerations` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#pods-enforceTolerations}
 
 EnforceTolerations will add the specified tolerations to all pods synced by the virtual cluster.
 
@@ -60,7 +60,7 @@ EnforceTolerations will add the specified tolerations to all pods synced by the 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-useSecretsForSATokens}
+### `useSecretsForSATokens` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#pods-useSecretsForSATokens}
 
 UseSecretsForSATokens will use secrets to save the generated service account tokens by virtual cluster instead of using a
 pod annotation.
@@ -76,7 +76,7 @@ pod annotation.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-runtimeClassName}
+### `runtimeClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-runtimeClassName}
 
 RuntimeClassName is the runtime class to set for synced pods.
 
@@ -91,7 +91,7 @@ RuntimeClassName is the runtime class to set for synced pods.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-priorityClassName}
+### `priorityClassName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-priorityClassName}
 
 PriorityClassName is the priority class to set for synced pods.
 
@@ -106,7 +106,7 @@ PriorityClassName is the priority class to set for synced pods.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts}
+### `rewriteHosts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts}
 
 RewriteHosts is a special option needed to rewrite statefulset containers to allow the correct FQDN. virtual cluster will add
 a small container to each stateful set pod that will initially rewrite the /etc/hosts file to match the FQDN expected by
@@ -120,7 +120,7 @@ the virtual cluster.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-enabled}
 
 Enabled specifies if rewriting stateful set pods should be enabled.
 
@@ -135,7 +135,7 @@ Enabled specifies if rewriting stateful set pods should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer}
+#### `initContainer` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer}
 
 InitContainer holds extra options for the init container used by vCluster to rewrite the FQDN for stateful set pods.
 
@@ -147,7 +147,7 @@ InitContainer holds extra options for the init container used by vCluster to rew
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine:3.20</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer-image}
+##### `image` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default">library/alpine:3.20</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-image}
 
 Image is the image virtual cluster should use to rewrite this FQDN.
 
@@ -162,7 +162,7 @@ Image is the image virtual cluster should use to rewrite this FQDN.
 <details className="config-field" data-expandable="true">
 <summary>
 
-##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer-resources}
+##### `resources` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources}
 
 Resources are the resources that should be assigned to the init container for each stateful set init container.
 
@@ -174,7 +174,7 @@ Resources are the resources that should be assigned to the init container for ea
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer-resources-limits}
+##### `limits` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources-limits}
 
 Limits are resource limits for the container
 
@@ -189,7 +189,7 @@ Limits are resource limits for the container
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-rewriteHosts-initContainer-resources-requests}
+##### `requests` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default">map&#91;cpu:30m memory:64Mi&#93;</span> <span className="config-field-enum"></span> {#pods-rewriteHosts-initContainer-resources-requests}
 
 Requests are minimal resources that will be consumed by the container
 
@@ -213,7 +213,7 @@ Requests are minimal resources that will be consumed by the container
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -225,7 +225,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -240,7 +240,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -255,7 +255,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -270,7 +270,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -284,7 +284,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -299,7 +299,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -314,7 +314,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -329,7 +329,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -344,7 +344,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -359,7 +359,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -378,7 +378,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-patches-labels}
 
 Labels treats the path value as a labels selector.
 
@@ -396,7 +396,7 @@ Labels treats the path value as a labels selector.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `hybridScheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-hybridScheduling}
+### `hybridScheduling` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#pods-hybridScheduling}
 
 HybridScheduling is used to enable and configure hybrid scheduling for pods in the virtual cluster.
 
@@ -408,7 +408,7 @@ HybridScheduling is used to enable and configure hybrid scheduling for pods in t
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-hybridScheduling-enabled}
+#### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#pods-hybridScheduling-enabled}
 
 Enabled specifies if hybrid scheduling is enabled.
 
@@ -423,7 +423,7 @@ Enabled specifies if hybrid scheduling is enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `hostSchedulers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#pods-hybridScheduling-hostSchedulers}
+#### `hostSchedulers` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default">&#91;&#93;</span> <span className="config-field-enum"></span> {#pods-hybridScheduling-hostSchedulers}
 
 HostSchedulers is a list of schedulers that are deployed on the host cluster.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/priorityClasses.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/priorityClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses}
+## `priorityClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses}
 
 PriorityClasses defines if priority classes created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ PriorityClasses defines if priority classes created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#priorityClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#priorityClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#priorityClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/secrets.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/secrets.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets}
+## `secrets` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets}
 
 Secrets defines if secrets created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Secrets defines if secrets created within the virtual cluster should get synced 
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#secrets-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-all}
+### `all` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#secrets-all}
 
 All defines if all resources of that type should get synced or only the necessary ones that are needed.
 
@@ -44,7 +44,7 @@ All defines if all resources of that type should get synced or only the necessar
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -56,7 +56,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -71,7 +71,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -101,7 +101,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -115,7 +115,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -130,7 +130,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -145,7 +145,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -160,7 +160,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -175,7 +175,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -190,7 +190,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -209,7 +209,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#secrets-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#secrets-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/serviceAccounts.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/serviceAccounts.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts}
+## `serviceAccounts` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts}
 
 ServiceAccounts defines if service accounts created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ ServiceAccounts defines if service accounts created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#serviceAccounts-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#serviceAccounts-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#serviceAccounts-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/services.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/services.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services}
+## `services` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services}
 
 Services defines if services created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ Services defines if services created within the virtual cluster should get synce
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#services-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#services-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#services-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/storageClasses.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/storageClasses.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses}
+## `storageClasses` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses}
 
 StorageClasses defines if storage classes created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ StorageClasses defines if storage classes created within the virtual cluster sho
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#storageClasses-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#storageClasses-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#storageClasses-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/volumeSnapshots.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/sync/toHost/volumeSnapshots.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots}
+## `volumeSnapshots` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots}
 
 VolumeSnapshots defines if volume snapshots created within the virtual cluster should get synced to the host cluster.
 
@@ -14,7 +14,7 @@ VolumeSnapshots defines if volume snapshots created within the virtual cluster s
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#volumeSnapshots-enabled}
 
 Enabled defines if this option should be enabled.
 
@@ -29,7 +29,7 @@ Enabled defines if this option should be enabled.
 <details className="config-field" data-expandable="true">
 <summary>
 
-### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches}
+### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches}
 
 Patches patch the resource according to the provided specification.
 
@@ -41,7 +41,7 @@ Patches patch the resource according to the provided specification.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-path}
+#### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-path}
 
 Path is the path within the patch to target. If the path is not found within the patch, the patch is not applied.
 
@@ -56,7 +56,7 @@ Path is the path within the patch to target. If the path is not found within the
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-expression}
+#### `expression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-expression}
 
 Expression transforms the value according to the given JavaScript expression.
 
@@ -71,7 +71,7 @@ Expression transforms the value according to the given JavaScript expression.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reverseExpression}
+#### `reverseExpression` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reverseExpression}
 
 ReverseExpression transforms the value according to the given JavaScript expression.
 
@@ -86,7 +86,7 @@ ReverseExpression transforms the value according to the given JavaScript express
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference}
+#### `reference` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference}
 
 Reference treats the path value as a reference to another object and will rewrite it based on the chosen mode
 automatically. In single-namespace mode this will translate the name to "vxxxxxxxxx" to avoid conflicts with
@@ -100,7 +100,7 @@ other names, in multi-namespace mode this will not translate the name.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-apiVersion}
+##### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-apiVersion}
 
 APIVersion is the apiVersion of the referenced object.
 
@@ -115,7 +115,7 @@ APIVersion is the apiVersion of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-apiVersionPath}
+##### `apiVersionPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-apiVersionPath}
 
 APIVersionPath is optional relative path to use to determine the kind. If APIVersionPath is not found, will fallback to apiVersion.
 
@@ -130,7 +130,7 @@ APIVersionPath is optional relative path to use to determine the kind. If APIVer
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-kind}
+##### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-kind}
 
 Kind is the kind of the referenced object.
 
@@ -145,7 +145,7 @@ Kind is the kind of the referenced object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-kindPath}
+##### `kindPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-kindPath}
 
 KindPath is the optional relative path to use to determine the kind. If KindPath is not found, will fallback to kind.
 
@@ -160,7 +160,7 @@ KindPath is the optional relative path to use to determine the kind. If KindPath
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-namePath}
+##### `namePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-namePath}
 
 NamePath is the optional relative path to the reference name within the object.
 
@@ -175,7 +175,7 @@ NamePath is the optional relative path to the reference name within the object.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-reference-namespacePath}
+##### `namespacePath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-reference-namespacePath}
 
 NamespacePath is the optional relative path to the reference namespace within the object. If omitted or not found, namespacePath equals to the
 metadata.namespace path of the object.
@@ -194,7 +194,7 @@ metadata.namespace path of the object.
 <details className="config-field" data-expandable="true">
 <summary>
 
-#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#volumeSnapshots-patches-labels}
+#### `labels` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#volumeSnapshots-patches-labels}
 
 Labels treats the path value as a labels selector.
 

--- a/vcluster_versioned_docs/version-0.26.0/_partials/config/telemetry.mdx
+++ b/vcluster_versioned_docs/version-0.26.0/_partials/config/telemetry.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="true">
 <summary>
 
-## `telemetry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry}
+## `telemetry` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry}
 
 Configuration related to telemetry gathered about vCluster usage.
 
@@ -14,7 +14,7 @@ Configuration related to telemetry gathered about vCluster usage.
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-enabled}
+### `enabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#telemetry-enabled}
 
 Enabled specifies that the telemetry for the vCluster control plane should be enabled.
 
@@ -29,7 +29,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `instanceCreator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-instanceCreator}
+### `instanceCreator` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-instanceCreator}
 
 
 
@@ -44,7 +44,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `machineID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-machineID}
+### `machineID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-machineID}
 
 
 
@@ -59,7 +59,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `platformUserID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-platformUserID}
+### `platformUserID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-platformUserID}
 
 
 
@@ -74,7 +74,7 @@ Enabled specifies that the telemetry for the vCluster control plane should be en
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `platformInstanceID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> <span data-pro="false" className="config-field-pro">pro</span> {#telemetry-platformInstanceID}
+### `platformInstanceID` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#telemetry-platformInstanceID}
 
 
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
Removes incorrect "pro" suffix from `vCluster` configuration reference that was confusing users about feature availability in the open-source project.


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->
https://deploy-preview-909--vcluster-docs-site.netlify.app/docs/vcluster/configure/vcluster-yaml/
https://deploy-preview-909--vcluster-docs-site.netlify.app/docs/vcluster/next/configure/vcluster-yaml/

## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-550

