### PR TITLE
feat: clarify namespace usage with EKS pod identity

### DIFF
--- a/vcluster/integrations/pod-identity/eks-pod-identity.mdx
+++ b/vcluster/integrations/pod-identity/eks-pod-identity.mdx
@@ -7,6 +7,7 @@ sidebar_position: 1
 import CodeBlock from '@theme/CodeBlock';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem'
+import GlossaryTerm from '@site/src/components/GlossaryTerm'
 
 import Deploy from '../../_partials/deploy/deploy.mdx'
 import GetResourceName from '../pod-identity/_partials/get-resource-name.mdx'
@@ -18,14 +19,14 @@ import ProAdmonition from '../../_partials/admonitions/pro-admonition.mdx'
 
 <ProAdmonition/>
 
-# Integrating EKS Pod Identity with vCluster
+# Integrate EKS Pod Identity with vCluster
 
-This tutorial guides you through the process of integrating AWS Service Accounts with your vCluster using Pod Identity.
+This tutorial guides you through the process of integrating AWS Service Accounts with your <GlossaryTerm term="vcluster">vCluster</GlossaryTerm> using Pod Identity.
 
 Setting up Pod Identity requires you to link an AWS Service Account with the Kubernetes Service Account (KSA) used by your workloads.
-This KSA needs to be available in the host cluster in which your vCluster instance runs.
+This KSA needs to be available in the <GlossaryTerm term="host-cluster">host cluster</GlossaryTerm> in which your vCluster instance runs.
 
-To achieve this setup, we'll need to use the [sync.toHost feature][sync-toHost-docs] in order to expose the KSA in the host cluster together with the vCluster Platform API to retrieve the updated name of the KSA in the host cluster.
+To achieve this setup, use the [sync.toHost feature][sync-toHost-docs] to expose the KSA in the host cluster together with the <GlossaryTerm term="platform">platform</GlossaryTerm> API to retrieve the updated name of the KSA in the host cluster.
 
 ### Prerequisites
 This guide assumes you have the following prerequisites:
@@ -33,18 +34,18 @@ This guide assumes you have the following prerequisites:
 - `aws` CLI installed and configured
 - An existing EKS cluster with the CSI driver set up, IAM OIDC provider, and Pod Identity agent deployed
 
-### Step-by-Step Guide
+### Step-by-step guide
 
-#### 1. Start vCluster Platform and create an access key
+#### 1. Start the platform and create an access key
 
-In order to integrate your workloads with EKS Pod Identity, you'll need a vCluster Platform instance running.
-If you don't have one already, follow the [vCluster Platform installation guide][vcluster-platform-install-link].
+In order to integrate your workloads with EKS Pod Identity, you'll need a platform instance running.
+If you don't have one already, follow the [platform installation guide][vcluster-platform-install-link].
 
-Once you're done, you'll need to create a new access key. This will allow you to use the vCluster Platform API.
-Please follow this [guide to create a new access key][access-key-link].
+Once you're done, you'll need to create a new <GlossaryTerm term="access-key">access key</GlossaryTerm>. This allows you to use the platform API.
+Follow this [guide to create a new access key][access-key-link].
 
 
-#### 2. Set Up Variables
+#### 2. Set up variables
 
 <Tabs>
 
@@ -108,7 +109,7 @@ variable "auth_token" {
 
 </Tabs>
 
-#### 3. Create vCluster Configuration
+#### 3. Create vCluster configuration
 
 Create the `vcluster.yaml` file with following content:
 
@@ -132,7 +133,7 @@ Establish a connection to your vCluster instance:
 vcluster connect ${VCLUSTER_NAME}
 ```
 
-#### 6. Create Example Workload
+#### 6. Create example workload
 
 Create an example workload to list S3 buckets.
 
@@ -173,11 +174,11 @@ EOF
 kubectl apply -f example-workload.yaml
 ```
 
-#### 7. Read Updated Name From vCluster Platform API
+#### 7. Read updated name from platform API
 
 <GetResourceName />
 
-#### 8. Create IAM Policy and Role for Pod Identity
+#### 8. Create IAM policy and role for Pod Identity
 
 <Tabs>
 
@@ -227,9 +228,47 @@ aws iam attach-role-policy --role-name my-role --policy-arn=arn:aws:iam::${AWS_A
 
 Create the pod identity association.
 
+:::info Namespace configuration
+The namespace parameter depends on your vCluster deployment type:
+- **Standalone vCluster** (not using the platform): Use the namespace where vCluster is deployed
+- **Platform-managed vCluster**: The namespace follows the pattern `loft-<project-name>-v-<vcluster-name>`
+:::
+
+<Tabs groupId="deployment-type">
+<TabItem value="standalone" label="Standalone vCluster">
+
+For standalone vCluster deployments (deployed with `vcluster create` or Helm without the platform):
+
 ```bash
-aws eks create-pod-identity-association --cluster-name ${CLUSTER_NAME} --role-arn arn:aws:iam::${AWS_ACCOUNT_ID}:role/my-role --namespace ${VCLUSTER_NAME} --service-account ${KSA_NAME}
+# Set the namespace where vCluster is deployed
+export VCLUSTER_NAMESPACE="team-x"  # Replace with your actual namespace
+
+aws eks create-pod-identity-association \
+  --cluster-name ${CLUSTER_NAME} \
+  --role-arn arn:aws:iam::${AWS_ACCOUNT_ID}:role/my-role \
+  --namespace ${VCLUSTER_NAMESPACE} \
+  --service-account ${KSA_NAME}
 ```
+
+</TabItem>
+<TabItem value="platform" label="Platform-managed vCluster">
+
+For vCluster deployments managed by the platform with a <GlossaryTerm term="project">project</GlossaryTerm>:
+
+```bash
+# Set project name and construct the namespace
+export PROJECT_NAME="my-project"  # Replace with your actual project name
+export PLATFORM_NAMESPACE="loft-${PROJECT_NAME}-v-${VCLUSTER_NAME}"
+
+aws eks create-pod-identity-association \
+  --cluster-name ${CLUSTER_NAME} \
+  --role-arn arn:aws:iam::${AWS_ACCOUNT_ID}:role/my-role \
+  --namespace ${PLATFORM_NAMESPACE} \
+  --service-account ${KSA_NAME}
+```
+
+</TabItem>
+</Tabs>
 
 </TabItem>
 
@@ -265,7 +304,7 @@ resource "aws_iam_role_policy_attachment" "example_s3" {
 
 </Tabs>
 
-#### 9. Verify the Setup
+#### 9. Verify the setup
 
 Verify the setup by checking the logs.
 


### PR DESCRIPTION
<!-- 
When changing something in a file, our linting system `vale`, will treat the whole file as changed and will lint it. 
In this case, follow the instructions from vale and fix the linting issues. 
If there are too many errors, ask the tech writer in PR comment to fix the issues.
Read more about working with vale in the contribution guidelines: https://github.com/loft-sh/vcluster-docs/blob/main/CONTRIBUTING.md#style-guide-automation-style-guide-automation
-->
# Content Description
<!-- Brief overview of changes (1-2 sentences) -->
- clarify differences in namespace usage when using vCluster standalone vs vCluster platform
- wrap glossary terms
- make vale happy


## Preview Link 
<!-- The preview link from Netlify needs `/docs` appended after it.
If you want the preview link to be available in the Linear issue, you must include the word `preview` in the markdown link name [Document Preview](https://netlify.preview/docs/xxxx). -->


## Internal Reference
<!--Add the GitHub or Linear ticket reference-->
Closes DOC-

