### PR TITLE
fix: add note that the virtual cluster must be in running state

### DIFF
--- a/vcluster/manage/certificates.mdx
+++ b/vcluster/manage/certificates.mdx
@@ -19,6 +19,15 @@ Certificate rotation requires vCluster version v0.27.0 or higher.
 The virtual cluster must run the k8s distribution.
 :::
 
+:::important
+The virtual cluster must be in a
+[running](https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-state-running)
+state otherwise the cert commands below abort the operation. In case of
+certificate expiration during runtime of a virtual cluster it will still be in
+a running state (though, non-functional) and the rotation can still be
+performed.
+:::
+
 ## Check certificate information {#check-certificate-information}
 
 The `vcluster certs check` command provides the following information for each certificate of the given virtual cluster:


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

